### PR TITLE
feat: three-role model (Owner/Manager/Member) with owner-only billing, settings & account cancel

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -24,14 +24,20 @@ caller's `accountId` and `role`, and `requireRole(...)` guards enforce it.
 
 Roles, in ascending privilege:
 
-- **Team Member** — works in the account's data; no member management.
-- **Manager** — additionally invites/removes Team Members.
-- **Owner** — full control: manage all roles, billing, deleting the account.
-  The last remaining owner can't be removed or demoted.
+- **Member** — works in the account's data; no member management.
+- **Manager** — additionally invites/removes Members and manages roles, but not
+  billing or account settings.
+- **Owner** — full control: manage all roles, billing, account settings, and
+  canceling the account. The last remaining owner can't be removed or demoted.
 
 Members are added via tokenized invites (`POST /v1/members/invites` →
 `POST /v1/auth/accept-invite`); the invite token is emailed to the invitee and
-also returned to the inviter.
+also returned to the inviter. An Owner may invite any role (including another
+Owner); a Manager may only invite Members.
+
+Billing and account settings are **Owner-only**. Canceling an account is a soft
+delete — the row and its data are retained but the account is marked `canceled`,
+which locks every session out at authentication time.
 
 Authentication is **passwordless**. Signup and login email a 6-digit one-time
 code (`POST /v1/auth/signup` and `/v1/auth/login` return `202 { status:
@@ -52,10 +58,13 @@ in 10 minutes, and lock after 5 wrong attempts.
 | POST   | `/v1/auth/accept-invite`        | —              | Accept an invite and join an account |
 | GET    | `/v1/auth/me`                   | JWT            | Current user, account, and role     |
 | GET    | `/v1/members`                   | JWT            | List members + pending invites      |
-| POST   | `/v1/members/invites`           | Owner/Manager  | Invite a Manager or Team Member     |
+| POST   | `/v1/members/invites`           | Owner/Manager  | Invite a teammate (any role / Member) |
 | DELETE | `/v1/members/invites/:inviteId` | Owner/Manager  | Revoke a pending invite             |
 | PATCH  | `/v1/members/:userId/role`      | Owner          | Change a member's role              |
 | DELETE | `/v1/members/:userId`           | Owner/Manager  | Remove a member                     |
+| PATCH  | `/v1/account`                   | Owner          | Update account business settings    |
+| POST   | `/v1/account/cancel`            | Owner          | Cancel (soft-delete) the account    |
+| GET    | `/v1/billing`                   | Owner          | Billing summary (free-plan placeholder) |
 | GET    | `/v1/items`                     | JWT            | List your account's items (paged)   |
 | POST   | `/v1/items`                     | JWT            | Create an item                      |
 | GET    | `/v1/items/:id`                 | JWT            | Fetch one item                      |
@@ -65,14 +74,22 @@ in 10 minutes, and lock after 5 wrong attempts.
 ## Scripts
 
 ```bash
-pnpm --filter @rivus/api dev      # watch-mode dev server (needs MongoDB)
-pnpm --filter @rivus/api test     # run the hermetic test suite
-pnpm --filter @rivus/api build    # bundle to dist/ with tsdown
-pnpm --filter @rivus/api openapi  # regenerate openapi.json for the docs site
+pnpm --filter @rivus/api dev           # watch-mode dev server (needs MongoDB)
+pnpm --filter @rivus/api test          # run the hermetic test suite
+pnpm --filter @rivus/api build         # bundle to dist/ with tsdown
+pnpm --filter @rivus/api openapi       # regenerate openapi.json for the docs site
+pnpm --filter @rivus/api migrate:roles # rename the legacy team_member role to member
 ```
 
 Start MongoDB locally with `pnpm services:up` from the repo root. Configuration
 comes from environment variables — see `.env.example`.
+
+### Migrations
+
+The third role was renamed from `team_member` to `member`. Existing databases
+that predate the rename must run `pnpm --filter @rivus/api migrate:roles` once
+(it rewrites `team_member` → `member` in `memberships` and `invites`); it is
+idempotent and a no-op on fresh databases.
 
 ### Email (Resend)
 

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -468,7 +468,7 @@
     },
     "/v1/members/invites": {
       "post": {
-        "summary": "Invite a Manager or Team Member to your account",
+        "summary": "Invite a teammate (Owner, Manager, or Member) to your account",
         "tags": [
           "members"
         ],
@@ -490,8 +490,9 @@
                   "role": {
                     "type": "string",
                     "enum": [
+                      "owner",
                       "manager",
-                      "team_member"
+                      "member"
                     ]
                   }
                 },
@@ -641,7 +642,7 @@
                     "enum": [
                       "owner",
                       "manager",
-                      "team_member"
+                      "member"
                     ]
                   }
                 },
@@ -790,6 +791,204 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/account/": {
+      "patch": {
+        "summary": "Update account business settings (owner only)",
+        "tags": [
+          "account"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "businessName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "phone": {
+                    "type": "string",
+                    "maxLength": 40
+                  },
+                  "address": {
+                    "type": "string",
+                    "maxLength": 300
+                  },
+                  "website": {
+                    "type": "string",
+                    "maxLength": 2048
+                  },
+                  "timezone": {
+                    "type": "string",
+                    "maxLength": 64
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/account/cancel": {
+      "post": {
+        "summary": "Cancel the account — a soft delete that locks it (owner only)",
+        "tags": [
+          "account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/billing/": {
+      "get": {
+        "summary": "Billing summary for the account (owner only)",
+        "tags": [
+          "billing"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Billing"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
             "description": "Default Response",
             "content": {
               "application/json": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,6 +12,7 @@
 		"start": "node dist/index.mjs",
 		"deploy": "wrangler deploy",
 		"openapi": "tsx src/openapi.ts",
+		"migrate:roles": "node scripts/migrate-roles.mjs",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",

--- a/packages/api/scripts/migrate-roles.mjs
+++ b/packages/api/scripts/migrate-roles.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * One-off data migration: rename the `team_member` role to `member`.
+ *
+ * The role literal changed from `team_member` to `member` across the codebase.
+ * The Mongoose enums now only accept `owner | manager | member`, so any existing
+ * `memberships` / `invites` documents still holding `team_member` must be
+ * rewritten or they will fail validation on the next write.
+ *
+ * Idempotent: re-running it simply matches zero documents the second time.
+ *
+ * Usage:
+ *   MONGODB_URI="mongodb://…" node scripts/migrate-roles.mjs
+ *   # or: pnpm --filter @rivus/api migrate:roles
+ */
+import mongoose from 'mongoose';
+
+const uri =
+	process.env.MONGODB_URI ?? 'mongodb://localhost:27017/rivus?replicaSet=rs0&directConnection=true';
+
+async function main() {
+	await mongoose.connect(uri);
+	const db = mongoose.connection.db;
+	if (!db) {
+		throw new Error('No database handle after connecting');
+	}
+
+	const collections = ['memberships', 'invites'];
+	for (const name of collections) {
+		const result = await db
+			.collection(name)
+			.updateMany({ role: 'team_member' }, { $set: { role: 'member' } });
+		process.stdout.write(
+			`${name}: matched ${result.matchedCount}, modified ${result.modifiedCount}\n`,
+		);
+	}
+
+	await mongoose.disconnect();
+	process.stdout.write('Role migration complete.\n');
+}
+
+main().catch(async (error) => {
+	console.error(error);
+	await mongoose.disconnect().catch(() => {});
+	process.exit(1);
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -11,7 +11,9 @@ import { parseCorsOrigin } from './config';
 import authPlugin from './plugins/auth';
 import swaggerPlugin from './plugins/swagger';
 import { ConflictError, InviteNotPendingError } from './repositories/errors';
+import { accountRoutes } from './routes/account';
 import { authRoutes } from './routes/auth';
+import { billingRoutes } from './routes/billing';
 import { healthRoutes } from './routes/health';
 import { itemRoutes } from './routes/items';
 import { memberRoutes } from './routes/members';
@@ -96,6 +98,8 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	app.register(healthRoutes);
 	app.register(authRoutes, { prefix: '/v1/auth' });
 	app.register(memberRoutes, { prefix: '/v1/members' });
+	app.register(accountRoutes, { prefix: '/v1/account' });
+	app.register(billingRoutes, { prefix: '/v1/billing' });
 	app.register(itemRoutes, { prefix: '/v1/items' });
 
 	return app;

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -10,7 +10,7 @@ import {
 import { parseCorsOrigin } from './config';
 import authPlugin from './plugins/auth';
 import swaggerPlugin from './plugins/swagger';
-import { ConflictError, InviteNotPendingError } from './repositories/errors';
+import { ConflictError, InviteNotPendingError, LastOwnerError } from './repositories/errors';
 import { accountRoutes } from './routes/account';
 import { authRoutes } from './routes/auth';
 import { billingRoutes } from './routes/billing';
@@ -69,6 +69,14 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 				error: 'Unauthorized',
 				message: error.message,
 				statusCode: 401,
+			});
+		}
+
+		if (error instanceof LastOwnerError) {
+			return reply.status(409).send({
+				error: 'Conflict',
+				message: error.message,
+				statusCode: 409,
 			});
 		}
 

--- a/packages/api/src/db/models/account.model.ts
+++ b/packages/api/src/db/models/account.model.ts
@@ -7,6 +7,8 @@ export interface AccountDocument {
 	address: string;
 	website: string;
 	timezone: string;
+	status: 'active' | 'canceled';
+	canceledAt: Date | null;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -19,6 +21,10 @@ const accountSchema = new Schema<AccountDocument>(
 		address: { type: String, default: '' },
 		website: { type: String, default: '' },
 		timezone: { type: String, default: 'UTC' },
+		// Soft delete: `canceled` keeps the row (and its data) but locks the account
+		// out at authentication time. Defaults keep existing/active accounts unchanged.
+		status: { type: String, enum: ['active', 'canceled'], default: 'active', index: true },
+		canceledAt: { type: Date, default: null },
 	},
 	{ timestamps: true },
 );

--- a/packages/api/src/db/models/account.model.ts
+++ b/packages/api/src/db/models/account.model.ts
@@ -9,6 +9,13 @@ export interface AccountDocument {
 	timezone: string;
 	status: 'active' | 'canceled';
 	canceledAt: Date | null;
+	/**
+	 * Bumped inside owner-management transactions so two concurrent demote/remove
+	 * requests write the same account document, conflict, and serialize — closing
+	 * the check-then-write race that could otherwise orphan an account. Internal;
+	 * never serialized to the API.
+	 */
+	membershipsVersion: number;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -25,6 +32,7 @@ const accountSchema = new Schema<AccountDocument>(
 		// out at authentication time. Defaults keep existing/active accounts unchanged.
 		status: { type: String, enum: ['active', 'canceled'], default: 'active', index: true },
 		canceledAt: { type: Date, default: null },
+		membershipsVersion: { type: Number, default: 0 },
 	},
 	{ timestamps: true },
 );

--- a/packages/api/src/db/models/invite.model.ts
+++ b/packages/api/src/db/models/invite.model.ts
@@ -4,7 +4,7 @@ export interface InviteDocument {
 	accountId: Types.ObjectId;
 	email: string;
 	name: string;
-	role: 'manager' | 'team_member';
+	role: 'owner' | 'manager' | 'member';
 	status: 'pending' | 'accepted' | 'revoked';
 	token: string;
 	invitedBy: Types.ObjectId;
@@ -17,7 +17,7 @@ const inviteSchema = new Schema<InviteDocument>(
 		accountId: { type: Schema.Types.ObjectId, ref: 'Account', required: true, index: true },
 		email: { type: String, required: true, lowercase: true, trim: true, index: true },
 		name: { type: String, required: true, trim: true },
-		role: { type: String, enum: ['manager', 'team_member'], required: true },
+		role: { type: String, enum: ['owner', 'manager', 'member'], required: true },
 		status: {
 			type: String,
 			enum: ['pending', 'accepted', 'revoked'],

--- a/packages/api/src/db/models/membership.model.ts
+++ b/packages/api/src/db/models/membership.model.ts
@@ -3,7 +3,7 @@ import { model, Schema, type Types } from 'mongoose';
 export interface MembershipDocument {
 	accountId: Types.ObjectId;
 	userId: Types.ObjectId;
-	role: 'owner' | 'manager' | 'team_member';
+	role: 'owner' | 'manager' | 'member';
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -13,7 +13,7 @@ const membershipSchema = new Schema<MembershipDocument>(
 		accountId: { type: Schema.Types.ObjectId, ref: 'Account', required: true, index: true },
 		// Unique so a user belongs to exactly one account (one account per user).
 		userId: { type: Schema.Types.ObjectId, ref: 'User', required: true, unique: true, index: true },
-		role: { type: String, enum: ['owner', 'manager', 'team_member'], required: true },
+		role: { type: String, enum: ['owner', 'manager', 'member'], required: true },
 	},
 	{ timestamps: true },
 );

--- a/packages/api/src/http-schemas.ts
+++ b/packages/api/src/http-schemas.ts
@@ -1,4 +1,4 @@
-import { itemStatusSchema, roleSchema } from '@rivus/core';
+import { accountStatusSchema, itemStatusSchema, roleSchema } from '@rivus/core';
 import { z } from 'zod';
 
 /** Public user projection — never includes the password hash. */
@@ -22,6 +22,8 @@ export const accountResponseSchema = z
 		address: z.string(),
 		website: z.string(),
 		timezone: z.string(),
+		status: accountStatusSchema,
+		canceledAt: z.string().nullable(),
 		createdAt: z.string(),
 		updatedAt: z.string(),
 	})
@@ -70,15 +72,15 @@ export const memberResponseSchema = z
 
 /**
  * A pending invitation as shown in the roster. The bearer `token` is deliberately
- * omitted here — anyone who can list members (including Team Members) would
- * otherwise be able to claim a pending Manager invite.
+ * omitted here — anyone who can list members (including Members) would otherwise
+ * be able to claim a pending Manager or Owner invite.
  */
 export const inviteSummarySchema = z
 	.object({
 		id: z.string(),
 		email: z.string(),
 		name: z.string(),
-		role: z.enum(['manager', 'team_member']),
+		role: roleSchema,
 		status: z.enum(['pending', 'accepted', 'revoked']),
 		createdAt: z.string(),
 	})
@@ -123,6 +125,19 @@ export const itemListResponseSchema = z
 		meta: paginationMetaSchema,
 	})
 	.meta({ id: 'ItemList' });
+
+/**
+ * Billing summary for the account (owner-only). Rivus has no payment provider
+ * wired up yet, so this is a placeholder: every account is on the free plan and
+ * `seats` reflects the current member count.
+ */
+export const billingResponseSchema = z
+	.object({
+		plan: z.literal('free'),
+		status: accountStatusSchema,
+		seats: z.number().int(),
+	})
+	.meta({ id: 'Billing' });
 
 export const errorResponseSchema = z
 	.object({

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -28,7 +28,12 @@ export default fp(
 			if (!membership) {
 				throw app.httpErrors.unauthorized('Your access to this account has been revoked');
 			}
-			if (account?.status === 'canceled') {
+			// A missing account must fail closed: without this an orphaned membership
+			// would authenticate and downstream handlers would assume an account exists.
+			if (!account) {
+				throw app.httpErrors.unauthorized('Account no longer exists');
+			}
+			if (account.status === 'canceled') {
 				throw app.httpErrors.unauthorized('This account has been canceled');
 			}
 			request.user.role = membership.role;

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -17,15 +17,19 @@ export default fp(
 			} catch {
 				throw app.httpErrors.unauthorized('Authentication required');
 			}
-			// The token embeds accountId + role for speed, but membership can change
-			// after issuance. Revalidate against the DB so a removed user loses access
-			// immediately and a role change takes effect without waiting for expiry.
-			const membership = await app.deps.memberships.findByAccountAndUser(
-				request.user.accountId,
-				request.user.sub,
-			);
+			// The token embeds accountId + role for speed, but membership and account
+			// state can change after issuance. Revalidate against the DB so a removed
+			// user loses access immediately, a role change takes effect without waiting
+			// for expiry, and a canceled (soft-deleted) account locks everyone out.
+			const [membership, account] = await Promise.all([
+				app.deps.memberships.findByAccountAndUser(request.user.accountId, request.user.sub),
+				app.deps.accounts.findById(request.user.accountId),
+			]);
 			if (!membership) {
 				throw app.httpErrors.unauthorized('Your access to this account has been revoked');
+			}
+			if (account?.status === 'canceled') {
+				throw app.httpErrors.unauthorized('This account has been canceled');
 			}
 			request.user.role = membership.role;
 		});

--- a/packages/api/src/presenters.ts
+++ b/packages/api/src/presenters.ts
@@ -22,6 +22,8 @@ export function toPublicAccount(account: Account): Account {
 		address: account.address,
 		website: account.website,
 		timezone: account.timezone,
+		status: account.status,
+		canceledAt: account.canceledAt,
 		createdAt: account.createdAt,
 		updatedAt: account.updatedAt,
 	};

--- a/packages/api/src/repositories/errors.ts
+++ b/packages/api/src/repositories/errors.ts
@@ -23,3 +23,16 @@ export class InviteNotPendingError extends Error {
 		this.name = 'InviteNotPendingError';
 	}
 }
+
+/**
+ * Thrown when demoting or removing a membership would leave its account with no
+ * owner. The check and the write are performed atomically in the repository (a
+ * transaction in Mongo) so two concurrent owner-management requests can't both
+ * pass a stale count and orphan the account. The API maps it to HTTP 409.
+ */
+export class LastOwnerError extends Error {
+	constructor(message = 'An account must always have at least one owner') {
+		super(message);
+		this.name = 'LastOwnerError';
+	}
+}

--- a/packages/api/src/repositories/memory.ts
+++ b/packages/api/src/repositories/memory.ts
@@ -15,7 +15,7 @@ import {
 	type UpdateItemInput,
 	type UserId,
 } from '@rivus/core';
-import { ConflictError, InviteNotPendingError } from './errors';
+import { ConflictError, InviteNotPendingError, LastOwnerError } from './errors';
 import type {
 	AcceptInviteInput,
 	AcceptInviteResult,
@@ -246,6 +246,10 @@ export class InMemoryMembershipRepository implements MembershipRepository {
 	async updateRole(accountId: AccountId, userId: UserId, role: Role): Promise<Membership | null> {
 		for (const membership of this.data.memberships.values()) {
 			if (membership.accountId === accountId && membership.userId === userId) {
+				// Demoting the last owner would orphan the account; refuse atomically.
+				if (membership.role === 'owner' && role !== 'owner' && this.ownerCount(accountId) <= 1) {
+					throw new LastOwnerError();
+				}
 				const updated: Membership = { ...membership, role, updatedAt: now() };
 				this.data.memberships.set(membership.id, updated);
 				return structuredClone(updated);
@@ -257,10 +261,25 @@ export class InMemoryMembershipRepository implements MembershipRepository {
 	async delete(accountId: AccountId, userId: UserId): Promise<boolean> {
 		for (const membership of this.data.memberships.values()) {
 			if (membership.accountId === accountId && membership.userId === userId) {
+				// Removing the last owner would orphan the account; refuse atomically.
+				if (membership.role === 'owner' && this.ownerCount(accountId) <= 1) {
+					throw new LastOwnerError();
+				}
 				return this.data.memberships.delete(membership.id);
 			}
 		}
 		return false;
+	}
+
+	/** Count the owners of an account — the invariant guarded above is "at least one". */
+	private ownerCount(accountId: AccountId): number {
+		let count = 0;
+		for (const membership of this.data.memberships.values()) {
+			if (membership.accountId === accountId && membership.role === 'owner') {
+				count += 1;
+			}
+		}
+		return count;
 	}
 }
 

--- a/packages/api/src/repositories/memory.ts
+++ b/packages/api/src/repositories/memory.ts
@@ -34,6 +34,7 @@ import type {
 	SignupResult,
 	StoredUser,
 	StoredVerificationCode,
+	UpdateAccount,
 	UserRepository,
 	VerificationCodeRepository,
 } from './types';
@@ -136,6 +137,8 @@ export class InMemoryAccountRepository implements AccountRepository {
 			address: input.address,
 			website: input.website,
 			timezone: input.timezone,
+			status: 'active',
+			canceledAt: null,
 			createdAt: timestamp,
 			updatedAt: timestamp,
 		};
@@ -156,6 +159,40 @@ export class InMemoryAccountRepository implements AccountRepository {
 			}
 		}
 		return null;
+	}
+
+	async update(id: AccountId, input: UpdateAccount): Promise<Account | null> {
+		const account = this.data.accounts.get(id);
+		if (!account) {
+			return null;
+		}
+		// Only overwrite fields the caller actually sent (undefined means "leave as is").
+		const patch: Partial<Account> = {};
+		for (const key of ['name', 'phone', 'address', 'website', 'timezone'] as const) {
+			const value = input[key];
+			if (value !== undefined) {
+				patch[key] = value;
+			}
+		}
+		const updated: Account = { ...account, ...patch, updatedAt: now() };
+		this.data.accounts.set(id, updated);
+		return structuredClone(updated);
+	}
+
+	async cancel(id: AccountId): Promise<Account | null> {
+		const account = this.data.accounts.get(id);
+		if (!account) {
+			return null;
+		}
+		const timestamp = now();
+		const updated: Account = {
+			...account,
+			status: 'canceled',
+			canceledAt: timestamp,
+			updatedAt: timestamp,
+		};
+		this.data.accounts.set(id, updated);
+		return structuredClone(updated);
 	}
 }
 

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -43,6 +43,7 @@ import type {
 	SignupResult,
 	StoredUser,
 	StoredVerificationCode,
+	UpdateAccount,
 	UserRepository,
 	VerificationCodeRepository,
 } from './types';
@@ -88,6 +89,8 @@ function mapAccount(doc: HydratedDocument<AccountDocument>): Account {
 		address: doc.address,
 		website: doc.website,
 		timezone: doc.timezone,
+		status: doc.status,
+		canceledAt: doc.canceledAt ? doc.canceledAt.toISOString() : null,
 		createdAt: doc.createdAt.toISOString(),
 		updatedAt: doc.updatedAt.toISOString(),
 	};
@@ -192,6 +195,34 @@ export class MongoAccountRepository implements AccountRepository {
 
 	async findBySlug(slug: string): Promise<Account | null> {
 		const doc = await AccountModel.findOne({ slug: slug.trim().toLowerCase() }).exec();
+		return doc ? mapAccount(doc) : null;
+	}
+
+	async update(id: AccountId, input: UpdateAccount): Promise<Account | null> {
+		if (!Types.ObjectId.isValid(id)) {
+			return null;
+		}
+		// `$set` with only the provided keys, so a partial update never blanks a field.
+		const set: UpdateAccount = {};
+		for (const key of ['name', 'phone', 'address', 'website', 'timezone'] as const) {
+			const value = input[key];
+			if (value !== undefined) {
+				set[key] = value;
+			}
+		}
+		const doc = await AccountModel.findByIdAndUpdate(id, { $set: set }, { new: true }).exec();
+		return doc ? mapAccount(doc) : null;
+	}
+
+	async cancel(id: AccountId): Promise<Account | null> {
+		if (!Types.ObjectId.isValid(id)) {
+			return null;
+		}
+		const doc = await AccountModel.findByIdAndUpdate(
+			id,
+			{ $set: { status: 'canceled', canceledAt: new Date() } },
+			{ new: true },
+		).exec();
 		return doc ? mapAccount(doc) : null;
 	}
 }

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -14,7 +14,7 @@ import {
 	type UpdateItemInput,
 	type UserId,
 } from '@rivus/core';
-import mongoose, { type HydratedDocument, Types } from 'mongoose';
+import mongoose, { type ClientSession, type HydratedDocument, Types } from 'mongoose';
 import { type AccountDocument, AccountModel } from '../db/models/account.model';
 import { type InviteDocument, InviteModel } from '../db/models/invite.model';
 import { type ItemDocument, ItemModel } from '../db/models/item.model';
@@ -24,7 +24,7 @@ import {
 	type VerificationCodeDocument,
 	VerificationCodeModel,
 } from '../db/models/verification-code.model';
-import { ConflictError, InviteNotPendingError } from './errors';
+import { ConflictError, InviteNotPendingError, LastOwnerError } from './errors';
 import type {
 	AcceptInviteInput,
 	AcceptInviteResult,
@@ -227,6 +227,47 @@ export class MongoAccountRepository implements AccountRepository {
 	}
 }
 
+/**
+ * Run an owner-mutating membership write inside a transaction that first bumps
+ * the account's `membershipsVersion`. That shared write is the serialization
+ * point: two concurrent demote/remove requests on the same account collide on
+ * it, so one is retried by `withTransaction` and re-evaluates the owner count
+ * against the other's committed result — closing the check-then-write race.
+ */
+async function withOwnerGuard<T>(
+	accountOid: Types.ObjectId,
+	fn: (session: ClientSession) => Promise<T>,
+): Promise<T> {
+	const session = await mongoose.startSession();
+	try {
+		let result: T | undefined;
+		await session.withTransaction(async () => {
+			await AccountModel.updateOne(
+				{ _id: accountOid },
+				{ $inc: { membershipsVersion: 1 } },
+				{ session },
+			).exec();
+			result = await fn(session);
+		});
+		return result as T;
+	} finally {
+		await session.endSession();
+	}
+}
+
+/** Throw {@link LastOwnerError} unless the account still has another owner. */
+async function assertAnotherOwnerRemains(
+	accountOid: Types.ObjectId,
+	session: ClientSession,
+): Promise<void> {
+	const owners = await MembershipModel.countDocuments({ accountId: accountOid, role: 'owner' })
+		.session(session)
+		.exec();
+	if (owners <= 1) {
+		throw new LastOwnerError();
+	}
+}
+
 export class MongoMembershipRepository implements MembershipRepository {
 	async create(input: NewMembership): Promise<Membership> {
 		try {
@@ -277,23 +318,54 @@ export class MongoMembershipRepository implements MembershipRepository {
 		if (!Types.ObjectId.isValid(accountId) || !Types.ObjectId.isValid(userId)) {
 			return null;
 		}
-		const doc = await MembershipModel.findOneAndUpdate(
-			{ accountId: new Types.ObjectId(accountId), userId: new Types.ObjectId(userId) },
-			{ $set: { role } },
-			{ new: true },
-		).exec();
-		return doc ? mapMembership(doc) : null;
+		const accountOid = new Types.ObjectId(accountId);
+		const userOid = new Types.ObjectId(userId);
+		return withOwnerGuard(accountOid, async (session) => {
+			const target = await MembershipModel.findOne({ accountId: accountOid, userId: userOid })
+				.session(session)
+				.exec();
+			if (!target) {
+				return null;
+			}
+			// Demoting an owner must leave at least one behind. The owner count is read
+			// after the guard's account write, so a concurrent demote/remove forces a
+			// write conflict and retries against the fresh count.
+			if (target.role === 'owner' && role !== 'owner') {
+				await assertAnotherOwnerRemains(accountOid, session);
+			}
+			const doc = await MembershipModel.findOneAndUpdate(
+				{ accountId: accountOid, userId: userOid },
+				{ $set: { role } },
+				{ new: true, session },
+			).exec();
+			return doc ? mapMembership(doc) : null;
+		});
 	}
 
 	async delete(accountId: AccountId, userId: UserId): Promise<boolean> {
 		if (!Types.ObjectId.isValid(accountId) || !Types.ObjectId.isValid(userId)) {
 			return false;
 		}
-		const result = await MembershipModel.deleteOne({
-			accountId: new Types.ObjectId(accountId),
-			userId: new Types.ObjectId(userId),
-		}).exec();
-		return result.deletedCount === 1;
+		const accountOid = new Types.ObjectId(accountId);
+		const userOid = new Types.ObjectId(userId);
+		return withOwnerGuard(accountOid, async (session) => {
+			const target = await MembershipModel.findOne({ accountId: accountOid, userId: userOid })
+				.session(session)
+				.exec();
+			if (!target) {
+				return false;
+			}
+			if (target.role === 'owner') {
+				await assertAnotherOwnerRemains(accountOid, session);
+			}
+			const result = await MembershipModel.deleteOne({
+				accountId: accountOid,
+				userId: userOid,
+			})
+				.session(session)
+				.exec();
+			return result.deletedCount === 1;
+		});
 	}
 }
 

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -79,10 +79,27 @@ export interface NewAccount {
 	timezone: string;
 }
 
+/**
+ * Editable account business fields (owner-only account settings). Mirrors the
+ * stored shape; the route maps the public `businessName` onto `name`. Every
+ * field is optional so a partial update only touches what the caller sent.
+ */
+export interface UpdateAccount {
+	name?: string;
+	phone?: string;
+	address?: string;
+	website?: string;
+	timezone?: string;
+}
+
 export interface AccountRepository {
 	create(input: NewAccount): Promise<Account>;
 	findById(id: AccountId): Promise<Account | null>;
 	findBySlug(slug: string): Promise<Account | null>;
+	/** Apply a partial business-info update; returns the updated account or null. */
+	update(id: AccountId, input: UpdateAccount): Promise<Account | null>;
+	/** Soft-delete: mark the account `canceled` (data retained). Returns it, or null. */
+	cancel(id: AccountId): Promise<Account | null>;
 }
 
 export interface NewMembership {
@@ -105,7 +122,7 @@ export interface NewInvite {
 	accountId: AccountId;
 	email: string;
 	name: string;
-	role: Exclude<Role, 'owner'>;
+	role: Role;
 	token: string;
 	invitedBy: UserId;
 }
@@ -134,7 +151,7 @@ export interface SignupResult {
 export interface AcceptInviteInput {
 	user: NewUser;
 	accountId: AccountId;
-	role: Exclude<Role, 'owner'>;
+	role: Role;
 	inviteId: InviteId;
 }
 

--- a/packages/api/src/routes/account.ts
+++ b/packages/api/src/routes/account.ts
@@ -1,0 +1,78 @@
+import { type AccountId, updateAccountSchema } from '@rivus/core';
+import type { FastifyPluginAsync } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { accountResponseSchema, errorResponseSchema } from '../http-schemas';
+import { toPublicAccount } from '../presenters';
+import type { UpdateAccount } from '../repositories/types';
+
+/**
+ * Account-settings routes. Both are owner-only — managers and members are
+ * excluded by `requireRole('owner')`, matching the rule that billing and account
+ * settings are the owner's alone.
+ */
+export const accountRoutes: FastifyPluginAsync = async (fastify) => {
+	const app = fastify.withTypeProvider<ZodTypeProvider>();
+	const { accounts } = app.deps;
+
+	app.patch(
+		'/',
+		{
+			onRequest: [fastify.authenticate, fastify.requireRole('owner')],
+			schema: {
+				tags: ['account'],
+				summary: 'Update account business settings (owner only)',
+				security: [{ bearerAuth: [] }],
+				body: updateAccountSchema,
+				response: {
+					200: accountResponseSchema,
+					400: errorResponseSchema,
+					401: errorResponseSchema,
+					403: errorResponseSchema,
+					404: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const accountId = request.user.accountId as AccountId;
+			// The public field is `businessName`; the stored field is `name`.
+			const { businessName, ...rest } = request.body;
+			const patch: UpdateAccount = { ...rest };
+			if (businessName !== undefined) {
+				patch.name = businessName;
+			}
+			const updated = await accounts.update(accountId, patch);
+			if (!updated) {
+				throw app.httpErrors.notFound('Account not found');
+			}
+			return toPublicAccount(updated);
+		},
+	);
+
+	app.post(
+		'/cancel',
+		{
+			onRequest: [fastify.authenticate, fastify.requireRole('owner')],
+			schema: {
+				tags: ['account'],
+				summary: 'Cancel the account — a soft delete that locks it (owner only)',
+				security: [{ bearerAuth: [] }],
+				response: {
+					200: accountResponseSchema,
+					401: errorResponseSchema,
+					403: errorResponseSchema,
+					404: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const accountId = request.user.accountId as AccountId;
+			// Soft delete: the row and its data stay; `authenticate` then locks every
+			// session out of the canceled account on the next request.
+			const canceled = await accounts.cancel(accountId);
+			if (!canceled) {
+				throw app.httpErrors.notFound('Account not found');
+			}
+			return toPublicAccount(canceled);
+		},
+	);
+};

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -215,6 +215,11 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 			if (!user || !membership || !account) {
 				throw app.httpErrors.unauthorized('Invalid or expired code');
 			}
+			// A canceled (soft-deleted) account is a hard lockout: don't mint a session
+			// or leak its data, mirroring the accept-invite guard above.
+			if (account.status === 'canceled') {
+				throw app.httpErrors.unauthorized('Invalid or expired code');
+			}
 			const token = await reply.jwtSign({
 				sub: user.id,
 				email: user.email,

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -277,7 +277,9 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 				throw app.httpErrors.unauthorized('Invalid or expired invitation');
 			}
 			const account = await accounts.findById(invite.accountId);
-			if (!account) {
+			// A canceled (soft-deleted) account can't take on new members, even via an
+			// invite issued before it was canceled.
+			if (!account || account.status === 'canceled') {
 				throw app.httpErrors.unauthorized('Invalid or expired invitation');
 			}
 			// Creates the user + membership and marks the invite accepted atomically

--- a/packages/api/src/routes/billing.ts
+++ b/packages/api/src/routes/billing.ts
@@ -1,0 +1,37 @@
+import type { AccountId } from '@rivus/core';
+import type { FastifyPluginAsync } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { billingResponseSchema, errorResponseSchema } from '../http-schemas';
+
+/**
+ * Billing routes. Owner-only — managers and members cannot see billing. There is
+ * no payment provider yet, so the summary is a placeholder derived from the
+ * account's current state (every account is on the free plan).
+ */
+export const billingRoutes: FastifyPluginAsync = async (fastify) => {
+	const app = fastify.withTypeProvider<ZodTypeProvider>();
+	const { memberships } = app.deps;
+
+	app.get(
+		'/',
+		{
+			onRequest: [fastify.authenticate, fastify.requireRole('owner')],
+			schema: {
+				tags: ['billing'],
+				summary: 'Billing summary for the account (owner only)',
+				security: [{ bearerAuth: [] }],
+				response: {
+					200: billingResponseSchema,
+					401: errorResponseSchema,
+					403: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const accountId = request.user.accountId as AccountId;
+			const roster = await memberships.listByAccount(accountId);
+			// `authenticate` rejects canceled accounts, so a reachable account is active.
+			return { plan: 'free' as const, status: 'active' as const, seats: roster.length };
+		},
+	);
+};

--- a/packages/api/src/routes/members.ts
+++ b/packages/api/src/routes/members.ts
@@ -2,7 +2,6 @@ import {
 	type AccountId,
 	type InviteId,
 	inviteMemberSchema,
-	type Role,
 	type UserId,
 	updateMemberRoleSchema,
 } from '@rivus/core';
@@ -21,15 +20,6 @@ import { createInviteToken } from '../services/invites';
 
 const userIdParamsSchema = z.object({ userId: z.string().min(1) });
 const inviteIdParamsSchema = z.object({ inviteId: z.string().min(1) });
-
-/** Count the owners of an account (used to guard against orphaning it). */
-async function ownerCount(
-	memberships: { listByAccount(id: AccountId): Promise<{ role: Role }[]> },
-	accountId: AccountId,
-): Promise<number> {
-	const all = await memberships.listByAccount(accountId);
-	return all.filter((m) => m.role === 'owner').length;
-}
 
 export const memberRoutes: FastifyPluginAsync = async (fastify) => {
 	const app = fastify.withTypeProvider<ZodTypeProvider>();
@@ -188,14 +178,8 @@ export const memberRoutes: FastifyPluginAsync = async (fastify) => {
 			if (!target) {
 				throw app.httpErrors.notFound('Member not found');
 			}
-			// Don't let the final owner be demoted out of ownership.
-			if (
-				target.role === 'owner' &&
-				role !== 'owner' &&
-				(await ownerCount(memberships, accountId)) <= 1
-			) {
-				throw app.httpErrors.conflict('Cannot change the role of the last owner');
-			}
+			// `updateRole` atomically refuses to demote the last owner (409 via
+			// LastOwnerError), so the check and the write can't race.
 			const updated = await memberships.updateRole(accountId, targetUserId, role);
 			const user = await users.findById(targetUserId);
 			if (!updated || !user) {
@@ -233,9 +217,8 @@ export const memberRoutes: FastifyPluginAsync = async (fastify) => {
 			if (request.user.role === 'manager' && target.role !== 'member') {
 				throw app.httpErrors.forbidden('Managers can only remove Members');
 			}
-			if (target.role === 'owner' && (await ownerCount(memberships, accountId)) <= 1) {
-				throw app.httpErrors.conflict('Cannot remove the last owner');
-			}
+			// `delete` atomically refuses to remove the last owner (409 via
+			// LastOwnerError), so the check and the write can't race.
 			await memberships.delete(accountId, targetUserId);
 			return reply.code(204).send(null);
 		},

--- a/packages/api/src/routes/members.ts
+++ b/packages/api/src/routes/members.ts
@@ -70,7 +70,7 @@ export const memberRoutes: FastifyPluginAsync = async (fastify) => {
 			onRequest: [fastify.authenticate, fastify.requireRole('owner', 'manager')],
 			schema: {
 				tags: ['members'],
-				summary: 'Invite a Manager or Team Member to your account',
+				summary: 'Invite a teammate (Owner, Manager, or Member) to your account',
 				security: [{ bearerAuth: [] }],
 				body: inviteMemberSchema,
 				response: {
@@ -84,9 +84,10 @@ export const memberRoutes: FastifyPluginAsync = async (fastify) => {
 		async (request, reply) => {
 			const accountId = request.user.accountId as AccountId;
 			const { email, name, role } = request.body;
-			// Managers may only bring in Team Members, never other Managers.
-			if (request.user.role === 'manager' && role !== 'team_member') {
-				throw app.httpErrors.forbidden('Managers can only invite Team Members');
+			// Owners may invite any role; managers may only bring in Members (never
+			// other Managers or Owners — that would be a privilege escalation).
+			if (request.user.role === 'manager' && role !== 'member') {
+				throw app.httpErrors.forbidden('Managers can only invite Members');
 			}
 			if (await users.findByEmail(email)) {
 				throw app.httpErrors.conflict('A user with this email already exists');
@@ -148,9 +149,9 @@ export const memberRoutes: FastifyPluginAsync = async (fastify) => {
 			if (!invite || invite.accountId !== accountId) {
 				throw app.httpErrors.notFound('Invite not found');
 			}
-			// A Manager manages only Team Members, so can't revoke a Manager invite.
-			if (request.user.role === 'manager' && invite.role !== 'team_member') {
-				throw app.httpErrors.forbidden('Managers can only revoke Team Member invites');
+			// A Manager manages only Members, so can't revoke a Manager or Owner invite.
+			if (request.user.role === 'manager' && invite.role !== 'member') {
+				throw app.httpErrors.forbidden('Managers can only revoke Member invites');
 			}
 			const revoked = await invites.revoke(accountId, inviteId);
 			if (!revoked) {
@@ -229,8 +230,8 @@ export const memberRoutes: FastifyPluginAsync = async (fastify) => {
 			if (!target) {
 				throw app.httpErrors.notFound('Member not found');
 			}
-			if (request.user.role === 'manager' && target.role !== 'team_member') {
-				throw app.httpErrors.forbidden('Managers can only remove Team Members');
+			if (request.user.role === 'manager' && target.role !== 'member') {
+				throw app.httpErrors.forbidden('Managers can only remove Members');
 			}
 			if (target.role === 'owner' && (await ownerCount(memberships, accountId)) <= 1) {
 				throw app.httpErrors.conflict('Cannot remove the last owner');

--- a/packages/api/src/services/email.ts
+++ b/packages/api/src/services/email.ts
@@ -11,7 +11,7 @@ export interface InviteEmail {
 	/** Name of the account the invitee is being asked to join. */
 	accountName: string;
 	/** Role the invitee will hold once they accept. */
-	role: Exclude<Role, 'owner'>;
+	role: Role;
 	/** Absolute URL the invitee opens to accept (carries the invite token). */
 	acceptUrl: string;
 }
@@ -39,10 +39,11 @@ export interface Mailer {
 	sendVerificationCode(email: VerificationEmail): Promise<void>;
 }
 
-/** Human-readable labels for the assignable roles. */
-const ROLE_LABELS: Record<Exclude<Role, 'owner'>, string> = {
+/** Human-readable labels for each role. */
+const ROLE_LABELS: Record<Role, string> = {
+	owner: 'Owner',
 	manager: 'Manager',
-	team_member: 'Team Member',
+	member: 'Member',
 };
 
 /** Escape the five characters that are unsafe to interpolate into HTML. */

--- a/packages/api/test/account.test.ts
+++ b/packages/api/test/account.test.ts
@@ -1,6 +1,13 @@
 import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { addMember, authHeader, buildTestApp, signupOwner } from './helpers';
+import {
+	addMember,
+	authHeader,
+	buildTestApp,
+	buildTestAppWithRepos,
+	latestCodeFor,
+	signupOwner,
+} from './helpers';
 
 describe('account settings', () => {
 	let app: FastifyInstance;
@@ -172,6 +179,27 @@ describe('account cancellation (soft delete)', () => {
 		expect(accepted.statusCode).toBe(401);
 	});
 
+	it('refuses to issue a session when logging in to a canceled account (401)', async () => {
+		const owner = await signupOwner(app);
+		await cancel(owner.token);
+		// The user record survives a soft delete, so a login code is still issued...
+		await app.inject({
+			method: 'POST',
+			url: '/v1/auth/login',
+			payload: { email: owner.credentials.email },
+		});
+		// ...but verifying it must not mint a session for the canceled account.
+		const verified = await app.inject({
+			method: 'POST',
+			url: '/v1/auth/verify',
+			payload: {
+				email: owner.credentials.email,
+				code: latestCodeFor(app, owner.credentials.email),
+			},
+		});
+		expect(verified.statusCode).toBe(401);
+	});
+
 	it('forbids a manager from canceling the account (403)', async () => {
 		const owner = await signupOwner(app);
 		const manager = await addMember(app, owner.token, 'manager', 'mgr@example.com');
@@ -184,5 +212,25 @@ describe('account cancellation (soft delete)', () => {
 		const member = await addMember(app, owner.token, 'member', 'tm@example.com');
 		const response = await cancel(member.token);
 		expect(response.statusCode).toBe(403);
+	});
+});
+
+describe('authentication when the account record is missing', () => {
+	it('fails closed (401) rather than authenticating an orphaned membership', async () => {
+		const { app, repos } = await buildTestAppWithRepos();
+		try {
+			const owner = await signupOwner(app);
+			// Simulate an account row that vanished while the membership remained.
+			repos.data.accounts.delete(owner.account.id);
+
+			const me = await app.inject({
+				method: 'GET',
+				url: '/v1/auth/me',
+				headers: authHeader(owner.token),
+			});
+			expect(me.statusCode).toBe(401);
+		} finally {
+			await app.close();
+		}
 	});
 });

--- a/packages/api/test/account.test.ts
+++ b/packages/api/test/account.test.ts
@@ -1,0 +1,188 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { addMember, authHeader, buildTestApp, signupOwner } from './helpers';
+
+describe('account settings', () => {
+	let app: FastifyInstance;
+
+	beforeEach(async () => {
+		app = await buildTestApp();
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	function updateAccount(token: string, payload: Record<string, unknown>) {
+		return app.inject({
+			method: 'PATCH',
+			url: '/v1/account',
+			headers: authHeader(token),
+			payload,
+		});
+	}
+
+	it('requires authentication', async () => {
+		const response = await app.inject({
+			method: 'PATCH',
+			url: '/v1/account',
+			payload: { businessName: 'Nope' },
+		});
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('lets an owner update business settings and reflects them on the session', async () => {
+		const owner = await signupOwner(app);
+		const response = await updateAccount(owner.token, {
+			businessName: 'Cascade Plumbing & Heating',
+			phone: '+1 206 555 0100',
+			timezone: 'America/Los_Angeles',
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toMatchObject({
+			name: 'Cascade Plumbing & Heating',
+			phone: '+1 206 555 0100',
+			timezone: 'America/Los_Angeles',
+			status: 'active',
+		});
+
+		const me = await app.inject({
+			method: 'GET',
+			url: '/v1/auth/me',
+			headers: authHeader(owner.token),
+		});
+		expect(me.json().account).toMatchObject({
+			name: 'Cascade Plumbing & Heating',
+			phone: '+1 206 555 0100',
+		});
+	});
+
+	it('applies a partial update without blanking untouched fields', async () => {
+		const owner = await signupOwner(app, { businessName: 'Acme Co' });
+		await updateAccount(owner.token, { phone: '+1 555 0001' });
+		const response = await updateAccount(owner.token, { address: '1 Main St' });
+
+		expect(response.statusCode).toBe(200);
+		// The earlier phone survives an address-only update; the name is untouched too.
+		expect(response.json()).toMatchObject({
+			name: 'Acme Co',
+			phone: '+1 555 0001',
+			address: '1 Main St',
+		});
+	});
+
+	it('rejects an empty update (400)', async () => {
+		const owner = await signupOwner(app);
+		const response = await updateAccount(owner.token, {});
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('forbids a manager from updating account settings (403)', async () => {
+		const owner = await signupOwner(app);
+		const manager = await addMember(app, owner.token, 'manager', 'mgr@example.com');
+		const response = await updateAccount(manager.token, { businessName: 'Hijack' });
+		expect(response.statusCode).toBe(403);
+	});
+
+	it('forbids a member from updating account settings (403)', async () => {
+		const owner = await signupOwner(app);
+		const member = await addMember(app, owner.token, 'member', 'tm@example.com');
+		const response = await updateAccount(member.token, { businessName: 'Hijack' });
+		expect(response.statusCode).toBe(403);
+	});
+});
+
+describe('account cancellation (soft delete)', () => {
+	let app: FastifyInstance;
+
+	beforeEach(async () => {
+		app = await buildTestApp();
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	function cancel(token: string) {
+		return app.inject({ method: 'POST', url: '/v1/account/cancel', headers: authHeader(token) });
+	}
+
+	it('lets an owner cancel the account and marks it canceled', async () => {
+		const owner = await signupOwner(app);
+		const response = await cancel(owner.token);
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.status).toBe('canceled');
+		expect(body.canceledAt).toBeTypeOf('string');
+	});
+
+	it("locks out the owner's own token once the account is canceled", async () => {
+		const owner = await signupOwner(app);
+		await cancel(owner.token);
+
+		const after = await app.inject({
+			method: 'GET',
+			url: '/v1/auth/me',
+			headers: authHeader(owner.token),
+		});
+		expect(after.statusCode).toBe(401);
+	});
+
+	it('locks out every member of a canceled account', async () => {
+		const owner = await signupOwner(app);
+		const member = await addMember(app, owner.token, 'member', 'tm@example.com');
+		await cancel(owner.token);
+
+		const memberMe = await app.inject({
+			method: 'GET',
+			url: '/v1/items',
+			headers: authHeader(member.token),
+		});
+		expect(memberMe.statusCode).toBe(401);
+	});
+
+	it('retains the account data (soft delete, not a purge)', async () => {
+		const owner = await signupOwner(app);
+		await cancel(owner.token);
+		// The row is still present in the store, just flagged canceled.
+		const stored = await app.deps.accounts.findById(owner.account.id);
+		expect(stored?.status).toBe('canceled');
+	});
+
+	it('refuses to accept a pending invite once the account is canceled (401)', async () => {
+		const owner = await signupOwner(app);
+		// Create a pending invite, then cancel the account before it is accepted.
+		const inviteToken = (
+			await app.inject({
+				method: 'POST',
+				url: '/v1/members/invites',
+				headers: authHeader(owner.token),
+				payload: { email: 'late@example.com', name: 'Late', role: 'member' },
+			})
+		).json().token;
+		await cancel(owner.token);
+
+		const accepted = await app.inject({
+			method: 'POST',
+			url: '/v1/auth/accept-invite',
+			payload: { token: inviteToken },
+		});
+		expect(accepted.statusCode).toBe(401);
+	});
+
+	it('forbids a manager from canceling the account (403)', async () => {
+		const owner = await signupOwner(app);
+		const manager = await addMember(app, owner.token, 'manager', 'mgr@example.com');
+		const response = await cancel(manager.token);
+		expect(response.statusCode).toBe(403);
+	});
+
+	it('forbids a member from canceling the account (403)', async () => {
+		const owner = await signupOwner(app);
+		const member = await addMember(app, owner.token, 'member', 'tm@example.com');
+		const response = await cancel(member.token);
+		expect(response.statusCode).toBe(403);
+	});
+});

--- a/packages/api/test/auth.test.ts
+++ b/packages/api/test/auth.test.ts
@@ -392,7 +392,7 @@ describe('accept-invite', () => {
 		await app.close();
 	});
 
-	function invite(token: string, role: 'manager' | 'team_member', email: string) {
+	function invite(token: string, role: 'manager' | 'member', email: string) {
 		return app.inject({
 			method: 'POST',
 			url: '/v1/members/invites',
@@ -403,8 +403,7 @@ describe('accept-invite', () => {
 
 	it('lets an invitee join the account, then sign in with a code', async () => {
 		const owner = await signupOwner(app);
-		const inviteToken = (await invite(owner.token, 'team_member', 'newhire@example.com')).json()
-			.token;
+		const inviteToken = (await invite(owner.token, 'member', 'newhire@example.com')).json().token;
 
 		const accept = await app.inject({
 			method: 'POST',
@@ -414,7 +413,7 @@ describe('accept-invite', () => {
 
 		expect(accept.statusCode).toBe(201);
 		const body = accept.json();
-		expect(body.role).toBe('team_member');
+		expect(body.role).toBe('member');
 		expect(body.account.id).toBe(owner.account.id);
 		expect(body.user.email).toBe('newhire@example.com');
 
@@ -429,7 +428,7 @@ describe('accept-invite', () => {
 			latestCodeFor(app, 'newhire@example.com'),
 		);
 		expect(login.statusCode).toBe(200);
-		expect(login.json().role).toBe('team_member');
+		expect(login.json().role).toBe('member');
 	});
 
 	it('rejects an unknown invite token with 401', async () => {
@@ -443,8 +442,7 @@ describe('accept-invite', () => {
 
 	it('rejects accepting an already-accepted invite with 401', async () => {
 		const owner = await signupOwner(app);
-		const inviteToken = (await invite(owner.token, 'team_member', 'twice@example.com')).json()
-			.token;
+		const inviteToken = (await invite(owner.token, 'member', 'twice@example.com')).json().token;
 		await app.inject({
 			method: 'POST',
 			url: '/v1/auth/accept-invite',
@@ -466,7 +464,7 @@ describe('accept-invite', () => {
 			accountId: owner.account.id as AccountId,
 			email: 'taken@example.com',
 			name: 'Taken',
-			role: 'team_member',
+			role: 'member',
 			token: 'preseeded-token',
 			invitedBy: owner.user.id as UserId,
 		});

--- a/packages/api/test/billing.test.ts
+++ b/packages/api/test/billing.test.ts
@@ -1,0 +1,55 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { addMember, authHeader, buildTestApp, signupOwner } from './helpers';
+
+describe('billing', () => {
+	let app: FastifyInstance;
+
+	beforeEach(async () => {
+		app = await buildTestApp();
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	function getBilling(token: string) {
+		return app.inject({ method: 'GET', url: '/v1/billing', headers: authHeader(token) });
+	}
+
+	it('requires authentication', async () => {
+		const response = await app.inject({ method: 'GET', url: '/v1/billing' });
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('returns the free-plan placeholder with the seat (member) count for an owner', async () => {
+		const owner = await signupOwner(app);
+		const response = await getBilling(owner.token);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ plan: 'free', status: 'active', seats: 1 });
+	});
+
+	it('counts every member as a seat', async () => {
+		const owner = await signupOwner(app);
+		await addMember(app, owner.token, 'manager', 'mgr@example.com');
+		await addMember(app, owner.token, 'member', 'tm@example.com');
+
+		const response = await getBilling(owner.token);
+		expect(response.json().seats).toBe(3);
+	});
+
+	it('forbids a manager from viewing billing (403)', async () => {
+		const owner = await signupOwner(app);
+		const manager = await addMember(app, owner.token, 'manager', 'mgr@example.com');
+		const response = await getBilling(manager.token);
+		expect(response.statusCode).toBe(403);
+	});
+
+	it('forbids a member from viewing billing (403)', async () => {
+		const owner = await signupOwner(app);
+		const member = await addMember(app, owner.token, 'member', 'tm@example.com');
+		const response = await getBilling(member.token);
+		expect(response.statusCode).toBe(403);
+	});
+});

--- a/packages/api/test/email.test.ts
+++ b/packages/api/test/email.test.ts
@@ -53,9 +53,9 @@ describe('renderInviteEmail', () => {
 		}
 	});
 
-	it('labels the team_member role in human-readable form', () => {
-		const { html } = renderInviteEmail({ ...sampleInvite, role: 'team_member' });
-		expect(html).toContain('Team Member');
+	it('labels the member role in human-readable form', () => {
+		const { html } = renderInviteEmail({ ...sampleInvite, role: 'member' });
+		expect(html).toContain('Member');
 	});
 
 	it('escapes HTML in user-controlled names to prevent injection', () => {

--- a/packages/api/test/helpers.ts
+++ b/packages/api/test/helpers.ts
@@ -143,3 +143,26 @@ export async function signupOwner(
 export function authHeader(token: string): { authorization: string } {
 	return { authorization: `Bearer ${token}` };
 }
+
+/** Invite a teammate with the given role and accept it, returning their session. */
+export async function addMember(
+	app: FastifyInstance,
+	ownerToken: string,
+	role: Role,
+	email: string,
+): Promise<{ token: string; userId: string }> {
+	const invite = await app.inject({
+		method: 'POST',
+		url: '/v1/members/invites',
+		headers: authHeader(ownerToken),
+		payload: { email, name: 'Teammate', role },
+	});
+	const inviteToken = invite.json().token as string;
+	const accepted = await app.inject({
+		method: 'POST',
+		url: '/v1/auth/accept-invite',
+		payload: { token: inviteToken },
+	});
+	const body = accepted.json();
+	return { token: body.token as string, userId: body.user.id as string };
+}

--- a/packages/api/test/members.test.ts
+++ b/packages/api/test/members.test.ts
@@ -323,6 +323,18 @@ describe('members', () => {
 		expect(response.statusCode).toBe(409);
 	});
 
+	it('allows removing an owner once a second owner exists', async () => {
+		const owner = await signupOwner(app);
+		const coOwner = await addMember(owner.token, 'owner', 'coowner@example.com');
+
+		const response = await app.inject({
+			method: 'DELETE',
+			url: `/v1/members/${coOwner.userId}`,
+			headers: authHeader(owner.token),
+		});
+		expect(response.statusCode).toBe(204);
+	});
+
 	it('returns 404 removing a non-member', async () => {
 		const owner = await signupOwner(app);
 		const response = await app.inject({

--- a/packages/api/test/members.test.ts
+++ b/packages/api/test/members.test.ts
@@ -1,3 +1,4 @@
+import type { Role } from '@rivus/core';
 import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { authHeader, buildTestApp, RecordingMailer, signupOwner } from './helpers';
@@ -13,7 +14,7 @@ describe('members', () => {
 		await app.close();
 	});
 
-	function inviteMember(token: string, role: 'manager' | 'team_member', email: string) {
+	function inviteMember(token: string, role: Role, email: string) {
 		return app.inject({
 			method: 'POST',
 			url: '/v1/members/invites',
@@ -23,7 +24,7 @@ describe('members', () => {
 	}
 
 	/** Invite + accept, returning the new member's session token and user id. */
-	async function addMember(ownerToken: string, role: 'manager' | 'team_member', email: string) {
+	async function addMember(ownerToken: string, role: Role, email: string) {
 		const inviteToken = (await inviteMember(ownerToken, role, email)).json().token;
 		const accepted = await app.inject({
 			method: 'POST',
@@ -72,10 +73,10 @@ describe('members', () => {
 		expect(list.json().invites[0]).not.toHaveProperty('token');
 	});
 
-	it('hides invite tokens from a Team Member listing the roster', async () => {
+	it('hides invite tokens from a Member listing the roster', async () => {
 		const owner = await signupOwner(app);
 		await inviteMember(owner.token, 'manager', 'manager@example.com');
-		const teamMember = await addMember(owner.token, 'team_member', 'tm@example.com');
+		const teamMember = await addMember(owner.token, 'member', 'tm@example.com');
 
 		const list = await app.inject({
 			method: 'GET',
@@ -107,10 +108,10 @@ describe('members', () => {
 		expect(list.json().invites).toEqual([]);
 	});
 
-	it('lets a Manager revoke a Team Member invite but not a Manager invite', async () => {
+	it('lets a Manager revoke a Member invite but not a Manager invite', async () => {
 		const owner = await signupOwner(app);
 		const manager = await addMember(owner.token, 'manager', 'mgr@example.com');
-		const tmInviteId = (await inviteMember(owner.token, 'team_member', 'tm@example.com')).json().id;
+		const tmInviteId = (await inviteMember(owner.token, 'member', 'tm@example.com')).json().id;
 		const mgrInviteId = (await inviteMember(owner.token, 'manager', 'mgr2@example.com')).json().id;
 
 		const revokeManager = await app.inject({
@@ -157,34 +158,52 @@ describe('members', () => {
 
 	it('rejects inviting an email that already has a user (409)', async () => {
 		const owner = await signupOwner(app);
-		await addMember(owner.token, 'team_member', 'dupe@example.com');
+		await addMember(owner.token, 'member', 'dupe@example.com');
 
-		const again = await inviteMember(owner.token, 'team_member', 'dupe@example.com');
+		const again = await inviteMember(owner.token, 'member', 'dupe@example.com');
 		expect(again.statusCode).toBe(409);
 	});
 
-	it('lets a manager invite a Team Member but not another Manager', async () => {
+	it('lets a manager invite a Member but not another Manager or an Owner', async () => {
 		const owner = await signupOwner(app);
 		const manager = await addMember(owner.token, 'manager', 'mgr@example.com');
 
-		const teamMember = await inviteMember(manager.token, 'team_member', 'tm@example.com');
-		expect(teamMember.statusCode).toBe(201);
+		const member = await inviteMember(manager.token, 'member', 'tm@example.com');
+		expect(member.statusCode).toBe(201);
 
 		const anotherManager = await inviteMember(manager.token, 'manager', 'mgr2@example.com');
 		expect(anotherManager.statusCode).toBe(403);
+
+		const newOwner = await inviteMember(manager.token, 'owner', 'owner2@example.com');
+		expect(newOwner.statusCode).toBe(403);
 	});
 
-	it('forbids a Team Member from inviting anyone (403)', async () => {
+	it('lets an owner invite another owner, who joins as an owner', async () => {
 		const owner = await signupOwner(app);
-		const teamMember = await addMember(owner.token, 'team_member', 'tm@example.com');
+		const invite = await inviteMember(owner.token, 'owner', 'coowner@example.com');
+		expect(invite.statusCode).toBe(201);
+		expect(invite.json()).toMatchObject({ email: 'coowner@example.com', role: 'owner' });
 
-		const response = await inviteMember(teamMember.token, 'team_member', 'another@example.com');
+		const second = await addMember(owner.token, 'owner', 'coowner2@example.com');
+		const me = await app.inject({
+			method: 'GET',
+			url: '/v1/auth/me',
+			headers: authHeader(second.token),
+		});
+		expect(me.json().role).toBe('owner');
+	});
+
+	it('forbids a Member from inviting anyone (403)', async () => {
+		const owner = await signupOwner(app);
+		const member = await addMember(owner.token, 'member', 'tm@example.com');
+
+		const response = await inviteMember(member.token, 'member', 'another@example.com');
 		expect(response.statusCode).toBe(403);
 	});
 
 	it('lets an owner change a member’s role', async () => {
 		const owner = await signupOwner(app);
-		const member = await addMember(owner.token, 'team_member', 'promote@example.com');
+		const member = await addMember(owner.token, 'member', 'promote@example.com');
 
 		const response = await app.inject({
 			method: 'PATCH',
@@ -200,7 +219,7 @@ describe('members', () => {
 	it('forbids a manager from changing roles (403)', async () => {
 		const owner = await signupOwner(app);
 		const manager = await addMember(owner.token, 'manager', 'mgr@example.com');
-		const teamMember = await addMember(owner.token, 'team_member', 'tm@example.com');
+		const teamMember = await addMember(owner.token, 'member', 'tm@example.com');
 
 		const response = await app.inject({
 			method: 'PATCH',
@@ -228,7 +247,7 @@ describe('members', () => {
 			method: 'PATCH',
 			url: `/v1/members/${owner.user.id}/role`,
 			headers: authHeader(owner.token),
-			payload: { role: 'team_member' },
+			payload: { role: 'member' },
 		});
 		expect(response.statusCode).toBe(409);
 	});
@@ -256,7 +275,7 @@ describe('members', () => {
 
 	it('lets an owner remove a member', async () => {
 		const owner = await signupOwner(app);
-		const member = await addMember(owner.token, 'team_member', 'remove@example.com');
+		const member = await addMember(owner.token, 'member', 'remove@example.com');
 
 		const response = await app.inject({
 			method: 'DELETE',
@@ -273,11 +292,11 @@ describe('members', () => {
 		expect(list.json().members).toHaveLength(1);
 	});
 
-	it('lets a manager remove a Team Member but not a Manager', async () => {
+	it('lets a manager remove a Member but not a Manager', async () => {
 		const owner = await signupOwner(app);
 		const manager = await addMember(owner.token, 'manager', 'mgr@example.com');
 		const otherManager = await addMember(owner.token, 'manager', 'mgr2@example.com');
-		const teamMember = await addMember(owner.token, 'team_member', 'tm@example.com');
+		const teamMember = await addMember(owner.token, 'member', 'tm@example.com');
 
 		const removeManager = await app.inject({
 			method: 'DELETE',
@@ -316,7 +335,7 @@ describe('members', () => {
 
 	it('rejects a removed member’s existing token (membership revalidated per request)', async () => {
 		const owner = await signupOwner(app);
-		const member = await addMember(owner.token, 'team_member', 'removed@example.com');
+		const member = await addMember(owner.token, 'member', 'removed@example.com');
 		await app.inject({
 			method: 'DELETE',
 			url: `/v1/members/${member.userId}`,
@@ -337,18 +356,18 @@ describe('members', () => {
 		const owner = await signupOwner(app);
 		const manager = await addMember(owner.token, 'manager', 'demote@example.com');
 
-		const before = await inviteMember(manager.token, 'team_member', 'before@example.com');
+		const before = await inviteMember(manager.token, 'member', 'before@example.com');
 		expect(before.statusCode).toBe(201);
 
 		await app.inject({
 			method: 'PATCH',
 			url: `/v1/members/${manager.userId}/role`,
 			headers: authHeader(owner.token),
-			payload: { role: 'team_member' },
+			payload: { role: 'member' },
 		});
 
 		// Same (now-stale) manager token — the guard refreshes the role from the DB.
-		const after = await inviteMember(manager.token, 'team_member', 'after@example.com');
+		const after = await inviteMember(manager.token, 'member', 'after@example.com');
 		expect(after.statusCode).toBe(403);
 	});
 
@@ -362,7 +381,7 @@ describe('members', () => {
 		});
 		const itemId = created.json().id;
 
-		const member = await addMember(owner.token, 'team_member', 'teammate@example.com');
+		const member = await addMember(owner.token, 'member', 'teammate@example.com');
 		const response = await app.inject({
 			method: 'GET',
 			url: `/v1/items/${itemId}`,
@@ -418,7 +437,7 @@ describe('member invitations send email', () => {
 				method: 'POST',
 				url: '/v1/members/invites',
 				headers: authHeader(owner.token),
-				payload: { email: 'newhire@example.com', name: 'New Hire', role: 'team_member' },
+				payload: { email: 'newhire@example.com', name: 'New Hire', role: 'member' },
 			});
 
 			// Delivery failed, but the invite is persisted and its token returned.

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -26,7 +26,14 @@ import { Avatar, Dot, Icon, RivusStatusChip, Txt } from '@/src/components/ui';
 import { colors, font, radii, SIDEBAR_BREAKPOINT, SIDEBAR_WIDTH } from '@/src/theme/tokens';
 
 type FeatherName = React.ComponentProps<typeof Feather>['name'];
-type NavItem = { href: string; label: string; icon: FeatherName; badge?: string };
+type NavItem = {
+	href: string;
+	label: string;
+	icon: FeatherName;
+	badge?: string;
+	/** When true, only Owners see this destination (billing & account settings). */
+	ownerOnly?: boolean;
+};
 
 const NAV: NavItem[] = [
 	{ href: '/', label: 'Home', icon: 'home' },
@@ -36,7 +43,14 @@ const NAV: NavItem[] = [
 	{ href: '/marketing', label: 'Marketing', icon: 'trending-up' },
 	{ href: '/knowledge', label: 'Knowledge', icon: 'book' },
 	{ href: '/team', label: 'Team', icon: 'user-check' },
+	{ href: '/billing', label: 'Billing', icon: 'credit-card', ownerOnly: true },
+	{ href: '/settings', label: 'Settings', icon: 'settings', ownerOnly: true },
 ];
+
+/** Hide owner-only destinations from managers and members. */
+function navFor(role: string | undefined): NavItem[] {
+	return NAV.filter((item) => !item.ownerOnly || role === 'owner');
+}
 
 function isActive(pathname: string, href: string): boolean {
 	return href === '/' ? pathname === '/' : pathname.startsWith(href);
@@ -121,7 +135,7 @@ function Sidebar() {
 			</View>
 
 			<View style={styles.nav}>
-				{NAV.map((item) => {
+				{navFor(session?.role).map((item) => {
 					const active = isActive(pathname, item.href);
 					return (
 						<Pressable
@@ -227,6 +241,7 @@ function CompactBar() {
 function NavStrip() {
 	const pathname = usePathname();
 	const router = useRouter();
+	const { session } = useAuth();
 	return (
 		<View style={styles.navStripWrap}>
 			<ScrollView
@@ -234,7 +249,7 @@ function NavStrip() {
 				showsHorizontalScrollIndicator={false}
 				contentContainerStyle={styles.navStrip}
 			>
-				{NAV.map((item) => {
+				{navFor(session?.role).map((item) => {
 					const active = isActive(pathname, item.href);
 					const content = (
 						<>

--- a/packages/app/app/billing.tsx
+++ b/packages/app/app/billing.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ActivityIndicator, ScrollView, StyleSheet, View } from 'react-native';
+import { ApiError, type Billing } from '@/src/api/client';
+import { useAuth } from '@/src/auth/AuthContext';
+import { Card, Pill, SectionLabel, Txt } from '@/src/components/ui';
+import { colors, font } from '@/src/theme/tokens';
+
+const PLAN_LABELS: Record<Billing['plan'], string> = {
+	free: 'Free',
+};
+
+export default function BillingScreen() {
+	const { session, client } = useAuth();
+	const token = session?.token;
+	const isOwner = session?.role === 'owner';
+
+	const [billing, setBilling] = useState<Billing | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		if (!token || !isOwner) {
+			setLoading(false);
+			return;
+		}
+		setLoading(true);
+		setError(null);
+		try {
+			setBilling(await client.getBilling(token));
+		} catch (caught) {
+			setError(caught instanceof ApiError ? caught.message : 'Could not load billing.');
+		} finally {
+			setLoading(false);
+		}
+	}, [client, token, isOwner]);
+
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	if (!session) {
+		return null;
+	}
+
+	if (!isOwner) {
+		return (
+			<ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+				<Txt style={styles.h1}>Billing</Txt>
+				<Card style={styles.card}>
+					<Txt style={styles.rowSub}>
+						Only the account Owner can view or manage billing. Ask an Owner if you need access.
+					</Txt>
+				</Card>
+			</ScrollView>
+		);
+	}
+
+	return (
+		<ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+			<Txt style={styles.h1}>Billing</Txt>
+			<Txt style={styles.subtitle}>Your plan and usage for {session.account.name}.</Txt>
+
+			<Card style={styles.card}>
+				<SectionLabel>Current plan</SectionLabel>
+				{loading ? (
+					<ActivityIndicator color={colors.brandPurple} style={styles.loading} />
+				) : error ? (
+					<Txt style={styles.errorTxt}>{error}</Txt>
+				) : billing ? (
+					<>
+						<View style={styles.planRow}>
+							<Txt style={styles.plan}>{PLAN_LABELS[billing.plan]}</Txt>
+							<Pill
+								label={billing.status === 'active' ? 'Active' : 'Canceled'}
+								color={colors.brandPurpleInk}
+								background="rgba(110,30,200,0.08)"
+							/>
+						</View>
+						<View style={styles.statRow}>
+							<Txt style={styles.statLabel}>Seats in use</Txt>
+							<Txt style={styles.statValue}>{billing.seats}</Txt>
+						</View>
+						<Txt style={styles.note}>
+							Paid plans aren’t available yet — every account is on the free plan while we finish
+							wiring up billing.
+						</Txt>
+					</>
+				) : null}
+			</Card>
+		</ScrollView>
+	);
+}
+
+const styles = StyleSheet.create({
+	content: {
+		padding: 26,
+		gap: 16,
+		maxWidth: 760,
+		width: '100%',
+		alignSelf: 'center',
+	},
+	h1: {
+		fontFamily: font.bold,
+		fontSize: 22,
+		color: colors.text,
+	},
+	subtitle: {
+		fontFamily: font.regular,
+		fontSize: 13.5,
+		color: colors.textMuted,
+		marginTop: -8,
+	},
+	card: {
+		gap: 12,
+	},
+	loading: {
+		paddingVertical: 12,
+	},
+	planRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+	},
+	plan: {
+		fontFamily: font.bold,
+		fontSize: 20,
+		color: colors.text,
+	},
+	statRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		borderTopWidth: 1,
+		borderTopColor: colors.border,
+		paddingTop: 12,
+	},
+	statLabel: {
+		fontFamily: font.regular,
+		fontSize: 13,
+		color: colors.textMuted,
+	},
+	statValue: {
+		fontFamily: font.semibold,
+		fontSize: 15,
+		color: colors.text,
+	},
+	rowSub: {
+		fontFamily: font.regular,
+		fontSize: 12.5,
+		color: colors.textMuted,
+	},
+	errorTxt: {
+		fontFamily: font.medium,
+		fontSize: 12.5,
+		color: colors.redInk,
+	},
+	note: {
+		fontFamily: font.regular,
+		fontSize: 12,
+		color: colors.textFaint,
+	},
+});

--- a/packages/app/app/settings.tsx
+++ b/packages/app/app/settings.tsx
@@ -1,0 +1,253 @@
+import { useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { ApiError } from '@/src/api/client';
+import { deviceTimezone, listTimezones } from '@/src/api/timezones';
+import { useAuth } from '@/src/auth/AuthContext';
+import {
+	Card,
+	GradientButton,
+	OutlineButton,
+	SectionLabel,
+	Select,
+	TextField,
+	Txt,
+} from '@/src/components/ui';
+import { colors, font } from '@/src/theme/tokens';
+
+function messageFor(error: unknown, fallback: string): string {
+	if (error instanceof ApiError || error instanceof Error) {
+		return error.message;
+	}
+	return fallback;
+}
+
+export default function SettingsScreen() {
+	const { session, updateAccount, cancelAccount } = useAuth();
+	const account = session?.account;
+
+	const [businessName, setBusinessName] = useState(account?.name ?? '');
+	const [phone, setPhone] = useState(account?.phone ?? '');
+	const [address, setAddress] = useState(account?.address ?? '');
+	const [website, setWebsite] = useState(account?.website ?? '');
+	const [timezone, setTimezone] = useState(account?.timezone || deviceTimezone());
+
+	const [saving, setSaving] = useState(false);
+	const [saved, setSaved] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const [confirmingCancel, setConfirmingCancel] = useState(false);
+	const [canceling, setCanceling] = useState(false);
+	const [cancelError, setCancelError] = useState<string | null>(null);
+
+	const timezoneOptions = useMemo(
+		() => listTimezones().map((zone) => ({ label: zone.replace(/_/g, ' '), value: zone })),
+		[],
+	);
+
+	if (!session) {
+		return null;
+	}
+
+	if (session.role !== 'owner') {
+		return (
+			<ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+				<Txt style={styles.h1}>Account settings</Txt>
+				<Card style={styles.card}>
+					<Txt style={styles.rowSub}>
+						Only the account Owner can change account settings or billing. Ask an Owner if you need
+						something updated.
+					</Txt>
+				</Card>
+			</ScrollView>
+		);
+	}
+
+	async function onSave() {
+		if (saving) {
+			return;
+		}
+		setError(null);
+		setSaved(false);
+		setSaving(true);
+		try {
+			await updateAccount({
+				businessName: businessName.trim(),
+				phone: phone.trim(),
+				address: address.trim(),
+				website: website.trim(),
+				timezone: timezone.trim(),
+			});
+			setSaved(true);
+		} catch (caught) {
+			setError(messageFor(caught, 'Could not save your changes.'));
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	async function onCancelAccount() {
+		if (canceling) {
+			return;
+		}
+		setCancelError(null);
+		setCanceling(true);
+		try {
+			// On success the session is cleared and this screen unmounts back to sign-in.
+			await cancelAccount();
+		} catch (caught) {
+			setCancelError(messageFor(caught, 'Could not cancel the account.'));
+			setCanceling(false);
+		}
+	}
+
+	return (
+		<ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+			<Txt style={styles.h1}>Account settings</Txt>
+			<Txt style={styles.subtitle}>Business details for {session.account.name}.</Txt>
+
+			<Card style={styles.card}>
+				<SectionLabel>Business information</SectionLabel>
+				<View style={styles.form}>
+					<TextField
+						label="Business name"
+						value={businessName}
+						onChangeText={(next) => {
+							setBusinessName(next);
+							setSaved(false);
+						}}
+						placeholder="Cascade Plumbing & Heating"
+						autoCapitalize="words"
+					/>
+					<TextField
+						label="Phone"
+						value={phone}
+						onChangeText={setPhone}
+						placeholder="+1 (206) 555-0100"
+						keyboardType="phone-pad"
+					/>
+					<TextField
+						label="Address"
+						value={address}
+						onChangeText={setAddress}
+						placeholder="1 Main St, Seattle, WA"
+					/>
+					<TextField
+						label="Website"
+						value={website}
+						onChangeText={setWebsite}
+						placeholder="https://yourbusiness.com"
+						autoCapitalize="none"
+						keyboardType="url"
+					/>
+					<Select
+						label="Time zone"
+						value={timezone}
+						onSelect={setTimezone}
+						options={timezoneOptions}
+						searchable
+					/>
+
+					{error ? <Txt style={styles.errorTxt}>{error}</Txt> : null}
+					{saved ? <Txt style={styles.savedTxt}>Saved.</Txt> : null}
+
+					<GradientButton
+						label={saving ? 'Saving…' : 'Save changes'}
+						icon="check"
+						onPress={onSave}
+					/>
+				</View>
+			</Card>
+
+			<Card style={[styles.card, styles.dangerCard]}>
+				<SectionLabel style={styles.dangerLabel}>Danger zone</SectionLabel>
+				<Txt style={styles.rowSub}>
+					Canceling closes {session.account.name} for everyone. Your data is retained but the
+					account is locked and all members are signed out. This can only be undone by contacting
+					support.
+				</Txt>
+
+				{cancelError ? <Txt style={styles.errorTxt}>{cancelError}</Txt> : null}
+
+				{confirmingCancel ? (
+					<View style={styles.confirmRow}>
+						<GradientButton
+							label={canceling ? 'Canceling…' : 'Yes, cancel account'}
+							icon="alert-triangle"
+							onPress={onCancelAccount}
+							style={styles.confirmBtn}
+						/>
+						<OutlineButton
+							label="Keep account"
+							onPress={() => setConfirmingCancel(false)}
+							style={styles.confirmBtn}
+						/>
+					</View>
+				) : (
+					<OutlineButton
+						label="Cancel account"
+						onPress={() => setConfirmingCancel(true)}
+						style={styles.dangerBtn}
+					/>
+				)}
+			</Card>
+		</ScrollView>
+	);
+}
+
+const styles = StyleSheet.create({
+	content: {
+		padding: 26,
+		gap: 16,
+		maxWidth: 760,
+		width: '100%',
+		alignSelf: 'center',
+	},
+	h1: {
+		fontFamily: font.bold,
+		fontSize: 22,
+		color: colors.text,
+	},
+	subtitle: {
+		fontFamily: font.regular,
+		fontSize: 13.5,
+		color: colors.textMuted,
+		marginTop: -8,
+	},
+	card: {
+		gap: 12,
+	},
+	form: {
+		gap: 13,
+	},
+	rowSub: {
+		fontFamily: font.regular,
+		fontSize: 12.5,
+		color: colors.textMuted,
+	},
+	errorTxt: {
+		fontFamily: font.medium,
+		fontSize: 12.5,
+		color: colors.redInk,
+	},
+	savedTxt: {
+		fontFamily: font.medium,
+		fontSize: 12.5,
+		color: colors.green,
+	},
+	dangerCard: {
+		borderColor: 'rgba(240,88,75,0.35)',
+	},
+	dangerLabel: {
+		color: colors.redInk,
+	},
+	dangerBtn: {
+		borderColor: 'rgba(240,88,75,0.45)',
+	},
+	confirmRow: {
+		flexDirection: 'row',
+		gap: 10,
+	},
+	confirmBtn: {
+		flex: 1,
+	},
+});

--- a/packages/app/app/team.tsx
+++ b/packages/app/app/team.tsx
@@ -20,8 +20,6 @@ import {
 } from '@/src/components/ui';
 import { colors, font, radii } from '@/src/theme/tokens';
 
-type InvitableRole = Exclude<Role, 'owner'>;
-
 function rolePillColors(role: Role): { color: string; background: string } {
 	if (role === 'owner') {
 		return { color: colors.purpleTintInk, background: colors.purpleTint };
@@ -36,14 +34,15 @@ export default function TeamScreen() {
 	const { session, client } = useAuth();
 	const token = session?.token;
 	const canInvite = session?.role === 'owner' || session?.role === 'manager';
-	// Managers may only add Team Members; owners may add either.
-	const roleOptions: { label: string; value: InvitableRole }[] =
+	// Owners may grant any role; managers may only add Members.
+	const roleOptions: { label: string; value: Role }[] =
 		session?.role === 'owner'
 			? [
+					{ label: 'Owner', value: 'owner' },
 					{ label: 'Manager', value: 'manager' },
-					{ label: 'Team Member', value: 'team_member' },
+					{ label: 'Member', value: 'member' },
 				]
-			: [{ label: 'Team Member', value: 'team_member' }];
+			: [{ label: 'Member', value: 'member' }];
 
 	const [members, setMembers] = useState<Member[]>([]);
 	const [invites, setInvites] = useState<InviteSummary[]>([]);
@@ -52,7 +51,7 @@ export default function TeamScreen() {
 
 	const [inviteName, setInviteName] = useState('');
 	const [inviteEmail, setInviteEmail] = useState('');
-	const [inviteRole, setInviteRole] = useState<InvitableRole>('team_member');
+	const [inviteRole, setInviteRole] = useState<Role>('member');
 	const [inviteError, setInviteError] = useState<string | null>(null);
 	const [lastInvite, setLastInvite] = useState<Invite | null>(null);
 	const [sending, setSending] = useState(false);

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -35,12 +35,14 @@ function makeAccount() {
 		address: '',
 		website: '',
 		timezone: 'UTC',
+		status: 'active' as const,
+		canceledAt: null,
 		createdAt: now,
 		updatedAt: now,
 	};
 }
 
-function makeAuthResponse(role: 'owner' | 'manager' | 'team_member' = 'owner') {
+function makeAuthResponse(role: 'owner' | 'manager' | 'member' = 'owner') {
 	return { token: faker.string.alphanumeric(40), user: makeUser(), account: makeAccount(), role };
 }
 
@@ -228,7 +230,7 @@ describe('createApiClient', () => {
 
 	describe('acceptInvite', () => {
 		it('joins an account with just the token and returns the session', async () => {
-			const response = makeAuthResponse('team_member');
+			const response = makeAuthResponse('member');
 			fetchMock.mockResolvedValueOnce(jsonResponse(response, { status: 201 }));
 
 			const client = createApiClient(BASE, fetchMock);
@@ -293,7 +295,7 @@ describe('createApiClient', () => {
 				id: faker.string.uuid(),
 				email: 'newhire@example.com',
 				name: 'New Hire',
-				role: 'team_member' as const,
+				role: 'member' as const,
 				status: 'pending' as const,
 				token: 'invite-token',
 				createdAt: now,
@@ -304,7 +306,7 @@ describe('createApiClient', () => {
 			const result = await client.inviteMember('owner-token', {
 				email: invite.email,
 				name: invite.name,
-				role: 'team_member',
+				role: 'member',
 			});
 
 			expect(result).toEqual(invite);
@@ -319,9 +321,66 @@ describe('createApiClient', () => {
 		it('rejects an invalid invite before hitting the network', async () => {
 			const client = createApiClient(BASE, fetchMock);
 			await expect(
-				client.inviteMember('tok', { email: 'not-an-email', name: 'X', role: 'team_member' }),
+				client.inviteMember('tok', { email: 'not-an-email', name: 'X', role: 'member' }),
 			).rejects.toThrow();
 			expect(fetchMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('updateAccount', () => {
+		it('PATCHes the account with the bearer token and returns it', async () => {
+			const account = makeAccount();
+			fetchMock.mockResolvedValueOnce(jsonResponse({ ...account, name: 'Renamed Co' }));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.updateAccount('owner-token', { businessName: 'Renamed Co' });
+
+			expect(result.name).toBe('Renamed Co');
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/account`);
+			expect(init.method).toBe('PATCH');
+			expect(JSON.parse(init.body as string)).toEqual({ businessName: 'Renamed Co' });
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer owner-token' });
+		});
+
+		it('rejects an empty update before hitting the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.updateAccount('tok', {})).rejects.toThrow();
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('cancelAccount', () => {
+		it('POSTs to the cancel endpoint and returns the canceled account', async () => {
+			const account = {
+				...makeAccount(),
+				status: 'canceled' as const,
+				canceledAt: new Date().toISOString(),
+			};
+			fetchMock.mockResolvedValueOnce(jsonResponse(account));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.cancelAccount('owner-token');
+
+			expect(result.status).toBe('canceled');
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/account/cancel`);
+			expect(init.method).toBe('POST');
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer owner-token' });
+		});
+	});
+
+	describe('getBilling', () => {
+		it('GETs the billing summary with the bearer token', async () => {
+			fetchMock.mockResolvedValueOnce(jsonResponse({ plan: 'free', status: 'active', seats: 3 }));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.getBilling('owner-token');
+
+			expect(result).toEqual({ plan: 'free', status: 'active', seats: 3 });
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/billing`);
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer owner-token' });
 		});
 	});
 

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -3,6 +3,7 @@ import {
 	type Account,
 	type AccountId,
 	acceptInviteSchema,
+	accountStatusSchema,
 	type InviteMemberInput,
 	type Item,
 	type ItemId,
@@ -16,8 +17,10 @@ import {
 	type Role,
 	roleSchema,
 	signupSchema,
+	type UpdateAccountInput,
 	type User,
 	type UserId,
+	updateAccountSchema,
 	type VerifyCodeInput,
 	verifyCodeSchema,
 } from '@rivus/core';
@@ -105,6 +108,8 @@ const accountResponseSchema = z.object({
 	address: z.string(),
 	website: z.string(),
 	timezone: z.string(),
+	status: accountStatusSchema,
+	canceledAt: z.string().nullable(),
 	createdAt: z.string(),
 	updatedAt: z.string(),
 }) satisfies z.ZodType<Account>;
@@ -147,7 +152,7 @@ const inviteSummarySchema = z.object({
 	id: z.string(),
 	email: z.string(),
 	name: z.string(),
-	role: z.enum(['manager', 'team_member']),
+	role: roleSchema,
 	status: z.enum(['pending', 'accepted', 'revoked']),
 	createdAt: z.string(),
 });
@@ -162,6 +167,15 @@ const memberListResponseSchema = z.object({
 	invites: z.array(inviteSummarySchema),
 });
 export type MemberList = z.infer<typeof memberListResponseSchema>;
+
+// Billing placeholder — no payment provider is wired up yet, so every account is
+// on the free plan and `seats` mirrors the member count.
+const billingResponseSchema = z.object({
+	plan: z.literal('free'),
+	status: accountStatusSchema,
+	seats: z.number().int(),
+});
+export type Billing = z.infer<typeof billingResponseSchema>;
 
 const itemResponseSchema = z.object({
 	id: itemId(),
@@ -221,6 +235,12 @@ export interface RivusApiClient {
 	me(token: string): Promise<Session>;
 	listMembers(token: string): Promise<MemberList>;
 	inviteMember(token: string, input: InviteMemberInput): Promise<Invite>;
+	/** Update the account's business settings (owner only). */
+	updateAccount(token: string, input: UpdateAccountInput): Promise<Account>;
+	/** Cancel (soft-delete) the account (owner only). */
+	cancelAccount(token: string): Promise<Account>;
+	/** Read the account's billing summary (owner only). */
+	getBilling(token: string): Promise<Billing>;
 	listItems(token: string, query?: Partial<PaginationQuery>): Promise<ItemListResponse>;
 }
 
@@ -308,6 +328,25 @@ export function createApiClient(baseUrl: string, fetchImpl: FetchLike = fetch): 
 		async inviteMember(token: string, input: InviteMemberInput) {
 			const payload = parseInput(inviteMemberSchema, input);
 			return request('/v1/members/invites', inviteResponseSchema, jsonInit('POST', payload, token));
+		},
+
+		async updateAccount(token: string, input: UpdateAccountInput) {
+			const payload = parseInput(updateAccountSchema, input);
+			return request('/v1/account', accountResponseSchema, jsonInit('PATCH', payload, token));
+		},
+
+		cancelAccount(token: string) {
+			return request('/v1/account/cancel', accountResponseSchema, {
+				method: 'POST',
+				headers: authHeaders(token),
+			});
+		},
+
+		getBilling(token: string) {
+			return request('/v1/billing', billingResponseSchema, {
+				method: 'GET',
+				headers: authHeaders(token),
+			});
 		},
 
 		async listItems(token: string, query?: Partial<PaginationQuery>) {

--- a/packages/app/src/auth/AuthContext.tsx
+++ b/packages/app/src/auth/AuthContext.tsx
@@ -1,4 +1,4 @@
-import type { LoginInput, VerifyCodeInput } from '@rivus/core';
+import type { LoginInput, UpdateAccountInput, VerifyCodeInput } from '@rivus/core';
 import { createContext, type ReactNode, useContext, useMemo, useState } from 'react';
 import {
 	type AuthResponse,
@@ -21,6 +21,10 @@ export interface AuthContextValue {
 	/** Exchange a one-time code for a session. */
 	verifyCode: (input: VerifyCodeInput) => Promise<void>;
 	acceptInvite: (token: string) => Promise<void>;
+	/** Update the account's business settings, keeping the session in sync (owner only). */
+	updateAccount: (input: UpdateAccountInput) => Promise<void>;
+	/** Cancel (soft-delete) the account, then sign out since it's now locked (owner only). */
+	cancelAccount: () => Promise<void>;
 	signOut: () => void;
 }
 
@@ -51,6 +55,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 			async acceptInvite(token) {
 				setSession(await client.acceptInvite({ token }));
 			},
+			async updateAccount(input) {
+				if (!session) {
+					return;
+				}
+				const account = await client.updateAccount(session.token, input);
+				setSession({ ...session, account });
+			},
+			async cancelAccount() {
+				if (!session) {
+					return;
+				}
+				await client.cancelAccount(session.token);
+				// The account is now canceled, so every authed call would 401 — drop the session.
+				setSession(null);
+			},
 			signOut() {
 				setSession(null);
 			},
@@ -77,7 +96,7 @@ export function roleLabel(role: AuthResponse['role']): string {
 		case 'manager':
 			return 'Manager';
 		default:
-			return 'Team Member';
+			return 'Member';
 	}
 }
 

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it } from 'vitest';
 import {
 	acceptInviteSchema,
 	accountBusinessSchema,
+	accountStatusSchema,
 	createItemSchema,
 	inviteMemberSchema,
 	loginSchema,
 	paginationQuerySchema,
 	signupSchema,
+	updateAccountSchema,
 	updateItemSchema,
 	updateMemberRoleSchema,
 	verifyCodeSchema,
@@ -131,18 +133,49 @@ describe('signupSchema', () => {
 });
 
 describe('inviteMemberSchema', () => {
-	it('accepts manager and team_member roles', () => {
-		for (const role of ['manager', 'team_member'] as const) {
+	it('accepts every known role (per-inviter limits are enforced server-side)', () => {
+		for (const role of ['owner', 'manager', 'member'] as const) {
 			expect(
 				inviteMemberSchema.parse({ email: faker.internet.email(), name: 'Pat', role }).role,
 			).toBe(role);
 		}
 	});
 
-	it('rejects inviting someone as owner', () => {
+	it('rejects an unknown role', () => {
 		expect(() =>
-			inviteMemberSchema.parse({ email: faker.internet.email(), name: 'Pat', role: 'owner' }),
+			inviteMemberSchema.parse({ email: faker.internet.email(), name: 'Pat', role: 'admin' }),
 		).toThrow();
+	});
+});
+
+describe('accountStatusSchema', () => {
+	it('accepts active and canceled', () => {
+		expect(accountStatusSchema.parse('active')).toBe('active');
+		expect(accountStatusSchema.parse('canceled')).toBe('canceled');
+	});
+
+	it('rejects an unknown status', () => {
+		expect(() => accountStatusSchema.parse('deleted')).toThrow();
+	});
+});
+
+describe('updateAccountSchema', () => {
+	it('accepts a partial update of one field', () => {
+		expect(updateAccountSchema.parse({ phone: '+1 206 555 0100' })).toEqual({
+			phone: '+1 206 555 0100',
+		});
+	});
+
+	it('trims and keeps the business name', () => {
+		expect(updateAccountSchema.parse({ businessName: '  Acme  ' }).businessName).toBe('Acme');
+	});
+
+	it('rejects an empty update', () => {
+		expect(() => updateAccountSchema.parse({})).toThrow();
+	});
+
+	it('rejects a malformed website', () => {
+		expect(() => updateAccountSchema.parse({ website: 'not a url' })).toThrow();
 	});
 });
 

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -66,13 +66,13 @@ export type VerifyCodeInput = z.infer<typeof verifyCodeSchema>;
 // `Role` itself is the source-of-truth union in `types.ts` (mirrors the
 // `ItemStatus`/`itemStatusSchema` split); here we only need the runtime schema.
 /** Every role a member can hold. */
-export const roleSchema = z.enum(['owner', 'manager', 'team_member'], {
+export const roleSchema = z.enum(['owner', 'manager', 'member'], {
 	error: 'Choose a valid role.',
 });
 
-/** Roles that can be granted to an invited member (ownership is not invitable). */
-export const assignableRoleSchema = z.enum(['manager', 'team_member'], {
-	error: 'Choose either Manager or Team Member.',
+/** Lifecycle state of an account (`canceled` is a soft delete). */
+export const accountStatusSchema = z.enum(['active', 'canceled'], {
+	error: 'Status must be either active or canceled.',
 });
 
 export const businessNameSchema = requiredText('Business name', 160);
@@ -110,11 +110,15 @@ export const signupSchema = z.object({
 });
 export type SignupInput = z.infer<typeof signupSchema>;
 
-/** Invite a new Manager or Team Member to an existing account. */
+/**
+ * Invite a new member to an existing account with any role. Which roles a given
+ * inviter may actually grant (an owner can grant any; a manager only `member`)
+ * is enforced server-side, not by this shape.
+ */
 export const inviteMemberSchema = z.object({
 	email: emailSchema,
 	name: nameSchema,
-	role: assignableRoleSchema,
+	role: roleSchema,
 });
 export type InviteMemberInput = z.infer<typeof inviteMemberSchema>;
 
@@ -135,6 +139,25 @@ export const updateMemberRoleSchema = z.object({
 	role: roleSchema,
 });
 export type UpdateMemberRoleInput = z.infer<typeof updateMemberRoleSchema>;
+
+/**
+ * Update an account's business information (owner-only account settings). Every
+ * field is optional — like {@link updateItemSchema}, a partial update only
+ * touches what the caller sends — but at least one must be present. The slug is
+ * derived from the name and is not editable here.
+ */
+export const updateAccountSchema = z
+	.object({
+		businessName: businessNameSchema.optional(),
+		phone: phoneSchema.optional(),
+		address: addressSchema.optional(),
+		website: websiteSchema.optional(),
+		timezone: timezoneSchema.optional(),
+	})
+	.refine((value) => Object.values(value).some((field) => field !== undefined), {
+		error: 'Provide at least one field to update.',
+	});
+export type UpdateAccountInput = z.infer<typeof updateAccountSchema>;
 
 export const itemStatusSchema = z.enum(['active', 'archived'], {
 	error: 'Status must be either active or archived.',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -23,11 +23,19 @@ export interface User {
 
 /**
  * A role within a business account, in ascending order of privilege:
- * - `team_member` — works in the account's data, cannot manage members.
- * - `manager` — additionally invites/removes Team Members.
- * - `owner` — full control: billing, deleting the account, and managing roles.
+ * - `member` — works in the account's data; cannot invite or manage members.
+ * - `manager` — everything a member can, plus inviting/removing members and
+ *   managing roles, but not billing or account settings.
+ * - `owner` — full control, including billing, account settings, and canceling
+ *   the account.
  */
-export type Role = 'owner' | 'manager' | 'team_member';
+export type Role = 'owner' | 'manager' | 'member';
+
+/**
+ * Lifecycle of an account. `canceled` is a soft delete: the owner closed the
+ * account but its data is retained (and access is blocked) rather than purged.
+ */
+export type AccountStatus = 'active' | 'canceled';
 
 /** A business account — the tenant that owns all of its members' data. */
 export interface Account {
@@ -41,6 +49,10 @@ export interface Account {
 	website: string;
 	/** IANA time zone, e.g. `America/Los_Angeles`. */
 	timezone: string;
+	/** Lifecycle state; `canceled` accounts are soft-deleted and locked out. */
+	status: AccountStatus;
+	/** When the account was canceled, or `null` while it is active. */
+	canceledAt: IsoDateString | null;
 	createdAt: IsoDateString;
 	updatedAt: IsoDateString;
 }
@@ -64,7 +76,7 @@ export interface Invite {
 	accountId: AccountId;
 	email: string;
 	name: string;
-	role: Exclude<Role, 'owner'>;
+	role: Role;
 	status: InviteStatus;
 	/** Opaque token the invitee presents to accept the invitation. */
 	token: string;

--- a/packages/docs/site/docs/api.md
+++ b/packages/docs/site/docs/api.md
@@ -34,14 +34,16 @@ curl -s http://localhost:4000/v1/auth/me \
 ## Accounts & roles
 
 Every user belongs to one **account**, which owns all of its members' data.
-Members hold one of three roles — **Owner**, **Manager**, or **Team Member** —
-and Owners/Managers add teammates via tokenized invites:
+Members hold one of three roles — **Owner**, **Manager**, or **Member** — and
+Owners/Managers add teammates via tokenized invites. An Owner can invite any role
+(including another Owner); a Manager can only invite Members. Billing and account
+settings are Owner-only.
 
 ```bash
 # Owner or Manager invites a teammate (returns an invite token)
 curl -s -X POST http://localhost:4000/v1/members/invites \
   -H "authorization: Bearer $TOKEN" -H 'content-type: application/json' \
-  -d '{"email":"sam@example.com","name":"Sam","role":"team_member"}'
+  -d '{"email":"sam@example.com","name":"Sam","role":"member"}'
 
 # The invitee accepts and sets a password to join the account
 curl -s -X POST http://localhost:4000/v1/auth/accept-invite \


### PR DESCRIPTION
## What & why

The "Invite a teammate" form offered only **Manager / Team Member**. This replaces it with the three-role model requested, and the permissions behind it:

| Role | Can do |
| --- | --- |
| **Owner** | Everything — including **billing**, **account settings**, and **canceling the account** (a soft delete) |
| **Manager** | Everything except billing and account settings (can invite/manage Members) |
| **Member** | Everything except team invites |

The data model already had `owner` (the account creator) and a third role stored as the literal `team_member`. Per the agreed decisions: the literal is **renamed to `member`**, **Owner is now invitable** (Owners can grant any role; Managers can invite **Members only**), and billing / account-settings / cancel-account are **built** (they didn't exist before).

## Changes

**`@rivus/core`**
- `Role` is now `owner | manager | member`; added `AccountStatus` and account `status` / `canceledAt`.
- New `accountStatusSchema` and `updateAccountSchema`; invites accept any role (per-inviter limits enforced server-side).

**`@rivus/api`**
- Members: Owners invite any role; Managers may only invite / revoke / remove **Members** (never Managers or Owners — prevents privilege escalation).
- New **owner-only** routes: `PATCH /v1/account` (business settings), `POST /v1/account/cancel` (soft delete), `GET /v1/billing` (free-plan placeholder).
- `authenticate` now locks out **canceled** accounts on every request, and a canceled account can no longer accept a pending invite.
- Account repositories gain `update` / `cancel`; soft delete retains the row and its data.

**`@rivus/app`**
- Invite selector now offers **Owner / Manager / Member** (Managers see Member only).
- New owner-only **Billing** and **Account Settings** screens (Settings hosts the cancel-account danger zone with a confirm step), gated in the nav.
- `AuthContext` gains `updateAccount` / `cancelAccount` (cancel clears the now-locked session); client gains the matching methods.

**Docs & migration**
- Regenerated `openapi.json`, refreshed the API README and docs site.
- Added `pnpm --filter @rivus/api migrate:roles` + script to rewrite legacy `team_member` → `member` rows (idempotent).

## Testing

`pnpm lint && pnpm type-check && pnpm test` all pass. Test counts: core 57, **api 124**, app 49, worker 14, website 43. Coverage stays above thresholds (new routes, repos, schemas, and client methods are covered; owner-only 403s, the canceled-account lockout, owner-invite, and the manager restriction all have tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018uW5p1k6JrLgGmSchMa4er)_