### PR TITLE
feat(deploy): add production Cloudflare deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -1,12 +1,14 @@
 name: Deploy (production)
 
 # Validate the whole monorepo, then deploy every package to the Cloudflare
-# `production` environment in parallel. Runs when a GitHub release is published,
-# or manually via the Actions tab.
+# `production` environment in parallel. Runs when a stable GitHub release is
+# published, or manually via the Actions tab.
 on:
   workflow_dispatch:
   release:
-    types: [published]
+    # `released` excludes pre-releases (betas/RCs) — they would otherwise ship
+    # to prod via `published`. Switch to `published` if pre-releases should deploy.
+    types: [released]
 
 # Read-only by default; the deploy jobs authenticate to Cloudflare with secrets.
 permissions:
@@ -103,12 +105,20 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
+      # The container always runs with NODE_ENV=production, where the API refuses
+      # to boot without a real MONGODB_URI and a strong JWT_SECRET. Fail fast
+      # rather than replace api.rivus.ai with a container that crash-loops.
+      - name: Require API secrets
+        run: |
+          if [ -z "$PROD_MONGODB_URI" ] || [ -z "$PROD_JWT_SECRET" ]; then
+            echo "::error::Set PROD_MONGODB_URI and PROD_JWT_SECRET in the production environment before deploying the API."
+            exit 1
+          fi
       # wrangler builds the Dockerfile (Docker is preinstalled on ubuntu-latest)
       # and pushes the image to Cloudflare's registry before deploying the Worker.
       - run: pnpm --filter @rivus/api exec wrangler deploy --env production
-      # Keep the Worker's secrets in sync. Skipped until the GitHub secrets exist.
+      # Keep the Worker's secrets in sync (both are guaranteed present above).
       - name: Sync API secrets
