### PR TITLE
feat(app): default the root to sign-in and move signup to its own URL

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -7,7 +7,7 @@ import {
 	Montserrat_700Bold,
 	useFonts,
 } from '@expo-google-fonts/montserrat';
-import { Slot, usePathname, useRouter } from 'expo-router';
+import { Redirect, Slot, usePathname, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import {
 	ActivityIndicator,
@@ -42,6 +42,14 @@ function isActive(pathname: string, href: string): boolean {
 	return href === '/' ? pathname === '/' : pathname.startsWith(href);
 }
 
+/** Paths that render their own auth screen instead of the dashboard shell. */
+const AUTH_PATHS = ['/login', '/signup'];
+
+function isAuthPath(pathname: string): boolean {
+	const normalized = pathname.replace(/\/+$/, '') || '/';
+	return AUTH_PATHS.includes(normalized);
+}
+
 export default function RootLayout() {
 	const [loaded] = useFonts({
 		Montserrat_300Light,
@@ -70,8 +78,18 @@ export default function RootLayout() {
 /** Show the auth screens until there's a session, then the dashboard shell. */
 function Gate() {
 	const { session } = useAuth();
+	const pathname = usePathname();
+	const onAuthRoute = isAuthPath(pathname);
+
 	if (!session) {
-		return <AuthScreen />;
+		// Signed out: /login and /signup render their own screen; every other
+		// path (the root included) falls back to the sign-in screen.
+		return onAuthRoute ? <Slot /> : <AuthScreen initialMode="signin" />;
+	}
+
+	// Signed in: the auth routes aren't meant for an active session.
+	if (onAuthRoute) {
+		return <Redirect href="/" />;
 	}
 	return <Shell />;
 }

--- a/packages/app/app/login.tsx
+++ b/packages/app/app/login.tsx
@@ -1,0 +1,6 @@
+import { AuthScreen } from '@/src/auth/AuthScreen';
+
+/** Sign-in screen. The root path also lands here for signed-out visitors. */
+export default function LoginScreen() {
+	return <AuthScreen initialMode="signin" />;
+}

--- a/packages/app/app/signup.tsx
+++ b/packages/app/app/signup.tsx
@@ -1,0 +1,6 @@
+import { AuthScreen } from '@/src/auth/AuthScreen';
+
+/** "Create your business" account flow, on its own URL. */
+export default function SignupScreen() {
+	return <AuthScreen initialMode="signup" />;
+}

--- a/packages/app/src/auth/AuthScreen.tsx
+++ b/packages/app/src/auth/AuthScreen.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'expo-router';
 import { useMemo, useState } from 'react';
 import { Platform, Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { ApiError, type SignupBody } from '@/src/api/client';
@@ -39,9 +40,15 @@ function messageFor(error: unknown): string {
 	return 'Something went wrong. Please try again.';
 }
 
-export function AuthScreen() {
+type AuthScreenProps = {
+	/** Which form the screen opens on. Each auth route picks its own. */
+	initialMode?: Mode;
+};
+
+export function AuthScreen({ initialMode = 'signin' }: AuthScreenProps = {}) {
+	const router = useRouter();
 	const { signUp, signIn, verifyCode, acceptInvite } = useAuth();
-	const [mode, setMode] = useState<Mode>('signup');
+	const [mode, setMode] = useState<Mode>(initialMode);
 	const [step, setStep] = useState<Step>('form');
 
 	const [businessName, setBusinessName] = useState('');
@@ -285,13 +292,19 @@ export function AuthScreen() {
 								{mode !== 'signin' ? (
 									<Link
 										label="Already have an account? Sign in"
-										onPress={() => switchMode('signin')}
+										onPress={() => {
+											switchMode('signin');
+											router.replace('/login');
+										}}
 									/>
 								) : null}
 								{mode !== 'signup' ? (
 									<Link
 										label="New here? Create a business account"
-										onPress={() => switchMode('signup')}
+										onPress={() => {
+											switchMode('signup');
+											router.replace('/signup');
+										}}
 									/>
 								) : null}
 								{mode !== 'invite' ? (


### PR DESCRIPTION
## What & why

Going to the root of the product app now lands on the **sign-in (logon) screen**, and the "Create your business" flow has moved to its own URL at **`/signup`**.

Previously the app's `Gate` rendered a single `AuthScreen` that defaulted to the **signup** form for *every* signed-out path, ignoring the URL. So:

- the app root showed "Create your business account" instead of a logon screen, and
- the marketing site's `Sign in → ${appUrl}/login` deep link actually rendered the signup form.

## Changes

- **`app/login.tsx`** (new) — `/login` renders the sign-in form.
- **`app/signup.tsx`** (new) — `/signup` renders the "Create your business" form (its own URL).
- **`app/_layout.tsx`** — the `Gate` now:
  - renders `/login` and `/signup` via `<Slot />` when signed out,
  - falls back to the **sign-in** screen for the root (and any other signed-out path),
  - redirects signed-in users off the auth routes to the dashboard.
- **`src/auth/AuthScreen.tsx`** — takes an `initialMode` prop (default `signin`); the in-form *Sign in* / *Create a business account* toggles now navigate to `/login` / `/signup` so the address bar tracks the visible form.

## Website

No source change was needed: the marketing site already points its CTAs at the new URLs — `Sign in → ${appUrl}/login` and `Get started free → ${appUrl}/signup` (locked in by `site-nav.test.tsx` and `final-cta.test.tsx`). Those links previously all resolved to the signup form; they now land on the correct screen.

## Verification

- `pnpm lint && pnpm type-check && pnpm test` — all green (258 tests across 6 packages).
- `pnpm --filter @rivus/app export:web` — the static export now emits dedicated `/login` and `/signup` routes alongside `/`, with no render errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yxF39JWAfXQJ1nMtgP87v

---
_Generated by [Claude Code](https://claude.ai/code/session_014yxF39JWAfXQJ1nMtgP87v)_