### PR TITLE
mono - chore: upgrade pnpm to 11.7.0 (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"type": "git",
 		"url": "git+https://github.com/jaredwray/rivus.git"
 	},
-	"packageManager": "pnpm@10.33.0",
+	"packageManager": "pnpm@11.7.0+sha512.19cc852c120c7125760f2443ee6be0ca5b40f9f50598de1a09a1f177503e010e57c23c77646e01e761de59bf874fb22a3398c33ab9691fc13eb946b6f0f4d620",
 	"engines": {
 		"node": ">=24"
 	},

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,9 +31,10 @@ minimumReleaseAge: 10080
 minimumReleaseAgeStrict: true
 minimumReleaseAgeIgnoreMissingTime: false
 
-# Only these dependencies are permitted to run install lifecycle (build) scripts.
-# Everything else is blocked by default. Add entries deliberately, never wholesale.
-onlyBuiltDependencies:
-  - '@biomejs/biome'
-  - esbuild
-  - workerd
+# Install (build) scripts are blocked by default. allowBuilds explicitly
+# allows (true) or denies (false) each dependency that ships one. Add entries
+# deliberately, never wholesale. (pnpm 11 replaced onlyBuiltDependencies.)
+allowBuilds:
+  esbuild: true
+  workerd: true
+  sharp: false


### PR DESCRIPTION
## Summary
Upgrade the package manager to **pnpm 11.7.0** (from 10.33.0), managed via corepack. This is the monorepo-tooling group — `pnpm` itself isn't surfaced by `pnpm outdated`. **Breaking: requires pnpm 11.**

## Versions
- `packageManager` `pnpm@10.33.0` → `pnpm@11.7.0` (with corepack integrity hash)

## Build-script policy migration (security-relevant)
pnpm 11 **removed `onlyBuiltDependencies`** (and `neverBuiltDependencies` / `ignoredBuiltDependencies` / etc.) in favor of an **`allowBuilds`** map. Migrated faithfully — same effective policy, new format:
- `esbuild: true`, `workerd: true` (were in `onlyBuiltDependencies`)
- `sharp: false` (was blocked/ignored before)
- `@biomejs/biome` ships no install build script in 2.5.0, so it needs no entry

## corepack / CI
- `packageManager` is the single source of truth — corepack reads it locally (`corepack enable`).
- CI keeps `pnpm/action-setup` (no `version:` input), which reads `packageManager` and installs 11.7.0, so local and CI stay in lockstep.

## Verification (under pnpm 11.7.0)
- [x] `esbuild` / `workerd` run their build scripts; `sharp` stays blocked
- [x] `pnpm install --frozen-lockfile` exits 0 (it **failed** before the `allowBuilds` migration)
- [x] `pnpm lint`, `pnpm type-check`, `pnpm test:coverage` (118 tests), `pnpm build`
- [x] Lockfile format unchanged (`9.0`) — no churn

## Breaking notes
Requires pnpm 11. Contributors should run `corepack enable` so the `packageManager` field is honored. The build-script allow-list now lives in `allowBuilds` (true/false) instead of `onlyBuiltDependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iwbJn55ynCqJbYn6qj5xw

---
_Generated by [Claude Code](https://claude.ai/code/session_016iwbJn55ynCqJbYn6qj5xw)_