### PR TITLE
fix(api): make an unauthorized MongoDB diagnosable instead of opaque 500s

### DIFF
--- a/packages/api/src/db/mongoose.ts
+++ b/packages/api/src/db/mongoose.ts
@@ -11,7 +11,56 @@ export async function disconnectMongoose(): Promise<void> {
 	await mongoose.disconnect();
 }
 
-/** True once the Mongoose connection is open and usable. */
+/** True once the Mongoose connection's socket is open (a liveness signal). */
 export function isMongoConnected(): boolean {
 	return mongoose.connection.readyState === 1;
+}
+
+/**
+ * Verify the connection can actually *operate on* the database, not merely that
+ * the socket and authentication handshake completed. `mongoose.connect()` resolves
+ * as soon as the user authenticates, but a user that authenticates yet lacks roles
+ * on the target database still fails *every* query with "not authorized" — which
+ * otherwise surfaces only as an opaque 500 on each request. `{ ping: 1 }` is exempt
+ * from authorization and so wouldn't catch that; `dbStats` requires read privileges
+ * on the database, so it does. Returns false (never throws) when the connection is
+ * closed or the command fails, which is what a readiness probe wants.
+ */
+export async function isDatabaseReady(): Promise<boolean> {
+	const db = mongoose.connection.db;
+	if (!isMongoConnected() || !db) {
+		return false;
+	}
+	try {
+		await db.command({ dbStats: 1 });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Like {@link isDatabaseReady}, but throws a clear, actionable error instead of
+ * returning false — so a roles/connection-string misconfiguration fails loudly at
+ * startup (with a log that says how to fix it) rather than letting the API boot
+ * "healthy" and then return 500 for every authenticated request.
+ */
+export async function assertDatabaseReady(): Promise<void> {
+	const db = mongoose.connection.db;
+	if (!isMongoConnected() || !db) {
+		throw new Error('MongoDB connection is not open');
+	}
+	try {
+		await db.command({ dbStats: 1 });
+	} catch (error) {
+		const name = mongoose.connection.name ?? '(default)';
+		throw new Error(
+			`Connected to MongoDB but cannot query database "${name}". The database user ` +
+				'authenticated successfully but is not authorized to read/write it, so every request ' +
+				`would fail with an opaque 500. Grant the user readWrite on "${name}" (in Atlas: ` +
+				'Database Access → Edit the user), and confirm MONGODB_URI uses the correct database ' +
+				`name and authSource. Underlying error: ${(error as Error).message}`,
+			{ cause: error },
+		);
+	}
 }

--- a/packages/api/src/db/mongoose.ts
+++ b/packages/api/src/db/mongoose.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import type { ReadinessResult } from '../types';
 
 /** Open the shared Mongoose connection. */
 export async function connectMongoose(uri: string): Promise<typeof mongoose> {
@@ -23,51 +24,40 @@ export function isMongoConnected(): boolean {
  * on the target database still fails *every* query with "not authorized" — which
  * otherwise surfaces only as an opaque 500 on each request.
  *
- * We probe with the very operation the API relies on — a `find` on an app
+ * We probe with the very operation the API relies on — a `find` on the `users`
  * collection — so the check requires exactly the privilege the service needs and
  * reproduces the original failure (signup's `findByEmail` is a `find` on `users`).
  * A diagnostic command tests the wrong thing: `ping` skips authorization entirely,
  * while `dbStats`/`listCollections` ride separate privileges that a least-privilege
  * CRUD role might not grant. `findOne` is cheap (a single `_id`-only document) and
  * returns null on an empty or not-yet-created collection, so it never false-fails.
- * Returns false (never throws) when the connection is closed or the query fails,
- * which is what a probe wants.
+ *
+ * Returns `{ ready, reason }` rather than throwing, so a caller can both gate
+ * readiness and surface *why* it failed (a startup log, the `/ready` body) without
+ * the container crash-looping out of reach.
  */
-export async function isDatabaseReady(): Promise<boolean> {
+export async function checkDatabaseReady(): Promise<ReadinessResult> {
 	const db = mongoose.connection.db;
 	if (!isMongoConnected() || !db) {
-		return false;
+		return { ready: false, reason: 'database connection is not open' };
 	}
 	try {
 		await db.collection('users').findOne({}, { projection: { _id: 1 } });
-		return true;
-	} catch {
-		return false;
+		return { ready: true };
+	} catch (error) {
+		return { ready: false, reason: summarizeDatabaseError(error) };
 	}
 }
 
 /**
- * Like {@link isDatabaseReady}, but throws a clear, actionable error instead of
- * returning false — so a roles/connection-string misconfiguration fails loudly at
- * startup (with a log that says how to fix it) rather than letting the API boot
- * "healthy" and then return 500 for every authenticated request.
+ * Reduce a driver error to a short, safe one-liner for logs and the public `/ready`
+ * probe: keep the diagnostic (e.g. "not authorized on rivus") but drop Mongo's
+ * verbose command echo — filters, projections, per-request session UUIDs — and cap
+ * the length, so the endpoint never leaks request internals or unbounded text.
  */
-export async function assertDatabaseReady(): Promise<void> {
-	const db = mongoose.connection.db;
-	if (!isMongoConnected() || !db) {
-		throw new Error('MongoDB connection is not open');
-	}
-	try {
-		await db.collection('users').findOne({}, { projection: { _id: 1 } });
-	} catch (error) {
-		const name = mongoose.connection.name ?? '(default)';
-		throw new Error(
-			`Connected to MongoDB but cannot query database "${name}". The database user ` +
-				'authenticated successfully but is not authorized to read/write it, so every request ' +
-				`would fail with an opaque 500. Grant the user readWrite on "${name}" (in Atlas: ` +
-				'Database Access → Edit the user), and confirm MONGODB_URI uses the correct database ' +
-				`name and authSource. Underlying error: ${(error as Error).message}`,
-			{ cause: error },
-		);
-	}
+function summarizeDatabaseError(error: unknown): string {
+	const { codeName, message } = (error ?? {}) as { codeName?: string; message?: string };
+	const full = message ?? String(error);
+	const summary = (full.split(' to execute command')[0] ?? full).trim().slice(0, 200);
+	return codeName ? `${codeName}: ${summary}` : summary;
 }

--- a/packages/api/src/db/mongoose.ts
+++ b/packages/api/src/db/mongoose.ts
@@ -21,12 +21,17 @@ export function isMongoConnected(): boolean {
  * the socket and authentication handshake completed. `mongoose.connect()` resolves
  * as soon as the user authenticates, but a user that authenticates yet lacks roles
  * on the target database still fails *every* query with "not authorized" — which
- * otherwise surfaces only as an opaque 500 on each request. `{ ping: 1 }` is exempt
- * from authorization and so wouldn't catch that; `listCollections` requires the
- * `listCollections` privilege (granted by the read/readWrite roles the app needs),
- * so it does — and with `nameOnly: true` it only reads the metadata catalog, so it
- * stays cheap enough to run on every readiness poll. Returns false (never throws)
- * when the connection is closed or the command fails, which is what a probe wants.
+ * otherwise surfaces only as an opaque 500 on each request.
+ *
+ * We probe with the very operation the API relies on — a `find` on an app
+ * collection — so the check requires exactly the privilege the service needs and
+ * reproduces the original failure (signup's `findByEmail` is a `find` on `users`).
+ * A diagnostic command tests the wrong thing: `ping` skips authorization entirely,
+ * while `dbStats`/`listCollections` ride separate privileges that a least-privilege
+ * CRUD role might not grant. `findOne` is cheap (a single `_id`-only document) and
+ * returns null on an empty or not-yet-created collection, so it never false-fails.
+ * Returns false (never throws) when the connection is closed or the query fails,
+ * which is what a probe wants.
  */
 export async function isDatabaseReady(): Promise<boolean> {
 	const db = mongoose.connection.db;
@@ -34,7 +39,7 @@ export async function isDatabaseReady(): Promise<boolean> {
 		return false;
 	}
 	try {
-		await db.command({ listCollections: 1, nameOnly: true });
+		await db.collection('users').findOne({}, { projection: { _id: 1 } });
 		return true;
 	} catch {
 		return false;
@@ -53,7 +58,7 @@ export async function assertDatabaseReady(): Promise<void> {
 		throw new Error('MongoDB connection is not open');
 	}
 	try {
-		await db.command({ listCollections: 1, nameOnly: true });
+		await db.collection('users').findOne({}, { projection: { _id: 1 } });
 	} catch (error) {
 		const name = mongoose.connection.name ?? '(default)';
 		throw new Error(

--- a/packages/api/src/db/mongoose.ts
+++ b/packages/api/src/db/mongoose.ts
@@ -22,9 +22,11 @@ export function isMongoConnected(): boolean {
  * as soon as the user authenticates, but a user that authenticates yet lacks roles
  * on the target database still fails *every* query with "not authorized" — which
  * otherwise surfaces only as an opaque 500 on each request. `{ ping: 1 }` is exempt
- * from authorization and so wouldn't catch that; `dbStats` requires read privileges
- * on the database, so it does. Returns false (never throws) when the connection is
- * closed or the command fails, which is what a readiness probe wants.
+ * from authorization and so wouldn't catch that; `listCollections` requires the
+ * `listCollections` privilege (granted by the read/readWrite roles the app needs),
+ * so it does — and with `nameOnly: true` it only reads the metadata catalog, so it
+ * stays cheap enough to run on every readiness poll. Returns false (never throws)
+ * when the connection is closed or the command fails, which is what a probe wants.
  */
 export async function isDatabaseReady(): Promise<boolean> {
 	const db = mongoose.connection.db;
@@ -32,7 +34,7 @@ export async function isDatabaseReady(): Promise<boolean> {
 		return false;
 	}
 	try {
-		await db.command({ dbStats: 1 });
+		await db.command({ listCollections: 1, nameOnly: true });
 		return true;
 	} catch {
 		return false;
@@ -51,7 +53,7 @@ export async function assertDatabaseReady(): Promise<void> {
 		throw new Error('MongoDB connection is not open');
 	}
 	try {
-		await db.command({ dbStats: 1 });
+		await db.command({ listCollections: 1, nameOnly: true });
 	} catch (error) {
 		const name = mongoose.connection.name ?? '(default)';
 		throw new Error(

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -24,7 +24,7 @@ async function main(): Promise<void> {
 		items,
 		verificationCodes,
 		mailer: new NoopMailer(),
-		ping: async () => true,
+		ping: async () => ({ ready: true }),
 	});
 
 	await app.ready();

--- a/packages/api/src/routes/health.ts
+++ b/packages/api/src/routes/health.ts
@@ -31,10 +31,14 @@ export const healthRoutes: FastifyPluginAsync = async (fastify) => {
 			},
 		},
 		async (_request, reply) => {
-			if (!(await app.deps.ping())) {
+			const readiness = await app.deps.ping();
+			if (!readiness.ready) {
 				return reply.status(503).send({
 					error: 'Service Unavailable',
-					message: 'Dependencies are not ready',
+					// Surface *why* it isn't ready (e.g. the database authorization failure)
+					// so it can be diagnosed by hitting the endpoint, not just the logs. The
+					// reason is bounded upstream so this stays safe on a public probe.
+					message: readiness.reason ?? 'Dependencies are not ready',
 					statusCode: 503,
 				});
 			}

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -1,12 +1,7 @@
 import closeWithGrace from 'close-with-grace';
 import { buildApp } from './app';
 import { loadConfig } from './config';
-import {
-	assertDatabaseReady,
-	connectMongoose,
-	disconnectMongoose,
-	isDatabaseReady,
-} from './db/mongoose';
+import { checkDatabaseReady, connectMongoose, disconnectMongoose } from './db/mongoose';
 import {
 	MongoAccountRepository,
 	MongoInviteRepository,
@@ -22,11 +17,6 @@ import { createMailer } from './services/resend-mailer';
 export async function start(): Promise<void> {
 	const config = loadConfig();
 	await connectMongoose(config.MONGODB_URI);
-	// `connect()` only proves the client authenticated. A user that authenticates
-	// but lacks roles on the database fails *every* query with "not authorized", so
-	// verify real access now and fail fast with an actionable log, instead of
-	// booting "healthy" and returning an opaque 500 for every request.
-	await assertDatabaseReady();
 
 	const app = buildApp({
 		config,
@@ -38,10 +28,26 @@ export async function start(): Promise<void> {
 		items: new MongoItemRepository(),
 		verificationCodes: new MongoVerificationCodeRepository(),
 		mailer: createMailer(config),
-		// Real readiness: run an actual command so "connected but unauthorized"
-		// reports unready (503) instead of falsely healthy.
-		ping: isDatabaseReady,
+		// Real readiness: run an actual query so "connected but unauthorized" reports
+		// unready (503, with the reason) instead of falsely healthy.
+		ping: checkDatabaseReady,
 	});
+
+	// `connect()` only proves the client authenticated. A user that authenticates but
+	// lacks roles on the database fails every query with "not authorized", so verify
+	// real access and log a loud, actionable message if it's missing. We don't exit:
+	// staying up lets `/ready` report the reason (503) instead of crash-looping out
+	// of reach, and a transient blip self-heals on the next request.
+	const readiness = await checkDatabaseReady();
+	if (!readiness.ready) {
+		app.log.error(
+			{ reason: readiness.reason },
+			'MongoDB is connected but not usable — the database user authenticated but appears ' +
+				'unauthorized to read/write the database, so every request will fail until this is ' +
+				'fixed. Grant the user readWrite on the database (Atlas: Database Access → Edit user) ' +
+				'and confirm MONGODB_URI uses the correct database name and authSource.',
+		);
+	}
 
 	if (!config.RESEND_API_KEY) {
 		app.log.warn('RESEND_API_KEY is not set — invitation emails will not be delivered');

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -1,7 +1,12 @@
 import closeWithGrace from 'close-with-grace';
 import { buildApp } from './app';
 import { loadConfig } from './config';
-import { connectMongoose, disconnectMongoose, isMongoConnected } from './db/mongoose';
+import {
+	assertDatabaseReady,
+	connectMongoose,
+	disconnectMongoose,
+	isDatabaseReady,
+} from './db/mongoose';
 import {
 	MongoAccountRepository,
 	MongoInviteRepository,
@@ -17,6 +22,11 @@ import { createMailer } from './services/resend-mailer';
 export async function start(): Promise<void> {
 	const config = loadConfig();
 	await connectMongoose(config.MONGODB_URI);
+	// `connect()` only proves the client authenticated. A user that authenticates
+	// but lacks roles on the database fails *every* query with "not authorized", so
+	// verify real access now and fail fast with an actionable log, instead of
+	// booting "healthy" and returning an opaque 500 for every request.
+	await assertDatabaseReady();
 
 	const app = buildApp({
 		config,
@@ -28,7 +38,9 @@ export async function start(): Promise<void> {
 		items: new MongoItemRepository(),
 		verificationCodes: new MongoVerificationCodeRepository(),
 		mailer: createMailer(config),
-		ping: async () => isMongoConnected(),
+		// Real readiness: run an actual command so "connected but unauthorized"
+		// reports unready (503) instead of falsely healthy.
+		ping: isDatabaseReady,
 	});
 
 	if (!config.RESEND_API_KEY) {

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -12,6 +12,13 @@ import type {
 } from './repositories/types';
 import type { Mailer } from './services/email';
 
+/** Result of a readiness check: whether dependencies are usable, and why not. */
+export interface ReadinessResult {
+	ready: boolean;
+	/** A bounded, probe-safe explanation when `ready` is false (no request internals). */
+	reason?: string;
+}
+
 /** Everything the Fastify app needs injected — swap repositories in tests. */
 export interface AppDeps {
 	config: Config;
@@ -26,7 +33,7 @@ export interface AppDeps {
 	/** Sends transactional email (invitations and sign-in codes). */
 	mailer: Mailer;
 	/** Readiness check for downstream dependencies (e.g. the database). */
-	ping: () => Promise<boolean>;
+	ping: () => Promise<ReadinessResult>;
 }
 
 /** A route guard that rejects requests whose token role is not in `roles`. */

--- a/packages/api/test/health.test.ts
+++ b/packages/api/test/health.test.ts
@@ -46,12 +46,26 @@ describe('health', () => {
 		expect(response.json()).toEqual({ status: 'ready' });
 	});
 
-	it('returns 503 when a dependency is not ready', async () => {
-		const downApp = await buildTestApp({ ping: async () => false });
+	it('returns 503 with the reason when a dependency is not ready', async () => {
+		const downApp = await buildTestApp({
+			ping: async () => ({ ready: false, reason: 'Unauthorized: not authorized on rivus' }),
+		});
 		const response = await downApp.inject({ method: 'GET', url: '/ready' });
 
 		expect(response.statusCode).toBe(503);
-		expect(response.json().statusCode).toBe(503);
+		const body = response.json();
+		expect(body.statusCode).toBe(503);
+		// The reason is surfaced so the failure can be diagnosed from the endpoint.
+		expect(body.message).toBe('Unauthorized: not authorized on rivus');
+		await downApp.close();
+	});
+
+	it('falls back to a generic message when not ready without a reason', async () => {
+		const downApp = await buildTestApp({ ping: async () => ({ ready: false }) });
+		const response = await downApp.inject({ method: 'GET', url: '/ready' });
+
+		expect(response.statusCode).toBe(503);
+		expect(response.json().message).toBe('Dependencies are not ready');
 		await downApp.close();
 	});
 });

--- a/packages/api/test/helpers.ts
+++ b/packages/api/test/helpers.ts
@@ -40,7 +40,7 @@ export async function buildTestApp(overrides: Partial<AppDeps> = {}): Promise<Fa
 		verificationCodes,
 		// A recording mailer by default so helpers can read back the emailed code.
 		mailer: new RecordingMailer(),
-		ping: async () => true,
+		ping: async () => ({ ready: true }),
 		...overrides,
 	});
 	await app.ready();
@@ -67,7 +67,7 @@ export async function buildTestAppWithRepos(): Promise<{
 		items,
 		verificationCodes,
 		mailer: new RecordingMailer(),
-		ping: async () => true,
+		ping: async () => ({ ready: true }),
 	});
 	await app.ready();
 	return { app, repos };


### PR DESCRIPTION
## What you reported

Creating an account on the signup form returned **"An unexpected error occurred"** with `POST https://dev-api.rivus.ai/v1/auth/signup` → **500**.

## Root cause (reproduced against the live dev API)

The API code is fine — it works end-to-end against real MongoDB 7 and 8.2. The problem is the **dev environment's MongoDB connection**: the database user can **authenticate** but is **not authorized** to operate on the database. Every query then fails fast with:

```
MongoServerError: not authorized on <db> to execute command { find: "users", ... }
```

I confirmed this against the deployed dev API:

| Request | Result |
| --- | --- |
| `GET /health` | 200 (doesn't touch Mongo) |
| `GET /ready` | **200** — but only checked `readyState`, so it lied |
| `POST /v1/auth/signup` | **500** (write) |
| `POST /v1/auth/login` | **500** (a plain `findOne` **read**) |
| `POST /v1/auth/verify` | **500** (read) |

Reads fail too, and the failure is **fast (~0.8s, not a 10s buffer timeout)** — the signature of an **authorization** failure, not a connectivity/transaction issue. `mongoose.connect()` resolves as soon as the client authenticates, so the container boots "healthy" and then 500s every request, with the real error masked by the generic 500 handler.

## The actual fix for the dev environment (action required) 🔧

This PR does **not** change the broken credentials — that's operational. To make signup work on `dev-api.rivus.ai`, fix the `DEV_MONGODB_URI` secret's database user:

1. **Atlas → Database Access → Edit the user** → grant **`readWrite`** on the database the API uses (e.g. `rivus`). A user with *no* roles (or roles scoped to a different DB) authenticates fine but can't run a single query.
2. Confirm `DEV_MONGODB_URI` includes the **correct database name** and `authSource=admin` (Atlas users live in `admin`).

## What this PR changes (so this is never a silent 500 again)

- **`/ready` tells you _why_.** The readiness probe now runs a real query — a `find` on the `users` collection, the exact privilege the service needs (it reproduces the failing `findByEmail`). When the DB is connected but unusable it returns **503 with a bounded reason in the body**, so you can diagnose by hitting the endpoint instead of tailing container logs:

  ```
  GET /ready  →  503
  {"error":"Service Unavailable","message":"Unauthorized: not authorized on rivus","statusCode":503}
  ```

  The reason is bounded — Mongo's verbose command echo (filters, projections, per-request session UUIDs) is stripped and the length capped — so it stays safe on a public probe.
- **Loud startup log, no crash-loop.** On boot the API logs the full actionable message once (grant `readWrite`, check the URI) but keeps running, so `/ready` stays reachable and a transient blip self-heals on the next request. `/health` stays 200 (liveness).

Why a real `find` rather than a diagnostic command: `ping` skips authorization entirely, and `dbStats`/`listCollections` ride separate privileges a least-privilege role might not grant — so they could diverge from the app's actual access. `findOne` with an `_id`-only projection is a single-document lookup that returns `null` on an empty or not-yet-created collection, so it stays cheap and never false-fails. (Thanks to the Gemini and Codex review bots for pushing this to the most faithful, lightweight check.)

The readiness dependency (`AppDeps.ping`) now returns `{ ready, reason }` instead of a bare boolean.

## Verification

Reproduced both paths against local MongoDB (an authenticated-but-unauthorized user, and a correctly-authorized one):

- **Unauthorized DB** → API **boots** (no crash-loop), `/health` → 200, `/ready` → **503** with `"message":"Unauthorized: not authorized on rivus"`, and the full actionable guidance is logged once at startup.
- **Authorized DB** (including a fresh DB with no `users` collection yet) → `/ready` → **200**; `/signup` → **202**.

`pnpm lint && pnpm type-check && pnpm test` all pass (api: 105 tests, including new `/ready` reason coverage; coverage thresholds unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q1uUzbe141NQDzFtdhsLW