### PR TITLE
worker - chore: upgrade @cloudflare/workers-types

### DIFF
--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -20,7 +20,7 @@
 		"zod": "catalog:"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20260615.1",
+		"@cloudflare/workers-types": "^4.20260616.1",
 		"@faker-js/faker": "catalog:",
 		"@vitest/coverage-v8": "catalog:",
 		"typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,8 +281,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: ^4.20260615.1
-        version: 4.20260615.1
+        specifier: ^4.20260616.1
+        version: 4.20260616.1
       '@faker-js/faker':
         specifier: 'catalog:'
         version: 10.4.0
@@ -297,7 +297,7 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler:
         specifier: ^4.100.0
-        version: 4.100.0(@cloudflare/workers-types@4.20260615.1)
+        version: 4.100.0(@cloudflare/workers-types@4.20260616.1)
 
 packages:
 
@@ -876,8 +876,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@4.20260615.1':
-    resolution: {integrity: sha512-fGOiTwoLj/8bU8mj3VAfa1EULx4ceZhDwnjvY+afDBlSXI9pvY7PE9t62rGEhJjbAOGd7i5WUDun0eZCWBDrzg==}
+  '@cloudflare/workers-types@4.20260616.1':
+    resolution: {integrity: sha512-AHyA0NC2/gNOHiMN6vzS25xenMaQ0XTzfw+MUQSQHXQDjLldxCBwjjtbNfKhBg540qGXIEx31kM1+L84GyECJw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -6886,7 +6886,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260611.1':
     optional: true
 
-  '@cloudflare/workers-types@4.20260615.1': {}
+  '@cloudflare/workers-types@4.20260616.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -12644,7 +12644,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260611.1
       '@cloudflare/workerd-windows-64': 1.20260611.1
 
-  wrangler@4.100.0(@cloudflare/workers-types@4.20260615.1):
+  wrangler@4.100.0(@cloudflare/workers-types@4.20260616.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260611.1)
@@ -12655,7 +12655,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260611.1
     optionalDependencies:
-      '@cloudflare/workers-types': 4.20260615.1
+      '@cloudflare/workers-types': 4.20260616.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## Summary
Bump the worker's Cloudflare Workers type definitions to the latest gated patch.

## Versions
- `@cloudflare/workers-types` `4.20260615.1` → `4.20260616.1` (worker devDependency)

## Tests
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test:coverage` (118 tests)
- [x] `pnpm build`

## Note
This package republishes ~daily with date-stamped versions, so it will keep showing as "outdated" by a day or two. Worth letting it settle and bumping periodically rather than per build — happy to leave it here unless you want it chased continuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iwbJn55ynCqJbYn6qj5xw

---
_Generated by [Claude Code](https://claude.ai/code/session_016iwbJn55ynCqJbYn6qj5xw)_