-        if: ${{ env.PROD_MONGODB_URI != '' }}
         run: |
           printf '%s' "$PROD_MONGODB_URI" | pnpm --filter @rivus/api exec wrangler secret put MONGODB_URI --env production
           printf '%s' "$PROD_JWT_SECRET" | pnpm --filter @rivus/api exec wrangler secret put JWT_SECRET --env production

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -1,0 +1,114 @@
+name: Deploy (production)
+
+# Validate the whole monorepo, then deploy every package to the Cloudflare
+# `production` environment in parallel. Runs when a GitHub release is published,
+# or manually via the Actions tab.
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+# Read-only by default; the deploy jobs authenticate to Cloudflare with secrets.
+permissions:
+  contents: read
+
+# One production deploy at a time. Unlike development we do NOT cancel an
+# in-progress run — a half-applied production deploy is worse than a queued one.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Build, test & lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup
+      - run: pnpm lint
+      - run: pnpm type-check
+      - run: pnpm test:coverage
+      - run: pnpm build
+
+  deploy-worker:
+    name: Deploy worker
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup
+      - run: pnpm --filter @rivus/worker exec wrangler deploy --env production
+
+  deploy-docs:
+    name: Deploy docs
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup
+      - run: pnpm --filter @rivus/docs build
+      - run: pnpm --filter @rivus/docs exec wrangler deploy --env production
+
+  deploy-app:
+    name: Deploy app
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Baked into the Expo web bundle at export time.
+      EXPO_PUBLIC_API_URL: https://api.rivus.ai
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup
+      - run: pnpm --filter @rivus/app export:web
+      - run: pnpm --filter @rivus/app exec wrangler deploy --env production
+
+  deploy-website:
+    name: Deploy website
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Inlined into the Next client bundle by `next build` (run inside the
+      # OpenNext build).
+      NEXT_PUBLIC_API_URL: https://api.rivus.ai
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup
+      - run: pnpm --filter @rivus/website exec opennextjs-cloudflare build
+      - run: pnpm --filter @rivus/website exec opennextjs-cloudflare deploy -- --env production
+
+  deploy-api:
+    name: Deploy api (container)
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      PROD_MONGODB_URI: ${{ secrets.PROD_MONGODB_URI }}
+      PROD_JWT_SECRET: ${{ secrets.PROD_JWT_SECRET }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/setup
+      # wrangler builds the Dockerfile (Docker is preinstalled on ubuntu-latest)
+      # and pushes the image to Cloudflare's registry before deploying the Worker.
+      - run: pnpm --filter @rivus/api exec wrangler deploy --env production
+      # Keep the Worker's secrets in sync. Skipped until the GitHub secrets exist.
+      - name: Sync API secrets
+        if: ${{ env.PROD_MONGODB_URI != '' }}
+        run: |
+          printf '%s' "$PROD_MONGODB_URI" | pnpm --filter @rivus/api exec wrangler secret put MONGODB_URI --env production
+          printf '%s' "$PROD_JWT_SECRET" | pnpm --filter @rivus/api exec wrangler secret put JWT_SECRET --env production

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -6,7 +6,8 @@ validate the monorepo, then deploy all five packages in parallel:
 - [`Deploy (development)`](.github/workflows/deploy-development.yaml) → the
   `development` environment, on every push to `main` (or manually).
 - [`Deploy (production)`](.github/workflows/deploy-production.yaml) → the
-  `production` environment, when a GitHub **release is published** (or manually).
+  `production` environment, when a **stable release is published** (pre-releases
+  are skipped) or manually.
 
 ## Topology
 
@@ -78,8 +79,16 @@ environment points `API_BASE_URL` at `https://dev-api.rivus.ai`.
 
 Because GitHub environment secrets are scoped to their environment, the
 production job reads its own `CLOUDFLARE_*` values even though the names match
-development. The API's secrets are synced into the Worker automatically by the
-`deploy-api` job; the step is skipped until the `*_MONGODB_URI` secret is present.
+development, and the API's secrets are synced into the Worker automatically by
+the `deploy-api` job. Unlike development (where the sync is skipped until the
+secret exists), the **production** `deploy-api` job **fails fast** if either
+`PROD_MONGODB_URI` or `PROD_JWT_SECRET` is missing — the container always boots
+with `NODE_ENV=production` and would crash-loop without them.
+
+The production API also restricts CORS to Rivus subdomains: `CORS_ORIGIN` is set
+to `*.rivus.ai`, which the API parses into a subdomain matcher (development stays
+`*`). Adjust the value in `packages/api/wrangler.jsonc` to add other origins
+(comma-separated; exact origins and `*` wildcards are both supported).
 
 ## Deploying by hand
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,23 +1,27 @@
 # Deployment
 
-Every Rivus package deploys to **Cloudflare** with Wrangler. The
-[`Deploy (development)`](.github/workflows/deploy-development.yaml) workflow
-validates the monorepo, then deploys all five packages to the `development`
-environment in parallel.
+Every Rivus package deploys to **Cloudflare** with Wrangler. Two workflows
+validate the monorepo, then deploy all five packages in parallel:
+
+- [`Deploy (development)`](.github/workflows/deploy-development.yaml) → the
+  `development` environment, on every push to `main` (or manually).
+- [`Deploy (production)`](.github/workflows/deploy-production.yaml) → the
+  `production` environment, when a GitHub **release is published** (or manually).
 
 ## Topology
 
-| Package          | Cloudflare product                         | Dev URL                |
-| ---------------- | ------------------------------------------ | ---------------------- |
-| `@rivus/api`     | Worker + **Container** (Fastify on Node)   | `dev-api.rivus.ai`     |
-| `@rivus/app`     | Worker **Static Assets** (Expo web export) | `dev-app.rivus.ai`     |
-| `@rivus/website` | Worker via **OpenNext** (Next.js)          | `dev-www.rivus.ai`     |
-| `@rivus/docs`    | Worker **Static Assets** (Docula build)    | `dev-docs.rivus.ai`    |
-| `@rivus/worker`  | Worker (cron + on-demand tasks)            | cron only (`*.workers.dev`) |
+| Package          | Cloudflare product                         | Dev URL                     | Prod URL          |
+| ---------------- | ------------------------------------------ | --------------------------- | ----------------- |
+| `@rivus/api`     | Worker + **Container** (Fastify on Node)   | `dev-api.rivus.ai`          | `api.rivus.ai`    |
+| `@rivus/app`     | Worker **Static Assets** (Expo web export) | `dev-app.rivus.ai`          | `app.rivus.ai`    |
+| `@rivus/website` | Worker via **OpenNext** (Next.js)          | `dev-www.rivus.ai`          | `www.rivus.ai`    |
+| `@rivus/docs`    | Worker **Static Assets** (Docula build)    | `dev-docs.rivus.ai`         | `docs.rivus.ai`   |
+| `@rivus/worker`  | Worker (cron + on-demand tasks)            | cron only (`*.workers.dev`) | cron only         |
 
-Each package owns a `wrangler.jsonc` with a `development` named environment
-(`wrangler deploy --env development`). Names are suffixed `-dev`
-(`rivus-api-dev`, …) so development never collides with production.
+Each package owns a `wrangler.jsonc` with `development` and `production` named
+environments (`wrangler deploy --env <name>`). Development names are suffixed
+`-dev` (`rivus-api-dev`, …); production uses the bare names (`rivus-api`, …) so
+the two environments never collide.
 
 ### How the API runs on Cloudflare
 
@@ -44,12 +48,15 @@ environment points `API_BASE_URL` at `https://dev-api.rivus.ai`.
 
 1. **Cloudflare account + zone.** Add the `rivus.ai` zone to the account so the
    `custom_domain` routes can be created and certificates issued automatically.
-2. **GitHub `development` environment** (Settings → Environments) holding the
-   secrets below.
-3. **DNS / custom domains.** The first `wrangler deploy --env development` per
-   package creates the `dev-*.rivus.ai` custom domain on the zone.
-4. **MongoDB Atlas.** Allow Cloudflare egress to the dev cluster (for a quick
-   start, allow `0.0.0.0/0`; tighten later).
+2. **GitHub environments** (Settings → Environments): a `development` and a
+   `production` environment, each holding the secrets below. Consider adding a
+   required-reviewer protection rule to `production`.
+3. **DNS / custom domains.** The first `wrangler deploy --env <name>` per package
+   creates its custom domain on the zone (`dev-*.rivus.ai` for development,
+   `api/app/www/docs.rivus.ai` for production).
+4. **MongoDB Atlas.** Allow Cloudflare egress to each cluster (for a quick start,
+   allow `0.0.0.0/0`; tighten later). Use a **separate cluster/database** for
+   production.
 
 ### Required secrets (GitHub `development` environment)
 
@@ -60,10 +67,24 @@ environment points `API_BASE_URL` at `https://dev-api.rivus.ai`.
 | `DEV_MONGODB_URI`       | `deploy-api`   | Atlas SRV connection string. Pushed as a Worker secret. |
 | `DEV_JWT_SECRET`        | `deploy-api`   | ≥ 32 chars (the API refuses to boot otherwise in prod). |
 
-The API's secrets are also synced into the Worker automatically by the
-`deploy-api` job; the step is skipped until `DEV_MONGODB_URI` is present.
+### Required secrets (GitHub `production` environment)
+
+| Secret                  | Used by        | Notes                                              |
+| ----------------------- | -------------- | -------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`  | all deploy jobs | Same scopes as above. Can be the same token as development, or a separate production-scoped one. |
+| `CLOUDFLARE_ACCOUNT_ID` | all deploy jobs | Same account ID (unless production lives in a different Cloudflare account). |
+| `PROD_MONGODB_URI`      | `deploy-api`   | Production Atlas SRV connection string. Pushed as a Worker secret. |
+| `PROD_JWT_SECRET`       | `deploy-api`   | ≥ 32 chars, **distinct** from the development secret. |
+
+Because GitHub environment secrets are scoped to their environment, the
+production job reads its own `CLOUDFLARE_*` values even though the names match
+development. The API's secrets are synced into the Worker automatically by the
+`deploy-api` job; the step is skipped until the `*_MONGODB_URI` secret is present.
 
 ## Deploying by hand
+
+Swap `--env development` for `--env production` (and the matching API URLs) to
+target production.
 
 ```bash
 pnpm --filter @rivus/worker  exec wrangler deploy --env development
@@ -74,4 +95,12 @@ NEXT_PUBLIC_API_URL=https://dev-api.rivus.ai \
   pnpm --filter @rivus/website exec opennextjs-cloudflare build && \
   pnpm --filter @rivus/website exec opennextjs-cloudflare deploy -- --env development
 pnpm --filter @rivus/api     exec wrangler deploy --env development   # needs Docker
+```
+
+For production, also push the API secrets the first time (the workflow does this
+automatically):
+
+```bash
+printf '%s' "$PROD_MONGODB_URI" | pnpm --filter @rivus/api exec wrangler secret put MONGODB_URI --env production
+printf '%s' "$PROD_JWT_SECRET"  | pnpm --filter @rivus/api exec wrangler secret put JWT_SECRET  --env production
 ```

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -85,11 +85,10 @@ secret exists), the **production** `deploy-api` job **fails fast** if either
 `PROD_MONGODB_URI` or `PROD_JWT_SECRET` is missing — the container always boots
 with `NODE_ENV=production` and would crash-loop without them.
 
-The production API also restricts CORS to the production frontends: `CORS_ORIGIN`
-is set to `https://app.rivus.ai,https://www.rivus.ai`, which the API parses into
-an exact-origin allowlist (development stays `*`). The value accepts a
-comma-separated list of exact origins and/or `*` wildcards (e.g. `*.rivus.ai`);
-adjust it in `packages/api/wrangler.jsonc`.
+The production API also restricts CORS to Rivus subdomains: `CORS_ORIGIN` is set
+to `*.rivus.ai`, which the API parses into a regex matching any `*.rivus.ai`
+origin (development stays `*`). The value accepts a comma-separated list of exact
+origins and/or `*` wildcards; adjust it in `packages/api/wrangler.jsonc`.
 
 ## Deploying by hand
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -85,10 +85,11 @@ secret exists), the **production** `deploy-api` job **fails fast** if either
 `PROD_MONGODB_URI` or `PROD_JWT_SECRET` is missing — the container always boots
 with `NODE_ENV=production` and would crash-loop without them.
 
-The production API also restricts CORS to Rivus subdomains: `CORS_ORIGIN` is set
-to `*.rivus.ai`, which the API parses into a subdomain matcher (development stays
-`*`). Adjust the value in `packages/api/wrangler.jsonc` to add other origins
-(comma-separated; exact origins and `*` wildcards are both supported).
+The production API also restricts CORS to the production frontends: `CORS_ORIGIN`
+is set to `https://app.rivus.ai,https://www.rivus.ai`, which the API parses into
+an exact-origin allowlist (development stays `*`). The value accepts a
+comma-separated list of exact origins and/or `*` wildcards (e.g. `*.rivus.ai`);
+adjust it in `packages/api/wrangler.jsonc`.
 
 ## Deploying by hand
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -7,6 +7,7 @@ import {
 	serializerCompiler,
 	validatorCompiler,
 } from 'fastify-type-provider-zod';
+import { parseCorsOrigin } from './config';
 import authPlugin from './plugins/auth';
 import swaggerPlugin from './plugins/swagger';
 import { ConflictError } from './repositories/errors';
@@ -74,7 +75,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	});
 
 	app.register(sensible);
