### PR TITLE
fix: friendlier validation error messages

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -42,9 +42,13 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 
 	app.setErrorHandler((error: FastifyError, request, reply) => {
 		if (hasZodFastifySchemaValidationErrors(error)) {
+			// Lead with the first field's friendly message (the schemas spell these out
+			// in plain language) so a client that only shows `message` still says
+			// something useful; `details` keeps the full per-field breakdown.
+			const [firstIssue] = error.validation;
 			return reply.status(400).send({
 				error: 'Bad Request',
-				message: 'Request validation failed',
+				message: firstIssue?.message ?? 'Request validation failed',
 				statusCode: 400,
 				details: error.validation,
 			});

--- a/packages/api/test/auth.test.ts
+++ b/packages/api/test/auth.test.ts
@@ -119,9 +119,12 @@ describe('signup', () => {
 		expect(account.slug).toBe('account');
 	});
 
-	it('rejects an invalid email with 400', async () => {
+	it('rejects an invalid email with 400 and a friendly top-level message', async () => {
 		const response = await requestSignup(app, { ...signupBody(), email: 'not-an-email' });
 		expect(response.statusCode).toBe(400);
+		// Not the generic "Request validation failed" — the field's plain-language message.
+		expect(response.json().message).toBe('Enter a valid email address.');
+		expect(response.json().details).toHaveLength(1);
 	});
 
 	it('rejects signup without business information with 400', async () => {

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ApiError, createApiClient } from './client';
+import { ApiError, createApiClient, ValidationError } from './client';
 
 /** Build a `Response`-like object the client's `text()`/`ok` logic understands. */
 function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
@@ -130,6 +130,25 @@ describe('createApiClient', () => {
 					business: { businessName: '' },
 				}),
 			).rejects.toThrow();
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('surfaces a friendly ValidationError for a bad field, not a raw JSON dump', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			const error = await client
+				.signup({
+					email: 'owner@business.com',
+					name: 'Marcus Thompson',
+					business: { businessName: 'Acme', website: 'not a url' },
+				})
+				.catch((caught) => caught);
+
+			expect(error).toBeInstanceOf(ValidationError);
+			expect(error.message).toBe('Enter a valid website URL, like https://example.com.');
+			// Regression: the old path let `ZodError.message` — a pretty-printed JSON
+			// array — land in the UI verbatim. A friendly message is a single line.
+			expect(error.message).not.toContain('[');
+			expect(error.issues[0]?.path).toEqual(['business', 'website']);
 			expect(fetchMock).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -55,6 +55,38 @@ export class ApiError extends Error {
 	}
 }
 
+/**
+ * Thrown when a request body fails client-side validation before any network
+ * call. Its `message` is a single, human-readable line (the first issue), so UI
+ * that surfaces `error.message` shows friendly text — not the raw JSON array
+ * that `ZodError.message` serializes to. The full field-level `issues` are kept
+ * for callers that want to highlight individual inputs.
+ */
+export class ValidationError extends Error {
+	readonly issues: z.ZodError['issues'];
+
+	constructor(message: string, issues: z.ZodError['issues']) {
+		super(message);
+		this.name = 'ValidationError';
+		this.issues = issues;
+	}
+}
+
+/**
+ * Validate request input, raising a friendly {@link ValidationError} on failure.
+ * Wraps `schema.safeParse` so a bad field never escapes as a `ZodError` (whose
+ * `.message` is a JSON dump that would land verbatim in the UI).
+ */
+function parseInput<S extends z.ZodType>(schema: S, input: unknown): z.infer<S> {
+	const result = schema.safeParse(input);
+	if (!result.success) {
+		const message =
+			result.error.issues[0]?.message ?? 'Please check the details you entered and try again.';
+		throw new ValidationError(message, result.error.issues);
+	}
+	return result.data;
+}
+
 // --- Response schemas (mirror @rivus/api http-schemas; app depends on core only).
 
 const userResponseSchema = z.object({
@@ -240,22 +272,22 @@ export function createApiClient(baseUrl: string, fetchImpl: FetchLike = fetch): 
 		// `async` so input-validation errors surface as a rejected promise
 		// (the expected async contract) rather than a synchronous throw.
 		async signup(input: SignupBody) {
-			const payload = signupSchema.parse(input);
+			const payload = parseInput(signupSchema, input);
 			return request('/v1/auth/signup', codeSentResponseSchema, jsonInit('POST', payload));
 		},
 
 		async login(input: LoginInput) {
-			const payload = loginSchema.parse(input);
+			const payload = parseInput(loginSchema, input);
 			return request('/v1/auth/login', codeSentResponseSchema, jsonInit('POST', payload));
 		},
 
 		async verifyCode(input: VerifyCodeInput) {
-			const payload = verifyCodeSchema.parse(input);
+			const payload = parseInput(verifyCodeSchema, input);
 			return request('/v1/auth/verify', authResponseSchema, jsonInit('POST', payload));
 		},
 
 		async acceptInvite(input: AcceptInviteInput) {
-			const payload = acceptInviteSchema.parse(input);
+			const payload = parseInput(acceptInviteSchema, input);
 			return request('/v1/auth/accept-invite', authResponseSchema, jsonInit('POST', payload));
 		},
 
@@ -274,12 +306,12 @@ export function createApiClient(baseUrl: string, fetchImpl: FetchLike = fetch): 
 		},
 
 		async inviteMember(token: string, input: InviteMemberInput) {
-			const payload = inviteMemberSchema.parse(input);
+			const payload = parseInput(inviteMemberSchema, input);
 			return request('/v1/members/invites', inviteResponseSchema, jsonInit('POST', payload, token));
 		},
 
 		async listItems(token: string, query?: Partial<PaginationQuery>) {
-			const { page, pageSize } = paginationQuerySchema.parse(query ?? {});
+			const { page, pageSize } = parseInput(paginationQuerySchema, query ?? {});
 			const search = new URLSearchParams({
 				page: String(page),
 				pageSize: String(pageSize),

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -23,6 +23,12 @@ describe('loginSchema', () => {
 	it('rejects an invalid email', () => {
 		expect(() => loginSchema.parse({ email: 'not-an-email' })).toThrow();
 	});
+
+	it('explains an invalid email in plain language', () => {
+		const result = loginSchema.safeParse({ email: 'not-an-email' });
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe('Enter a valid email address.');
+	});
 });
 
 describe('verifyCodeSchema', () => {
@@ -72,6 +78,20 @@ describe('accountBusinessSchema', () => {
 		expect(() =>
 			accountBusinessSchema.parse({ businessName: 'Acme', website: 'not a url' }),
 		).toThrow();
+	});
+
+	it('gives a friendly, actionable message for a bad website URL', () => {
+		const result = accountBusinessSchema.safeParse({ businessName: 'Acme', website: 'not a url' });
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe(
+			'Enter a valid website URL, like https://example.com.',
+		);
+	});
+
+	it('prompts for the business name when it is blank', () => {
+		const result = accountBusinessSchema.safeParse({ businessName: '   ' });
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe('Business name is required.');
 	});
 
 	it('keeps provided phone, address, and timezone', () => {

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,13 +1,44 @@
 import { z } from 'zod';
 
 /**
+ * Free-text fields fail in two ways — left blank, or too long — and Zod's stock
+ * copy for them is terse and leaks the raw constraint ("Too small: expected
+ * string to have >=1 characters"). These helpers say, in plain language, what to
+ * do instead. `requiredText` reuses one message for the missing and the blank
+ * case so the caller is prompted the same way either way.
+ */
+function requiredText(label: string, max: number) {
+	return z
+		.string({ error: `${label} is required.` })
+		.trim()
+		.min(1, { error: `${label} is required.` })
+		.max(max, { error: `${label} must be ${max} characters or fewer.` });
+}
+
+/** An optional, trimmed free-text field, capped so it can't overflow storage. */
+function optionalText(label: string, max: number) {
+	return z
+		.string()
+		.trim()
+		.max(max, { error: `${label} must be ${max} characters or fewer.` });
+}
+
+/**
  * Trim + lowercase before validating so `  Foo@Bar.com ` is accepted. Built from
  * a plain `z.string()` (not `z.preprocess`) so generated OpenAPI/JSON Schema
  * still marks the field as required.
  */
-export const emailSchema = z.string().trim().toLowerCase().pipe(z.email().max(254));
+export const emailSchema = z
+	.string({ error: 'Email address is required.' })
+	.trim()
+	.toLowerCase()
+	.pipe(
+		z
+			.email({ error: 'Enter a valid email address.' })
+			.max(254, { error: 'That email address is too long.' }),
+	);
 
-export const nameSchema = z.string().trim().min(1).max(120);
+export const nameSchema = requiredText('Name', 120);
 
 /**
  * A 6-digit numeric one-time code emailed for passwordless sign-in. Trimmed so
@@ -16,7 +47,7 @@ export const nameSchema = z.string().trim().min(1).max(120);
 export const verificationCodeSchema = z
 	.string()
 	.trim()
-	.regex(/^\d{6}$/, 'Enter the 6-digit code we emailed you');
+	.regex(/^\d{6}$/, { error: 'Enter the 6-digit code we emailed you.' });
 
 export const loginSchema = z.object({
 	email: emailSchema,
@@ -35,22 +66,26 @@ export type VerifyCodeInput = z.infer<typeof verifyCodeSchema>;
 // `Role` itself is the source-of-truth union in `types.ts` (mirrors the
 // `ItemStatus`/`itemStatusSchema` split); here we only need the runtime schema.
 /** Every role a member can hold. */
-export const roleSchema = z.enum(['owner', 'manager', 'team_member']);
+export const roleSchema = z.enum(['owner', 'manager', 'team_member'], {
+	error: 'Choose a valid role.',
+});
 
 /** Roles that can be granted to an invited member (ownership is not invitable). */
-export const assignableRoleSchema = z.enum(['manager', 'team_member']);
+export const assignableRoleSchema = z.enum(['manager', 'team_member'], {
+	error: 'Choose either Manager or Team Member.',
+});
 
-export const businessNameSchema = z.string().trim().min(1).max(160);
-export const phoneSchema = z.string().trim().max(40);
-export const addressSchema = z.string().trim().max(300);
-export const timezoneSchema = z.string().trim().max(64);
+export const businessNameSchema = requiredText('Business name', 160);
+export const phoneSchema = optionalText('Phone number', 40);
+export const addressSchema = optionalText('Address', 300);
+export const timezoneSchema = optionalText('Time zone', 64);
 /** A website URL, or an empty string when none is provided. */
 export const websiteSchema = z
 	.string()
 	.trim()
-	.max(2048)
+	.max(2048, { error: 'That website URL is too long.' })
 	.refine((value) => value === '' || z.url().safeParse(value).success, {
-		message: 'Must be a valid URL',
+		error: 'Enter a valid website URL, like https://example.com.',
 	});
 
 /** The "standard business information" collected when an account is created. */
@@ -89,7 +124,9 @@ export type InviteMemberInput = z.infer<typeof inviteMemberSchema>;
  * directly, no password or extra code required.
  */
 export const acceptInviteSchema = z.object({
-	token: z.string().min(1),
+	token: z
+		.string({ error: 'Enter your invite code.' })
+		.min(1, { error: 'Enter your invite code.' }),
 });
 export type AcceptInviteInput = z.infer<typeof acceptInviteSchema>;
 
@@ -99,11 +136,13 @@ export const updateMemberRoleSchema = z.object({
 });
 export type UpdateMemberRoleInput = z.infer<typeof updateMemberRoleSchema>;
 
-export const itemStatusSchema = z.enum(['active', 'archived']);
+export const itemStatusSchema = z.enum(['active', 'archived'], {
+	error: 'Status must be either active or archived.',
+});
 
 export const createItemSchema = z.object({
 	name: nameSchema,
-	description: z.string().trim().max(2000).default(''),
+	description: optionalText('Description', 2000).default(''),
 	status: itemStatusSchema.default('active'),
 });
 export type CreateItemInput = z.infer<typeof createItemSchema>;
@@ -116,17 +155,22 @@ export type CreateItemInput = z.infer<typeof createItemSchema>;
 export const updateItemSchema = z
 	.object({
 		name: nameSchema.optional(),
-		description: z.string().trim().max(2000).optional(),
+		description: optionalText('Description', 2000).optional(),
 		status: itemStatusSchema.optional(),
 	})
 	.refine((value) => Object.values(value).some((field) => field !== undefined), {
-		message: 'At least one field must be provided',
+		error: 'Provide at least one field to update.',
 	});
 export type UpdateItemInput = z.infer<typeof updateItemSchema>;
 
 /** Query string for list endpoints; coerces `?page=2&pageSize=50`. */
 export const paginationQuerySchema = z.object({
-	page: z.coerce.number().int().min(1).default(1),
-	pageSize: z.coerce.number().int().min(1).max(100).default(20),
+	page: z.coerce.number().int().min(1, { error: 'Page must be 1 or greater.' }).default(1),
+	pageSize: z.coerce
+		.number()
+		.int()
+		.min(1, { error: 'Page size must be 1 or greater.' })
+		.max(100, { error: 'Page size must be 100 or fewer.' })
+		.default(20),
 });
 export type PaginationQuery = z.infer<typeof paginationQuerySchema>;


### PR DESCRIPTION
## Problem

When a field failed **client-side** validation, the signup form showed Zod's raw output instead of a sentence a person can act on. An invalid website rendered this in the error box:

```json
[
  {
    "code": "custom",
    "path": ["business", "website"],
    "message": "Must be a valid URL"
  }
]
```

**Root cause:** the API client called `signupSchema.parse(input)` before the network request; on failure it threw a `ZodError`, and `AuthScreen`'s `messageFor()` rendered `error.message` — which Zod 4 serializes to `JSON.stringify(issues, null, 2)`, i.e. that JSON blob. On top of that, most fields used Zod's terse defaults (`Too small: expected string to have >=1 characters`, `Invalid email address`).

## Fix

Three coordinated changes so a friendly message is both *written* and *surfaced*:

- **`@rivus/core` schemas** — every user-facing field now has a plain-language message (e.g. website → `Enter a valid website URL, like https://example.com.`, blank business name → `Business name is required.`). Two small helpers (`requiredText` / `optionalText`) keep the copy consistent and cover the missing-vs-blank cases with one message. No wire-schema changes (OpenAPI regenerates identical).
- **`@rivus/app` client** — input is now validated through a `parseInput` helper that raises a new exported `ValidationError`. Its `.message` is a single friendly line (the first issue); the structured `.issues` are retained for field-level highlighting. A raw `ZodError` (JSON dump) can no longer reach the UI. `messageFor()` already returns `error.message`, so the screen shows the friendly text unchanged.
- **`@rivus/api` error handler** — the 400 response leads with the first field's friendly message instead of the generic `Request validation failed`; `details` (the full per-field breakdown) is unchanged.

### Before → after (the screenshot case)

| | Error shown to the user |
|---|---|
| Before | `[ { "code": "custom", "path": ["business","website"], "message": "Must be a valid URL" } ]` |
| After | `Enter a valid website URL, like https://example.com.` |

## Tests

- **core** — asserts the friendly text for invalid email, bad website URL, and blank business name (coverage stays at 100%).
- **app** — new regression test: a bad website rejects with a `ValidationError` whose message is the friendly line and is *not* a JSON dump (and no network call is made).
- **api** — the invalid-email 400 now asserts the friendly top-level `message` and that `details` is still present.

`pnpm lint && pnpm type-check && pnpm test` all pass across the monorepo (core/api/app/worker/website); coverage thresholds hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkogqtKD3LLC3fFAykN4Xm)_