### PR TITLE
feat(app): handle the invite email's accept link end-to-end

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -57,7 +57,7 @@ function isActive(pathname: string, href: string): boolean {
 }
 
 /** Paths that render their own auth screen instead of the dashboard shell. */
-const AUTH_PATHS = ['/login', '/signup'];
+const AUTH_PATHS = ['/login', '/signup', '/accept-invite'];
 
 function isAuthPath(pathname: string): boolean {
 	const normalized = pathname.replace(/\/+$/, '') || '/';
@@ -96,8 +96,8 @@ function Gate() {
 	const onAuthRoute = isAuthPath(pathname);
 
 	if (!session) {
-		// Signed out: /login and /signup render their own screen; every other
-		// path (the root included) falls back to the sign-in screen.
+		// Signed out: /login, /signup and /accept-invite render their own screen;
+		// every other path (the root included) falls back to the sign-in screen.
 		return onAuthRoute ? <Slot /> : <AuthScreen initialMode="signin" />;
 	}
 

--- a/packages/app/app/accept-invite.tsx
+++ b/packages/app/app/accept-invite.tsx
@@ -9,5 +9,7 @@ import { AuthScreen } from '@/src/auth/AuthScreen';
 export default function AcceptInviteScreen() {
 	const { token } = useLocalSearchParams();
 	const inviteToken = Array.isArray(token) ? (token[0] ?? '') : (token ?? '');
-	return <AuthScreen initialMode="invite" initialInviteToken={inviteToken} />;
+	// `AuthScreen` seeds its state from `initialInviteToken` once (via useState), so
+	// key on the token to remount — and pick up the new code — if the link changes.
+	return <AuthScreen key={inviteToken} initialMode="invite" initialInviteToken={inviteToken} />;
 }

--- a/packages/app/app/accept-invite.tsx
+++ b/packages/app/app/accept-invite.tsx
@@ -1,0 +1,13 @@
+import { useLocalSearchParams } from 'expo-router';
+import { AuthScreen } from '@/src/auth/AuthScreen';
+
+/**
+ * Landing screen for the link in an invitation email
+ * (`<APP_URL>/accept-invite?token=…`). It opens the "join a team" form with the
+ * invite code pre-filled so the invitee only has to confirm to join.
+ */
+export default function AcceptInviteScreen() {
+	const { token } = useLocalSearchParams();
+	const inviteToken = Array.isArray(token) ? (token[0] ?? '') : (token ?? '');
+	return <AuthScreen initialMode="invite" initialInviteToken={inviteToken} />;
+}

--- a/packages/app/app/team.tsx
+++ b/packages/app/app/team.tsx
@@ -192,9 +192,10 @@ export default function TeamScreen() {
 
 						{lastInvite ? (
 							<View style={styles.callout}>
-								<Txt style={styles.calloutTitle}>Invite created for {lastInvite.email}</Txt>
+								<Txt style={styles.calloutTitle}>Invitation sent to {lastInvite.email}</Txt>
 								<Txt style={styles.calloutBody}>
-									Email delivery isn’t wired up yet — share this invite code so they can join:
+									We’ve emailed them a link to accept and join {session.account.name}. Prefer to
+									share it yourself? They can also join with this code:
 								</Txt>
 								<Txt selectable style={styles.code}>
 									{lastInvite.token}

--- a/packages/app/app/team.tsx
+++ b/packages/app/app/team.tsx
@@ -192,10 +192,10 @@ export default function TeamScreen() {
 
 						{lastInvite ? (
 							<View style={styles.callout}>
-								<Txt style={styles.calloutTitle}>Invitation sent to {lastInvite.email}</Txt>
+								<Txt style={styles.calloutTitle}>Invitation created for {lastInvite.email}</Txt>
 								<Txt style={styles.calloutBody}>
-									We’ve emailed them a link to accept and join {session.account.name}. Prefer to
-									share it yourself? They can also join with this code:
+									We’ve emailed them a link to join {session.account.name}. If it doesn’t arrive,
+									share this code so they can join:
 								</Txt>
 								<Txt selectable style={styles.code}>
 									{lastInvite.token}

--- a/packages/app/src/auth/AuthScreen.tsx
+++ b/packages/app/src/auth/AuthScreen.tsx
@@ -25,7 +25,7 @@ const COPY: Record<Mode, { title: string; subtitle: string; submit: string }> = 
 	},
 	invite: {
 		title: 'Join your team',
-		subtitle: 'Paste the invite code you were sent to join your team.',
+		subtitle: 'Use the invite code you were sent to join your team.',
 		submit: 'Join the team',
 	},
 };
@@ -43,9 +43,14 @@ function messageFor(error: unknown): string {
 type AuthScreenProps = {
 	/** Which form the screen opens on. Each auth route picks its own. */
 	initialMode?: Mode;
+	/** Invite code to pre-fill, supplied by the accept-invite email link. */
+	initialInviteToken?: string;
 };
 
-export function AuthScreen({ initialMode = 'signin' }: AuthScreenProps = {}) {
+export function AuthScreen({
+	initialMode = 'signin',
+	initialInviteToken = '',
+}: AuthScreenProps = {}) {
 	const router = useRouter();
 	const { signUp, signIn, verifyCode, acceptInvite } = useAuth();
 	const [mode, setMode] = useState<Mode>(initialMode);
@@ -58,7 +63,7 @@ export function AuthScreen({ initialMode = 'signin' }: AuthScreenProps = {}) {
 	const [timezone, setTimezone] = useState(() => deviceTimezone());
 	const [name, setName] = useState('');
 	const [email, setEmail] = useState('');
-	const [inviteToken, setInviteToken] = useState('');
+	const [inviteToken, setInviteToken] = useState(initialInviteToken);
 	const [code, setCode] = useState('');
 	const [pendingEmail, setPendingEmail] = useState('');
 


### PR DESCRIPTION
## Why

Invitation emails are now delivered (Resend, wired in `feat(api): send invitation emails via Resend`). Each email links the invitee to `<APP_URL>/accept-invite?token=…`.

But the app had **no route** for that path. So clicking the emailed link:
- **signed in** → rendered Expo Router's built-in *"Unmatched Route"* (`+not-found`) screen — i.e. it errored out; or
- **signed out** → fell through `Gate` to the sign-in screen and silently dropped the token.

Either way, an invite could never be accepted from the email, and the Team page still told users *"Email delivery isn't wired up yet."*

## What

- **Add `app/accept-invite.tsx`** — reads the `token` query param and opens the "Join your team" form with the invite code pre-filled, so the invitee just taps **Join the team**.
- **`AuthScreen` gains an `initialInviteToken` prop** so the code arrives filled in (and the invite subtitle reads naturally whether the code is pre-filled or pasted).
- **Treat `/accept-invite` as an auth path** in the root `Gate`, so a signed-out invitee lands on the invite screen (a signed-in user is redirected home, consistent with `/login` & `/signup`).
- **Refresh the Team page copy**: confirm the invitation was emailed, and keep the invite code as a manual fallback rather than claiming delivery isn't wired up.

The API side (persist invite → send email best-effort → `POST /v1/auth/accept-invite`) was already in place and tested; this PR connects the emailed link to the app so the flow works end-to-end.

## End-to-end flow

1. Owner/Manager sends an invite on the Team page → API persists it and emails the link via Resend.
2. Invitee opens `…/accept-invite?token=…` → new route shows **Join your team** with the code pre-filled.
3. Invitee taps **Join the team** → `POST /v1/auth/accept-invite` creates their user + membership and returns a session → they're in.

## Verification

- `pnpm lint && pnpm type-check && pnpm test` all pass (290 tests).
- `pnpm --filter @rivus/app export:web` now emits `/accept-invite` as a static route (previously absent, which is why the link resolved to `/+not-found`).

> Note: test the link from a **signed-out** browser/incognito — that's the real invitee experience. Accepting an invite while signed in as a different account (account switching) is intentionally out of scope; those users are redirected home for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDvjRbBN6EsDQhwLNhFgfh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDvjRbBN6EsDQhwLNhFgfh)_