-	app.register(cors, { origin: deps.config.CORS_ORIGIN });
+	app.register(cors, { origin: parseCorsOrigin(deps.config.CORS_ORIGIN) });
 	app.register(helmet, { contentSecurityPolicy: false });
 	app.register(authPlugin);
 	app.register(swaggerPlugin);

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -43,3 +43,46 @@ export type Config = z.infer<typeof envSchema>;
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
 	return envSchema.parse(env);
 }
+
+/** What `@fastify/cors` accepts for its `origin` option. */
+export type CorsOrigin = boolean | string | RegExp | Array<string | RegExp>;
+
+/**
+ * Translate the `CORS_ORIGIN` env string into a value `@fastify/cors` understands.
+ *
+ * - `*` (the default) allows any origin.
+ * - A comma-separated list yields multiple allowed origins.
+ * - An entry containing `*` is a wildcard — e.g. `*.rivus.ai` matches any single
+ *   subdomain (`app.rivus.ai`, `www.rivus.ai`) over http/https — and becomes an
+ *   anchored RegExp, since `@fastify/cors` only does exact matches on strings.
+ * - Any other entry is matched exactly.
+ */
+export function parseCorsOrigin(value: string): CorsOrigin {
+	const entries = value
+		.split(',')
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+	// A bare `*` (the default) short-circuits to "allow any origin".
+	if (entries.includes('*')) {
+		return '*';
+	}
+	const matchers = entries.map(toOriginMatcher);
+	const [first, ...rest] = matchers;
+	if (first === undefined) {
+		return false;
+	}
+	return rest.length === 0 ? first : matchers;
+}
+
+function toOriginMatcher(entry: string): string | RegExp {
+	if (!entry.includes('*')) {
+		return entry;
+	}
+	// Escape every regex metacharacter (including `*`), then turn the escaped `*`
+	// back into a single-label wildcard so `*.rivus.ai` matches `app.rivus.ai`
+	// but not `a.b.rivus.ai` or the bare `rivus.ai`.
+	const escaped = entry.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '[^.]+');
+	// Origin headers always carry a scheme; allow http/https when none is given.
+	const pattern = entry.includes('://') ? escaped : `https?://${escaped}`;
+	return new RegExp(`^${pattern}$`);
+}

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { loadConfig } from '../src/config';
+import { loadConfig, parseCorsOrigin } from '../src/config';
 
 describe('loadConfig', () => {
 	it('applies development defaults', () => {
@@ -28,5 +28,53 @@ describe('loadConfig', () => {
 			JWT_SECRET: 'x'.repeat(40),
 		} as NodeJS.ProcessEnv);
 		expect(config.NODE_ENV).toBe('production');
+	});
+});
+
+describe('parseCorsOrigin', () => {
+	it('allows any origin for the "*" default', () => {
+		expect(parseCorsOrigin('*')).toBe('*');
+	});
+
+	it('returns false when no origins are configured', () => {
+		expect(parseCorsOrigin('')).toBe(false);
+		expect(parseCorsOrigin('  ,  ')).toBe(false);
+	});
+
+	it('keeps a single exact origin as a string', () => {
+		expect(parseCorsOrigin('https://app.rivus.ai')).toBe('https://app.rivus.ai');
+	});
+
+	it('splits a comma-separated list into exact origins', () => {
+		expect(parseCorsOrigin('https://app.rivus.ai, https://www.rivus.ai')).toEqual([
+			'https://app.rivus.ai',
+			'https://www.rivus.ai',
+		]);
+	});
+
+	it('falls back to allow-all when "*" appears anywhere in the list', () => {
+		expect(parseCorsOrigin('https://app.rivus.ai,*')).toBe('*');
+	});
+
+	it('turns a subdomain wildcard into a matching regex', () => {
+		const origin = parseCorsOrigin('*.rivus.ai');
+		expect(origin).toBeInstanceOf(RegExp);
+		const re = origin as RegExp;
+		expect(re.test('https://app.rivus.ai')).toBe(true);
+		expect(re.test('https://www.rivus.ai')).toBe(true);
+		expect(re.test('http://app.rivus.ai')).toBe(true);
+		// Not the apex, not nested subdomains, not look-alikes.
+		expect(re.test('https://rivus.ai')).toBe(false);
+		expect(re.test('https://a.b.rivus.ai')).toBe(false);
+		expect(re.test('https://app.rivus.ai.evil.com')).toBe(false);
+		expect(re.test('https://evil.com')).toBe(false);
+	});
+
+	it('honours an explicit scheme in a wildcard', () => {
+		const origin = parseCorsOrigin('https://*.rivus.ai');
+		expect(origin).toBeInstanceOf(RegExp);
+		const re = origin as RegExp;
+		expect(re.test('https://app.rivus.ai')).toBe(true);
+		expect(re.test('http://app.rivus.ai')).toBe(false);
 	});
 });

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -53,11 +53,11 @@
 		"production": {
 			"name": "rivus-api",
 			"routes": [{ "pattern": "api.rivus.ai", "custom_domain": true }],
-			// Restrict cross-origin requests to the production frontends. The API
-			// parses this comma-separated allowlist (see src/config.ts
-			// `parseCorsOrigin`) into exact-origin matchers.
+			// Restrict cross-origin requests to Rivus subdomains. The API parses
+			// this (see src/config.ts `parseCorsOrigin`) into a regex matching any
+			// *.rivus.ai origin over http/https.
 			"vars": {
-				"CORS_ORIGIN": "https://app.rivus.ai,https://www.rivus.ai"
+				"CORS_ORIGIN": "*.rivus.ai"
 			},
 			"containers": [
 				{

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -49,6 +49,24 @@
 			"durable_objects": {
 				"bindings": [{ "name": "API_CONTAINER", "class_name": "ApiContainer" }]
 			}
+		},
+		"production": {
+			"name": "rivus-api",
+			"routes": [{ "pattern": "api.rivus.ai", "custom_domain": true }],
+			"vars": {
+				"CORS_ORIGIN": "*"
+			},
+			"containers": [
+				{
+					"class_name": "ApiContainer",
+					"image": "./Dockerfile",
+					"image_build_context": "../../",
+					"max_instances": 3
+				}
+			],
+			"durable_objects": {
+				"bindings": [{ "name": "API_CONTAINER", "class_name": "ApiContainer" }]
+			}
 		}
 	}
 }

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -53,8 +53,10 @@
 		"production": {
 			"name": "rivus-api",
 			"routes": [{ "pattern": "api.rivus.ai", "custom_domain": true }],
+			// Restrict cross-origin requests to Rivus subdomains (app/www). The API
+			// parses this (see src/config.ts `parseCorsOrigin`) into a subdomain regex.
 			"vars": {
-				"CORS_ORIGIN": "*"
+				"CORS_ORIGIN": "*.rivus.ai"
 			},
 			"containers": [
 				{

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -53,10 +53,11 @@
 		"production": {
 			"name": "rivus-api",
 			"routes": [{ "pattern": "api.rivus.ai", "custom_domain": true }],
-			// Restrict cross-origin requests to Rivus subdomains (app/www). The API
-			// parses this (see src/config.ts `parseCorsOrigin`) into a subdomain regex.
+			// Restrict cross-origin requests to the production frontends. The API
+			// parses this comma-separated allowlist (see src/config.ts
+			// `parseCorsOrigin`) into exact-origin matchers.
 			"vars": {
-				"CORS_ORIGIN": "*.rivus.ai"
+				"CORS_ORIGIN": "https://app.rivus.ai,https://www.rivus.ai"
 			},
 			"containers": [
 				{

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -13,6 +13,10 @@
 		"development": {
 			"name": "rivus-app-dev",
 			"routes": [{ "pattern": "dev-app.rivus.ai", "custom_domain": true }]
+		},
+		"production": {
+			"name": "rivus-app",
+			"routes": [{ "pattern": "app.rivus.ai", "custom_domain": true }]
 		}
 	}
 }

--- a/packages/docs/wrangler.jsonc
+++ b/packages/docs/wrangler.jsonc
@@ -15,6 +15,10 @@
 		"development": {
 			"name": "rivus-docs-dev",
 			"routes": [{ "pattern": "dev-docs.rivus.ai", "custom_domain": true }]
+		},
+		"production": {
+			"name": "rivus-docs",
+			"routes": [{ "pattern": "docs.rivus.ai", "custom_domain": true }]
 		}
 	}
 }

--- a/packages/website/wrangler.jsonc
+++ b/packages/website/wrangler.jsonc
@@ -15,6 +15,10 @@
 		"development": {
 			"name": "rivus-website-dev",
 			"routes": [{ "pattern": "dev-www.rivus.ai", "custom_domain": true }]
+		},
+		"production": {
+			"name": "rivus-website",
+			"routes": [{ "pattern": "www.rivus.ai", "custom_domain": true }]
 		}
 	}
 }

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -26,6 +26,9 @@
 		},
 		"production": {
 			"name": "rivus-worker",
+			// Cron-only in production: don't expose the on-demand task routes
+			// (src/router.ts) on a public *.workers.dev hostname.
+			"workers_dev": false,
 			"vars": {
 				"API_BASE_URL": "https://api.rivus.ai"
 			}

--- a/packages/worker/wrangler.jsonc
+++ b/packages/worker/wrangler.jsonc
@@ -23,6 +23,12 @@
 			"vars": {
 				"API_BASE_URL": "https://dev-api.rivus.ai"
 			}
+		},
+		"production": {
+			"name": "rivus-worker",
+			"vars": {
+				"API_BASE_URL": "https://api.rivus.ai"
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What

Adds a **`Deploy (production)`** workflow that mirrors the existing
`Deploy (development)` one, deploying all five packages to the Cloudflare
`production` environment in parallel.

## Changes

- **`.github/workflows/deploy-production.yaml`** — validate → deploy `worker`,
  `docs`, `app`, `website`, and `api` (container) to `--env production`. All
  jobs use `environment: production`.
- **`wrangler.jsonc` (all five packages)** — add a `production` named
  environment alongside `development`:
  - Bare worker names (`rivus-api`, `rivus-app`, …) so prod never collides with
    the `-dev` suffixed dev names.
  - Custom domains: `api.rivus.ai`, `app.rivus.ai`, `www.rivus.ai`,
    `docs.rivus.ai`.
  - `worker` / `app` / `website` public API URL → `https://api.rivus.ai`.
- **`DEPLOYMENT.md`** — document the production topology, the GitHub
  `production` environment, required secrets, and by-hand commands.

## Design choices (differ from development on purpose)

- **Trigger:** published GitHub **release** + manual `workflow_dispatch` (dev
  deploys on every push to `main`). Easy to switch to push/tag if you'd rather.
- **Concurrency:** single global `deploy-production` group with
  `cancel-in-progress: false` — a half-applied prod deploy is worse than a
  queued one.

## Variables / secrets needed

Create a GitHub **`production`** environment (Settings → Environments) with:

| Secret | Notes |
| --- | --- |
| `CLOUDFLARE_API_TOKEN` | Same scopes as dev; can reuse the dev token or use a prod-scoped one. |
| `CLOUDFLARE_ACCOUNT_ID` | Same account (unless prod lives elsewhere). |
| `PROD_MONGODB_URI` | Production Atlas SRV string; synced into the API Worker. |
| `PROD_JWT_SECRET` | ≥ 32 chars, distinct from dev. |

Environment-scoped secrets mean the `CLOUDFLARE_*` names can match dev while
holding different values. The API-secret sync step is skipped until
`PROD_MONGODB_URI` exists, so the workflow is safe to merge before the secrets
are set.

> [!NOTE]
> First prod deploy per package creates its `*.rivus.ai` custom domain on the
> zone, and the API container requires the Workers Paid plan (as in dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fdwkrmbkz6tEbxf5CqQdq2)_