### PR TITLE
fix(app): inline EXPO_PUBLIC_* env vars into the web bundle

### DIFF
--- a/.github/workflows/deploy-development.yaml
+++ b/.github/workflows/deploy-development.yaml
@@ -75,6 +75,19 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm --filter @rivus/app export:web
+      # The signup address field needs the Maps key inlined into the web bundle;
+      # if config.ts ever stops reading it as a literal process.env.* expression
+      # the value silently drops out and autocomplete degrades to a text field.
+      - name: Verify the Maps key inlined into the web bundle
+        run: |
+          if [ -z "$EXPO_PUBLIC_GOOGLE_MAPS_API_KEY" ]; then
+            echo "::warning::EXPO_PUBLIC_GOOGLE_MAPS_API_KEY is unset — signup address autocomplete will be a plain text field"
+          elif grep -rqF "$EXPO_PUBLIC_GOOGLE_MAPS_API_KEY" packages/app/dist/; then
+            echo "Google Maps key inlined into the web bundle ✓"
+          else
+            echo "::error::EXPO_PUBLIC_GOOGLE_MAPS_API_KEY is set but did not inline into the bundle"
+            exit 1
+          fi
       - run: pnpm --filter @rivus/app exec wrangler deploy --env development
 
   deploy-website:

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -79,6 +79,19 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm --filter @rivus/app export:web
+      # The signup address field needs the Maps key inlined into the web bundle;
+      # if config.ts ever stops reading it as a literal process.env.* expression
+      # the value silently drops out and autocomplete degrades to a text field.
+      - name: Verify the Maps key inlined into the web bundle
+        run: |
+          if [ -z "$EXPO_PUBLIC_GOOGLE_MAPS_API_KEY" ]; then
+            echo "::warning::EXPO_PUBLIC_GOOGLE_MAPS_API_KEY is unset — signup address autocomplete will be a plain text field"
+          elif grep -rqF "$EXPO_PUBLIC_GOOGLE_MAPS_API_KEY" packages/app/dist/; then
+            echo "Google Maps key inlined into the web bundle ✓"
+          else
+            echo "::error::EXPO_PUBLIC_GOOGLE_MAPS_API_KEY is set but did not inline into the bundle"
+            exit 1
+          fi
       - run: pnpm --filter @rivus/app exec wrangler deploy --env production
 
   deploy-website:

