### PR TITLE
mono - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     name: Lint & format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
@@ -36,9 +36,9 @@ jobs:
       matrix:
         node-version: [24]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,10 +24,10 @@ jobs:
       matrix:
         language: [javascript-typescript]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           languages: ${{ matrix.language }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8272c299f21ca24af15dfe9ac0971ba969e5e0d5 # v3.36.2
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2


### PR DESCRIPTION
## Summary
Upgrade pinned GitHub Actions refs to their latest versions — the GitHub Actions dev-phase group. SHA pins kept with version comments, matching the existing style.

## Versions
- `actions/checkout` `v4.3.1` → `v7.0.0` (major)
- `actions/setup-node` `v4.4.0` → `v6.4.0` (major)
- `pnpm/action-setup` SHA refresh (`v4.4.0`)
- `github/codeql-action` (init + analyze) SHA refresh (`v3.36.2`)

## Checks
- [x] Both workflow files parse as valid YAML
- [x] CI exercises every upgraded ref (checkout/setup-node/pnpm in lint + test jobs; codeql-action in the CodeQL job)

## Breaking notes
`actions/checkout` (4→7) and `actions/setup-node` (4→6) cross major versions. This is CI-only — no effect on the published packages — and is validated by this PR's own run on the upgraded actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iwbJn55ynCqJbYn6qj5xw

---
_Generated by [Claude Code](https://claude.ai/code/session_016iwbJn55ynCqJbYn6qj5xw)_