### PR TITLE
feat: block search crawlers on development deployments

### DIFF
--- a/.github/workflows/deploy-development.yaml
+++ b/.github/workflows/deploy-development.yaml
@@ -49,6 +49,8 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Selects the disallow-all robots.txt for the dev docs (dev-docs.rivus.ai).
+      RIVUS_ENV: development
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
@@ -63,6 +65,8 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Selects the disallow-all robots.txt for the dev app (dev-app.rivus.ai).
+      RIVUS_ENV: development
       # Baked into the Expo web bundle at export time.
       EXPO_PUBLIC_API_URL: https://dev-api.rivus.ai
     steps:
@@ -79,6 +83,9 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Selects the disallow-all robots.txt + noindex meta for the dev site
+      # (dev.rivus.ai); read at build time by robots.ts and the root layout.
+      RIVUS_ENV: development
       # Inlined into the Next client bundle by `next build` (run inside the
       # OpenNext build).
       NEXT_PUBLIC_API_URL: https://dev-api.rivus.ai

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -53,6 +53,8 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Crawlable: emits an allow-all robots.txt for the production docs.
+      RIVUS_ENV: production
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
@@ -67,6 +69,8 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Crawlable: emits an allow-all robots.txt for the production app.
+      RIVUS_ENV: production
       # Baked into the Expo web bundle at export time.
       EXPO_PUBLIC_API_URL: https://api.rivus.ai
     steps:
@@ -83,6 +87,9 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Crawlable: allow-all robots.txt and indexable metadata for the
+      # production site; read at build time by robots.ts and the root layout.
+      RIVUS_ENV: production
       # Inlined into the Next client bundle by `next build` (run inside the
       # OpenNext build).
       NEXT_PUBLIC_API_URL: https://api.rivus.ai

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -45,6 +45,30 @@ it ships as a **Cloudflare Container**:
 bundles `src/index.ts` and registers the `*/15 * * * *` cron. The `development`
 environment points `API_BASE_URL` at `https://dev-api.rivus.ai`.
 
+## Search engine crawling
+
+Only **production** is crawlable. Every pre-production deployment — the
+`development` environment (`dev.rivus.ai`, `dev-docs.rivus.ai`,
+`dev-app.rivus.ai`) and local builds — blocks all crawlers so it never lands in
+a search index.
+
+The signal is a single build-time variable, **`RIVUS_ENV`**, set per environment
+in the deploy workflows (`development` vs `production`). Anything other than
+`production` — including unset — is treated as non-production, so the safe
+default is "don't crawl":
+
+| Package          | Crawl rule emitted                                             |
+| ---------------- | ------------------------------------------------------------- |
+| `@rivus/website` | `src/app/robots.ts` builds `/robots.txt`; the root layout also adds a `noindex, nofollow` meta tag outside production. |
+| `@rivus/docs`    | `scripts/write-robots.mjs` writes `site/dist/robots.txt` after the Docula build. |
+| `@rivus/app`     | `scripts/write-robots.mjs` writes `dist/robots.txt` after the Expo web export. |
+
+Production emits an explicit allow-all `robots.txt`; development emits
+`User-agent: * / Disallow: /`. The API (`api.rivus.ai`) serves only JSON with no
+crawlable UI in any environment (its Swagger UI is off under `NODE_ENV=production`,
+which is how the container always runs), and the worker has no public route, so
+neither emits a `robots.txt`.
+
 ## One-time setup
 
 1. **Cloudflare account + zone.** Add the `rivus.ai` zone to the account so the

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -10,7 +10,7 @@
 		"android": "expo start --android",
 		"ios": "expo start --ios",
 		"web": "expo start --web",
-		"export:web": "expo export -p web",
+		"export:web": "expo export -p web && node scripts/write-robots.mjs",
 		"deploy": "wrangler deploy",
 		"test": "vitest run",
 		"test:watch": "vitest",

--- a/packages/app/scripts/write-robots.mjs
+++ b/packages/app/scripts/write-robots.mjs
@@ -1,0 +1,25 @@
+// Emit dist/robots.txt after the Expo web export. Only the production
+// deployment (app.rivus.ai) is crawlable; every pre-production build
+// (dev-app.rivus.ai) and local export blocks all crawlers so the
+// pre-release app never lands in a search index.
+//
+// The deploy workflows set RIVUS_ENV per Cloudflare environment; anything other
+// than "production" (including unset) is treated as non-production.
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const isProduction = process.env.RIVUS_ENV === 'production';
+
+const body = isProduction
+	? 'User-agent: *\nAllow: /\n'
+	: '# Pre-production app — keep it out of search indexes.\nUser-agent: *\nDisallow: /\n';
+
+const destination = resolve(here, '../dist/robots.txt');
+mkdirSync(dirname(destination), { recursive: true });
+writeFileSync(destination, body);
+
+console.log(
+	`[app] wrote ${destination} (${isProduction ? 'allow all' : 'disallow all'} — RIVUS_ENV=${process.env.RIVUS_ENV ?? 'unset'})`,
+);

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -7,7 +7,7 @@
 	"license": "MIT",
 	"scripts": {
 		"prebuild": "node scripts/sync-openapi.mjs",
-		"build": "docula build -s ./site -o ./site/dist -c",
+		"build": "docula build -s ./site -o ./site/dist -c && node scripts/write-robots.mjs",
 		"predev": "node scripts/sync-openapi.mjs",
 		"dev": "docula dev -s ./site",
 		"start": "docula start -s ./site",

--- a/packages/docs/scripts/write-robots.mjs
+++ b/packages/docs/scripts/write-robots.mjs
@@ -1,0 +1,25 @@
+// Emit site/dist/robots.txt after the Docula build. Only the production docs
+// (docs.rivus.ai) are crawlable; every pre-production build (dev-docs.rivus.ai)
+// and local build blocks all crawlers so pre-release docs never land in a
+// search index.
+//
+// The deploy workflows set RIVUS_ENV per Cloudflare environment; anything other
+// than "production" (including unset) is treated as non-production.
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const isProduction = process.env.RIVUS_ENV === 'production';
+
+const body = isProduction
+	? 'User-agent: *\nAllow: /\n'
+	: '# Pre-production docs — keep them out of search indexes.\nUser-agent: *\nDisallow: /\n';
+
+const destination = resolve(here, '../site/dist/robots.txt');
+mkdirSync(dirname(destination), { recursive: true });
+writeFileSync(destination, body);
+
+console.log(
+	`[docs] wrote ${destination} (${isProduction ? 'allow all' : 'disallow all'} — RIVUS_ENV=${process.env.RIVUS_ENV ?? 'unset'})`,
+);

--- a/packages/website/src/app/layout.tsx
+++ b/packages/website/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import { Montserrat } from 'next/font/google';
 import type { ReactNode } from 'react';
+import { isProductionEnv } from '../lib/env';
 import { siteConfig } from '../lib/site';
 import './globals.css';
 
@@ -14,6 +15,9 @@ const montserrat = Montserrat({
 export const metadata: Metadata = {
 	title: `${siteConfig.name} — ${siteConfig.tagline}`,
 	description: siteConfig.description,
+	// Keep every pre-production deployment (dev.rivus.ai, local builds) out of
+	// search indexes; production stays fully indexable. Pairs with /robots.txt.
+	robots: isProductionEnv() ? undefined : { index: false, follow: false },
 	openGraph: {
 		title: `${siteConfig.name} — ${siteConfig.tagline}`,
 		description: siteConfig.description,

--- a/packages/website/src/app/robots.test.ts
+++ b/packages/website/src/app/robots.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import robots from './robots';
+
+describe('robots.txt', () => {
+	const original = process.env.RIVUS_ENV;
+
+	afterEach(() => {
+		if (original === undefined) {
+			delete process.env.RIVUS_ENV;
+		} else {
+			process.env.RIVUS_ENV = original;
+		}
+	});
+
+	it('allows all crawlers in production', () => {
+		process.env.RIVUS_ENV = 'production';
+		expect(robots().rules).toEqual({ userAgent: '*', allow: '/' });
+	});
+
+	it('disallows all crawlers in the development environment', () => {
+		process.env.RIVUS_ENV = 'development';
+		expect(robots().rules).toEqual({ userAgent: '*', disallow: '/' });
+	});
+
+	it('disallows all crawlers when RIVUS_ENV is unset', () => {
+		delete process.env.RIVUS_ENV;
+		expect(robots().rules).toEqual({ userAgent: '*', disallow: '/' });
+	});
+});

--- a/packages/website/src/app/robots.ts
+++ b/packages/website/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+import { isProductionEnv } from '../lib/env';
+
+/**
+ * `/robots.txt`. Only the production marketing site (rivus.ai) should be
+ * crawled; every pre-production deployment (dev.rivus.ai) and local build
+ * disallows all crawlers so it never lands in a search index.
+ */
+export default function robots(): MetadataRoute.Robots {
+	return {
+		rules: isProductionEnv() ? { userAgent: '*', allow: '/' } : { userAgent: '*', disallow: '/' },
+	};
+}

--- a/packages/website/src/lib/env.test.ts
+++ b/packages/website/src/lib/env.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isProductionEnv } from './env';
+
+describe('isProductionEnv', () => {
+	it('is true only when RIVUS_ENV is exactly "production"', () => {
+		expect(isProductionEnv({ RIVUS_ENV: 'production' })).toBe(true);
+	});
+
+	it('is false for the development environment', () => {
+		expect(isProductionEnv({ RIVUS_ENV: 'development' })).toBe(false);
+	});
+
+	it('is false when RIVUS_ENV is unset (e.g. local builds)', () => {
+		expect(isProductionEnv({})).toBe(false);
+	});
+
+	it('reads from process.env by default', () => {
+		// No throw, returns a boolean regardless of ambient env.
+		expect(typeof isProductionEnv()).toBe('boolean');
+	});
+});

--- a/packages/website/src/lib/env.ts
+++ b/packages/website/src/lib/env.ts
@@ -6,6 +6,10 @@
  * and the `development` deploy — is treated as non-production, so a
  * pre-production surface is never accidentally exposed to search crawlers.
  */
-export function isProductionEnv(env: Record<string, string | undefined> = process.env): boolean {
-	return env.RIVUS_ENV === 'production';
+export function isProductionEnv(env?: Record<string, string | undefined>): boolean {
+	// Guard the `process` reference: this helper lives in `lib/`, so a future
+	// client/edge import shouldn't throw if `process` is undefined — it just
+	// falls back to "not production" (block crawling), the safe default.
+	const target = env ?? (typeof process !== 'undefined' ? process.env : {});
+	return target.RIVUS_ENV === 'production';
 }

--- a/packages/website/src/lib/env.ts
+++ b/packages/website/src/lib/env.ts
@@ -1,0 +1,11 @@
+/**
+ * Whether this build targets the production Cloudflare environment.
+ *
+ * The deploy workflows set `RIVUS_ENV` ("development" | "production") per
+ * environment. Anything other than "production" — including unset (local builds)
+ * and the `development` deploy — is treated as non-production, so a
+ * pre-production surface is never accidentally exposed to search crawlers.
+ */
+export function isProductionEnv(env: Record<string, string | undefined> = process.env): boolean {
+	return env.RIVUS_ENV === 'production';
+}


### PR DESCRIPTION
## What & why

Pre-production deployments should never land in a search index. Today none of our sites emit any crawl rules, so every `development` deployment (`dev.rivus.ai`, `dev-docs.rivus.ai`, `dev-app.rivus.ai`) is fully crawlable. This makes sure **development is never crawled**, while **production stays fully crawlable**.

## How

A single build-time signal, **`RIVUS_ENV`**, set per Cloudflare environment in the deploy workflows. Anything other than `production` — **including unset** (local builds) — is treated as non-production, so the safe default is *don't crawl*.

| Surface | Crawl rule |
| --- | --- |
| `@rivus/website` (`dev.rivus.ai`) | `src/app/robots.ts` builds `/robots.txt` (allow-all vs `Disallow: /`); the root layout also adds a `noindex, nofollow` meta tag outside production. |
| `@rivus/docs` (`dev-docs.rivus.ai`) | `scripts/write-robots.mjs` writes `site/dist/robots.txt` after the Docula build. |
| `@rivus/app` (`dev-app.rivus.ai`) | `scripts/write-robots.mjs` writes `dist/robots.txt` after the Expo web export. |

The **API** serves only JSON with no crawlable UI in any environment (its Swagger UI is off under `NODE_ENV=production`, which is how the container always runs), and the **worker** has no public route — so neither emits a `robots.txt`.

## Verification

End-to-end `next build` of the website:

| Build | `/robots.txt` | root `<meta robots>` |
| --- | --- | --- |
| dev (`RIVUS_ENV` unset) | `User-Agent: *` / `Disallow: /` | `noindex, nofollow` |
| prod (`RIVUS_ENV=production`) | `User-Agent: *` / `Allow: /` | _absent → indexable_ |

The docs/app generators were exercised in both modes and emit the matching bodies. `pnpm lint && pnpm type-check && pnpm test` all pass; website coverage is 99.6% lines / 97.46% branches (`isProductionEnv` and `robots()` are unit-tested, both branches).

See `DEPLOYMENT.md` → **Search engine crawling** for the documented behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdAKp8DGgR4aQXKLtHBG1S

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdAKp8DGgR4aQXKLtHBG1S)_