--- a/packages/app/src/api/config.ts
+++ b/packages/app/src/api/config.ts
@@ -8,12 +8,25 @@
 export const DEFAULT_API_URL = 'http://localhost:4000';
 
 /**
- * `process.env` under Node-like runtimes, else `{}`. Guarded because `process`
- * can be undefined in some React Native / Expo JS engines, where touching it
- * directly would crash.
+ * The build-time values of the `EXPO_PUBLIC_*` vars we read.
+ *
+ * Expo/Metro inlines these only where `process.env.EXPO_PUBLIC_*` appears as a
+ * **literal** member expression in source. Reading them indirectly (e.g. via a
+ * variable that holds `process.env`, as this used to) defeats the static
+ * replacement, so the value is `undefined` in the bundle and the address field
+ * silently degrades to a plain text input. Reference each var directly here so
+ * the bundler can substitute it; the accessors keep an injectable `env`
+ * parameter for hermetic tests. `typeof process` is guarded because `process`
+ * can be undefined in some React Native / Expo JS engines.
  */
 function ambientEnv(): Record<string, string | undefined> {
-	return typeof process !== 'undefined' ? process.env : {};
+	if (typeof process === 'undefined') {
+		return {};
+	}
+	return {
+		EXPO_PUBLIC_API_URL: process.env.EXPO_PUBLIC_API_URL,
+		EXPO_PUBLIC_GOOGLE_MAPS_API_KEY: process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY,
+	};
 }
 
 export function getApiBaseUrl(env: Record<string, string | undefined> = ambientEnv()): string {

--- a/packages/app/src/api/config.ts
+++ b/packages/app/src/api/config.ts
@@ -40,7 +40,9 @@ export function getApiBaseUrl(env: Record<string, string | undefined> = ambientE
  * The Google Maps Platform key used for address autocomplete, or `null` when
  * unset (the address field then degrades to a plain text input). This key is
  * inlined into the client bundle, so it must be HTTP-referrer + API restricted
- * in the Google Cloud console.
+ * in the Google Cloud console. Because that referrer restriction only authorizes
+ * web origins, callers gate autocomplete to web (see `AuthScreen`); native
+ * builds carry no referer and would be rejected.
  */
 export function getGoogleMapsApiKey(
 	env: Record<string, string | undefined> = ambientEnv(),

--- a/packages/app/src/api/config.ts
+++ b/packages/app/src/api/config.ts
@@ -16,11 +16,13 @@ export const DEFAULT_API_URL = 'http://localhost:4000';
  * replacement, so the value is `undefined` in the bundle and the address field
  * silently degrades to a plain text input. Reference each var directly here so
  * the bundler can substitute it; the accessors keep an injectable `env`
- * parameter for hermetic tests. `typeof process` is guarded because `process`
- * can be undefined in some React Native / Expo JS engines.
+ * parameter for hermetic tests. `process` and `process.env` are both guarded:
+ * in some React Native / Expo (or edge) JS engines `process` may be undefined,
+ * or shimmed as an object whose `env` is undefined, either of which would crash
+ * a direct property read.
  */
 function ambientEnv(): Record<string, string | undefined> {
-	if (typeof process === 'undefined') {
+	if (typeof process === 'undefined' || typeof process.env === 'undefined') {
 		return {};
 	}
 	return {

--- a/packages/app/src/auth/AuthScreen.tsx
+++ b/packages/app/src/auth/AuthScreen.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { Platform, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { ApiError, type SignupBody } from '@/src/api/client';
 import { getGoogleMapsApiKey } from '@/src/api/config';
 import { deviceTimezone, listTimezones } from '@/src/api/timezones';
@@ -58,7 +58,11 @@ export function AuthScreen() {
 	const [error, setError] = useState<string | null>(null);
 	const [submitting, setSubmitting] = useState(false);
 
-	const mapsApiKey = useMemo(() => getGoogleMapsApiKey(), []);
+	// The Maps key is HTTP-referrer restricted, which only authorizes web
+	// origins. Native requests carry no referer, so the key would be rejected on
+	// every keystroke; gate autocomplete to web and let the field fall back to a
+	// plain text input elsewhere.
+	const mapsApiKey = useMemo(() => (Platform.OS === 'web' ? getGoogleMapsApiKey() : null), []);
 	const timezoneOptions = useMemo(
 		() => listTimezones().map((zone) => ({ label: zone.replace(/_/g, ' '), value: zone })),
 		[],


### PR DESCRIPTION
## Problem

On the **Create account** form, the Google Places **address autocomplete** never showed suggestions — the field behaved like a plain text box.

## Root cause

`AddressAutocomplete` only calls Google when `getGoogleMapsApiKey()` returns a key; otherwise it degrades to a plain text input. That getter (and `getApiBaseUrl`) read their values through an `ambientEnv()` helper that returned `process.env` and then accessed `env.EXPO_PUBLIC_*` off the variable.

Expo/Metro inlines `process.env.EXPO_PUBLIC_*` **only where it appears as a literal member expression** in source. Reading it indirectly defeats the static substitution, so the values were `undefined` in the exported bundle even though the GitHub Actions secret was wired in correctly.

Proven by exporting the web bundle with a test key set:

| | before | after |
|---|---|---|
| `EXPO_PUBLIC_GOOGLE_MAPS_API_KEY` in bundle | ❌ absent | ✅ inlined |
| `EXPO_PUBLIC_API_URL` in bundle | ❌ absent (fell back to `localhost:4000`) | ✅ inlined |

So this also silently affected the **API base URL** in the deployed web app, not just autocomplete.

## Fix

- `packages/app/src/api/config.ts` — `ambientEnv()` now references each `process.env.EXPO_PUBLIC_*` var directly so the bundler can substitute it. Accessors keep their injectable `env` parameter, so the existing unit tests are unchanged.
- `deploy-development.yaml` / `deploy-production.yaml` — after `export:web`, a guard greps the exported bundle and **fails the deploy** if a configured Maps key didn't inline (warns if the key is intentionally unset). This would have caught the bug.

## Verification

- `pnpm lint && pnpm type-check && pnpm test` all pass (app 44, api 104, website 43, worker 14, core).
- Re-ran `expo export -p web` with a probe key and confirmed both vars now appear in the bundle.
- Confirmed the production key itself is valid and the API enabled: a request with `Referer: https://app.rivus.ai` (and `https://dev-app.rivus.ai`) returns 200 with suggestions.

## Follow-ups (config, not code — outside this PR)

The key is **HTTP-referrer restricted**. After this fix the deployed web app will work because `app.rivus.ai` / `dev-app.rivus.ai` are allowlisted, but:

- **Local web dev** (`http://localhost:8081`) is currently **not** in the allowlist → still 403. Add it in the Google Cloud console if you want autocomplete locally.
- **Native iOS/Android** send no `Referer`, so an HTTP-referrer-restricted key can't work there at all. If native autocomplete is needed, use a separate key (or proxy the Places call through `@rivus/api`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhKDtSaQmExRGCEhNjRav2

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhKDtSaQmExRGCEhNjRav2)_