### PR TITLE
fix(auth): keep web sessions signed in across reloads via HttpOnly cookie

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -113,8 +113,12 @@ with `NODE_ENV=production` and would crash-loop without them.
 
 The production API also restricts CORS to Rivus origins: `CORS_ORIGIN` is set to
 `https://rivus.ai,*.rivus.ai`, which the API parses into the exact apex origin
-plus a regex matching any `*.rivus.ai` subdomain (development stays `*`). The
-value accepts a comma-separated list of exact origins and/or `*` wildcards;
+plus a regex matching any `*.rivus.ai` subdomain. The deployed development
+environment uses `*.rivus.ai` (which covers `dev-app.rivus.ai`) — both containers
+run `NODE_ENV=production`, and the API refuses to boot with a `*` wildcard there
+because credentialed CORS reflects the request origin, so a wildcard would
+authorize every site. Only local development (`NODE_ENV=development`) stays `*`.
+The value accepts a comma-separated list of exact origins and/or `*` wildcards;
 adjust it in `packages/api/wrangler.jsonc`.
 
 ## Deploying by hand

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -431,6 +431,26 @@
         }
       }
     },
+    "/v1/auth/logout": {
+      "post": {
+        "summary": "Sign out — clears the session cookie",
+        "tags": [
+          "auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignedOut"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/members/": {
       "get": {
         "summary": "List members and pending invites for your account",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,6 +20,7 @@
 		"clean": "rm -rf dist coverage"
 	},
 	"dependencies": {
+		"@fastify/cookie": "^11.0.2",
 		"@fastify/cors": "^11.2.0",
 		"@fastify/helmet": "^13.0.2",
 		"@fastify/jwt": "^10.1.0",

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -98,7 +98,16 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	});
 
 	app.register(sensible);
-	app.register(cors, { origin: parseCorsOrigin(deps.config.CORS_ORIGIN) });
+	const corsOrigin = parseCorsOrigin(deps.config.CORS_ORIGIN);
+	app.register(cors, {
+		// Web clients send the session cookie cross-origin (app.rivus.ai →
+		// api.rivus.ai), which requires credentialed CORS. A credentialed request
+		// can't use a wildcard `Access-Control-Allow-Origin`, so reflect the request
+		// origin when configured wide-open (the dev default) and otherwise echo only
+		// the configured allowlist.
+		origin: corsOrigin === '*' ? true : corsOrigin,
+		credentials: true,
+	});
 	app.register(helmet, { contentSecurityPolicy: false });
 	app.register(authPlugin);
 	app.register(swaggerPlugin);

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -99,11 +99,21 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 
 	app.register(sensible);
 	const corsOrigin = parseCorsOrigin(deps.config.CORS_ORIGIN);
+	// Credentialed CORS can't safely use a wildcard: reflecting any origin while
+	// `credentials: true` lets any site make authenticated cross-origin requests and
+	// read the response. Require an explicit allowlist in production (the deployed
+	// dev and prod containers both run NODE_ENV=production); only local development
+	// may stay wide-open, where reflecting localhost origins is harmless.
+	if (deps.config.NODE_ENV === 'production' && corsOrigin === '*') {
+		throw new Error(
+			'CORS_ORIGIN must be an explicit origin allowlist in production, not "*": credentialed CORS reflects the request origin, so a wildcard would authorize every site.',
+		);
+	}
 	app.register(cors, {
 		// Web clients send the session cookie cross-origin (app.rivus.ai →
 		// api.rivus.ai), which requires credentialed CORS. A credentialed request
 		// can't use a wildcard `Access-Control-Allow-Origin`, so reflect the request
-		// origin when configured wide-open (the dev default) and otherwise echo only
+		// origin when configured wide-open (local dev only) and otherwise echo only
 		// the configured allowlist.
 		origin: corsOrigin === '*' ? true : corsOrigin,
 		credentials: true,

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -8,7 +8,7 @@ import {
 	validatorCompiler,
 } from 'fastify-type-provider-zod';
 import { parseCorsOrigin } from './config';
-import authPlugin from './plugins/auth';
+import authPlugin, { SESSION_COOKIE } from './plugins/auth';
 import swaggerPlugin from './plugins/swagger';
 import { ConflictError, InviteNotPendingError, LastOwnerError } from './repositories/errors';
 import { accountRoutes } from './routes/account';
@@ -118,6 +118,31 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 		origin: corsOrigin === '*' ? true : corsOrigin,
 		credentials: true,
 	});
+
+	// CSRF defense for cookie-authenticated writes. The session cookie rides along
+	// automatically on same-site requests, so a malicious or compromised same-site
+	// page could trigger a state-changing call with the victim's session. Bearer
+	// (native) and unauthenticated requests aren't CSRF-able, so we guard only the
+	// unsafe methods that actually carry the session cookie, and require the request
+	// to originate from the app itself. Local development (wildcard CORS) stays
+	// permissive; the deployed environments (an explicit allowlist) enforce it.
+	const appOrigin = new URL(deps.config.APP_URL).origin;
+	const enforceCsrf = corsOrigin !== '*';
+	app.addHook('onRequest', async (request) => {
+		if (!enforceCsrf || request.method === 'GET' || request.method === 'HEAD') {
+			return;
+		}
+		const hasSession = request.headers.cookie
+			?.split(';')
+			.some((entry) => entry.trimStart().startsWith(`${SESSION_COOKIE}=`));
+		if (!hasSession) {
+			return;
+		}
+		if (request.headers.origin !== appOrigin) {
+			throw app.httpErrors.forbidden('Cross-origin request blocked');
+		}
+	});
+
 	app.register(helmet, { contentSecurityPolicy: false });
 	app.register(authPlugin);
 	app.register(swaggerPlugin);

--- a/packages/api/src/http-schemas.ts
+++ b/packages/api/src/http-schemas.ts
@@ -50,6 +50,13 @@ export const codeSentResponseSchema = z
 	})
 	.meta({ id: 'CodeSent' });
 
+/** Acknowledges that the session cookie was cleared by `POST /v1/auth/logout`. */
+export const signedOutResponseSchema = z
+	.object({
+		status: z.literal('signed_out'),
+	})
+	.meta({ id: 'SignedOut' });
+
 /** Current-session view returned from `GET /v1/auth/me`. */
 export const sessionResponseSchema = z
 	.object({

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -1,14 +1,47 @@
+import fastifyCookie, { type CookieSerializeOptions } from '@fastify/cookie';
 import fastifyJwt from '@fastify/jwt';
 import type { Role } from '@rivus/core';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import fp from 'fastify-plugin';
+import type { Config } from '../config';
+
+/** Name of the HttpOnly cookie that carries the session JWT for web clients. */
+export const SESSION_COOKIE = 'rivus_session';
+
+/**
+ * Cookie attributes for the session cookie. It's `HttpOnly` so JavaScript can't
+ * read the token (XSS can't exfiltrate it), `SameSite=Lax` because the app and
+ * API are same-site subdomains of `rivus.ai` (so the cookie rides along on the
+ * app's API calls while cross-site requests don't send it), and `Secure` in
+ * production where everything is HTTPS. `maxAge` is passed in to match the JWT's
+ * own expiry so the browser drops the cookie exactly when the token dies.
+ */
+export function sessionCookieOptions(
+	config: Config,
+	maxAgeSeconds?: number,
+): CookieSerializeOptions {
+	return {
+		httpOnly: true,
+		secure: config.NODE_ENV === 'production',
+		sameSite: 'lax',
+		path: '/',
+		...(maxAgeSeconds !== undefined ? { maxAge: maxAgeSeconds } : {}),
+	};
+}
 
 /** Registers JWT signing/verification plus `authenticate` and `requireRole` guards. */
 export default fp(
 	async (app) => {
+		// The cookie parser must be registered before `@fastify/jwt` can read the
+		// token from a cookie, and before any route calls `reply.setCookie`.
+		await app.register(fastifyCookie);
 		await app.register(fastifyJwt, {
 			secret: app.deps.config.JWT_SECRET,
 			sign: { expiresIn: app.deps.config.JWT_EXPIRES_IN },
+			// Web clients authenticate via the HttpOnly cookie; native clients keep
+			// sending the bearer token. `jwtVerify` checks the Authorization header
+			// first and falls back to this cookie.
+			cookie: { cookieName: SESSION_COOKIE, signed: false },
 		});
 
 		app.decorate('authenticate', async (request: FastifyRequest, _reply: FastifyReply) => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2,18 +2,21 @@ import {
 	type AccountId,
 	acceptInviteSchema,
 	loginSchema,
+	type Role,
 	signupSchema,
 	type UserId,
 	verifyCodeSchema,
 } from '@rivus/core';
-import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import {
 	authResponseSchema,
 	codeSentResponseSchema,
 	errorResponseSchema,
 	sessionResponseSchema,
+	signedOutResponseSchema,
 } from '../http-schemas';
+import { SESSION_COOKIE, sessionCookieOptions } from '../plugins/auth';
 import { toPublicAccount, toPublicUser } from '../presenters';
 import { ConflictError } from '../repositories/errors';
 import type { PendingSignup, SignupResult, VerificationPurpose } from '../repositories/types';
@@ -46,6 +49,23 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 		void mailer
 			.sendVerificationCode({ to, code, purpose })
 			.catch((err) => request.log.error({ err }, 'failed to send verification code'));
+	}
+
+	/**
+	 * Sign a session JWT, set it as the HttpOnly session cookie (for web clients),
+	 * and return the token so it can also go in the response body (for native
+	 * clients, which have no cookie jar and send it as a bearer header). The cookie's
+	 * `maxAge` is derived from the token's own `exp` so the two expire together.
+	 */
+	async function issueSession(
+		reply: FastifyReply,
+		payload: { sub: UserId; email: string; accountId: AccountId; role: Role },
+	): Promise<string> {
+		const token = await reply.jwtSign(payload);
+		const decoded = app.jwt.decode<{ exp?: number }>(token);
+		const maxAge = decoded?.exp ? decoded.exp - Math.floor(Date.now() / 1000) : undefined;
+		reply.setCookie(SESSION_COOKIE, token, sessionCookieOptions(app.deps.config, maxAge));
+		return token;
 	}
 
 	/** Generate, store, and email a fresh one-time code for an email. */
@@ -194,7 +214,7 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 					throw app.httpErrors.unauthorized('Invalid or expired code');
 				}
 				const { user, account, membership } = await createAccount(email, record.signup);
-				const token = await reply.jwtSign({
+				const token = await issueSession(reply, {
 					sub: user.id,
 					email: user.email,
 					accountId: account.id,
@@ -220,7 +240,7 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 			if (account.status === 'canceled') {
 				throw app.httpErrors.unauthorized('Invalid or expired code');
 			}
-			const token = await reply.jwtSign({
+			const token = await issueSession(reply, {
 				sub: user.id,
 				email: user.email,
 				accountId: account.id,
@@ -297,7 +317,7 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 				role: invite.role,
 				inviteId: invite.id,
 			});
-			const token = await reply.jwtSign({
+			const token = await issueSession(reply, {
 				sub: user.id,
 				email: user.email,
 				accountId: account.id,
@@ -309,6 +329,24 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 				account: toPublicAccount(account),
 				role: membership.role,
 			});
+		},
+	);
+
+	app.post(
+		'/logout',
+		{
+			schema: {
+				tags: ['auth'],
+				summary: 'Sign out — clears the session cookie',
+				response: { 200: signedOutResponseSchema },
+			},
+		},
+		async (_request, reply) => {
+			// Clearing must use the same attributes the cookie was set with so the
+			// browser matches and expires it. No auth guard: signing out should work
+			// even with an already-expired or missing token.
+			reply.clearCookie(SESSION_COOKIE, sessionCookieOptions(app.deps.config));
+			return reply.send({ status: 'signed_out' });
 		},
 	);
 };

--- a/packages/api/test/auth.test.ts
+++ b/packages/api/test/auth.test.ts
@@ -1,6 +1,7 @@
 import type { AccountId, UserId } from '@rivus/core';
 import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SESSION_COOKIE } from '../src/plugins/auth';
 import { ConflictError } from '../src/repositories/errors';
 import { createInMemoryRepositories } from '../src/repositories/memory';
 import { hashSecret } from '../src/services/hash';
@@ -479,5 +480,70 @@ describe('accept-invite', () => {
 
 		expect(response.statusCode).toBe(409);
 		await rawApp.close();
+	});
+});
+
+describe('session cookie', () => {
+	let app: FastifyInstance;
+
+	beforeEach(async () => {
+		app = await buildTestApp();
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	type Injected = Awaited<ReturnType<FastifyInstance['inject']>>;
+	const cookieRe = new RegExp(`${SESSION_COOKIE}=([^;]*)`);
+
+	function setCookieHeader(res: Injected): string {
+		const header = res.headers['set-cookie'];
+		return Array.isArray(header) ? header.join('\n') : String(header ?? '');
+	}
+
+	function sessionCookieValue(res: Injected): string {
+		return setCookieHeader(res).match(cookieRe)?.[1] ?? '';
+	}
+
+	it('sets an HttpOnly, SameSite=Lax session cookie carrying the token on verify', async () => {
+		const email = 'cookie@example.com';
+		await requestSignup(app, signupBody({ email }));
+		const res = await verifyCode(app, email, latestCodeFor(app, email));
+
+		expect(res.statusCode).toBe(201);
+		const header = setCookieHeader(res);
+		expect(header).toContain(`${SESSION_COOKIE}=`);
+		expect(header).toContain('HttpOnly');
+		expect(header).toMatch(/SameSite=Lax/i);
+		expect(header).toContain('Path=/');
+		// The cookie carries the same JWT returned in the body (which native clients use).
+		expect(sessionCookieValue(res)).toBe(res.json().token);
+	});
+
+	it('authenticates /me with only the session cookie (no Authorization header)', async () => {
+		const email = 'cookie-me@example.com';
+		await requestSignup(app, signupBody({ email }));
+		const verified = await verifyCode(app, email, latestCodeFor(app, email));
+		const token = sessionCookieValue(verified);
+
+		const res = await app.inject({
+			method: 'GET',
+			url: '/v1/auth/me',
+			cookies: { [SESSION_COOKIE]: token },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(res.json().user.email).toBe(email);
+	});
+
+	it('clears the session cookie on logout', async () => {
+		const res = await app.inject({ method: 'POST', url: '/v1/auth/logout' });
+
+		expect(res.statusCode).toBe(200);
+		expect(res.json()).toEqual({ status: 'signed_out' });
+		// Cleared: the cookie is re-sent with an empty value so the browser drops it.
+		expect(setCookieHeader(res)).toContain(`${SESSION_COOKIE}=`);
+		expect(sessionCookieValue(res)).toBe('');
 	});
 });

--- a/packages/api/test/cors.test.ts
+++ b/packages/api/test/cors.test.ts
@@ -20,6 +20,23 @@ function buildAppWithCors(corsOrigin: string): FastifyInstance {
 	});
 }
 
+/** Build an app with a production config (with the secrets the prod guards require). */
+function buildProdApp(corsOrigin: string): FastifyInstance {
+	const repos = createInMemoryRepositories();
+	return buildApp({
+		config: loadConfig({
+			NODE_ENV: 'production',
+			JWT_SECRET: 'x'.repeat(32),
+			RESEND_API_KEY: 'test-resend-key',
+			LOG_LEVEL: 'silent',
+			CORS_ORIGIN: corsOrigin,
+		} as NodeJS.ProcessEnv),
+		...repos,
+		mailer: new RecordingMailer(),
+		ping: async () => ({ ready: true }),
+	});
+}
+
 /** Send a CORS preflight for a cross-origin POST from `origin`. */
 function preflight(app: FastifyInstance, origin: string) {
 	return app.inject({
@@ -30,10 +47,11 @@ function preflight(app: FastifyInstance, origin: string) {
 }
 
 describe('CORS', () => {
-	let app: FastifyInstance;
+	let app: FastifyInstance | undefined;
 
 	afterEach(async () => {
-		await app.close();
+		await app?.close();
+		app = undefined;
 	});
 
 	it('echoes an allowlisted origin and allows credentials (cookies)', async () => {
@@ -58,6 +76,20 @@ describe('CORS', () => {
 		const res = await preflight(app, 'https://anything.example');
 
 		expect(res.headers['access-control-allow-origin']).toBe('https://anything.example');
+		expect(res.headers['access-control-allow-credentials']).toBe('true');
+	});
+
+	it('refuses to boot with a wildcard origin in production (credentialed CORS)', () => {
+		// Reflecting any origin with credentials would authorize every site, so a
+		// `*` wildcard must fail fast under NODE_ENV=production rather than reflect.
+		expect(() => buildProdApp('*')).toThrow(/CORS_ORIGIN/);
+	});
+
+	it('boots in production with an explicit allowlist', async () => {
+		app = buildProdApp('https://rivus.ai,*.rivus.ai');
+		const res = await preflight(app, 'https://app.rivus.ai');
+
+		expect(res.headers['access-control-allow-origin']).toBe('https://app.rivus.ai');
 		expect(res.headers['access-control-allow-credentials']).toBe('true');
 	});
 });

--- a/packages/api/test/cors.test.ts
+++ b/packages/api/test/cors.test.ts
@@ -2,8 +2,9 @@ import type { FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
 import { buildApp } from '../src/app';
 import { loadConfig } from '../src/config';
+import { SESSION_COOKIE } from '../src/plugins/auth';
 import { createInMemoryRepositories } from '../src/repositories/memory';
-import { RecordingMailer } from './helpers';
+import { authHeader, RecordingMailer, signupOwner } from './helpers';
 
 /** Build an app with a specific CORS_ORIGIN so we can exercise both origin branches. */
 function buildAppWithCors(corsOrigin: string): FastifyInstance {
@@ -91,5 +92,60 @@ describe('CORS', () => {
 
 		expect(res.headers['access-control-allow-origin']).toBe('https://app.rivus.ai');
 		expect(res.headers['access-control-allow-credentials']).toBe('true');
+	});
+});
+
+describe('CSRF (cookie-authenticated writes)', () => {
+	let app: FastifyInstance | undefined;
+
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	// The default test APP_URL is https://app.rivus.ai, so that's the only origin
+	// allowed to make cookie-authenticated writes. An allowlist CORS value (not `*`)
+	// activates the guard. The session cookie value is the JWT, which `signupOwner`
+	// returns as `token`.
+	it('blocks a cookie-authenticated write from a foreign origin', async () => {
+		app = buildAppWithCors('https://app.rivus.ai,*.rivus.ai');
+		const owner = await signupOwner(app);
+
+		const res = await app.inject({
+			method: 'POST',
+			url: '/v1/account/cancel',
+			cookies: { [SESSION_COOKIE]: owner.token },
+			headers: { origin: 'https://evil.example' },
+		});
+
+		expect(res.statusCode).toBe(403);
+	});
+
+	it('allows a cookie-authenticated write from the app origin', async () => {
+		app = buildAppWithCors('https://app.rivus.ai,*.rivus.ai');
+		const owner = await signupOwner(app);
+
+		const res = await app.inject({
+			method: 'POST',
+			url: '/v1/account/cancel',
+			cookies: { [SESSION_COOKIE]: owner.token },
+			headers: { origin: 'https://app.rivus.ai' },
+		});
+
+		expect(res.statusCode).toBe(200);
+	});
+
+	it('does not guard bearer-authenticated writes (native clients)', async () => {
+		app = buildAppWithCors('https://app.rivus.ai,*.rivus.ai');
+		const owner = await signupOwner(app);
+
+		// No cookie, a bearer header, and no Origin — a native request, not CSRF-able.
+		const res = await app.inject({
+			method: 'POST',
+			url: '/v1/account/cancel',
+			headers: authHeader(owner.token),
+		});
+
+		expect(res.statusCode).toBe(200);
 	});
 });

--- a/packages/api/test/cors.test.ts
+++ b/packages/api/test/cors.test.ts
@@ -1,0 +1,63 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { loadConfig } from '../src/config';
+import { createInMemoryRepositories } from '../src/repositories/memory';
+import { RecordingMailer } from './helpers';
+
+/** Build an app with a specific CORS_ORIGIN so we can exercise both origin branches. */
+function buildAppWithCors(corsOrigin: string): FastifyInstance {
+	const repos = createInMemoryRepositories();
+	return buildApp({
+		config: loadConfig({
+			NODE_ENV: 'test',
+			JWT_SECRET: 'test-secret-value-1234',
+			CORS_ORIGIN: corsOrigin,
+		} as NodeJS.ProcessEnv),
+		...repos,
+		mailer: new RecordingMailer(),
+		ping: async () => ({ ready: true }),
+	});
+}
+
+/** Send a CORS preflight for a cross-origin POST from `origin`. */
+function preflight(app: FastifyInstance, origin: string) {
+	return app.inject({
+		method: 'OPTIONS',
+		url: '/v1/auth/login',
+		headers: { origin, 'access-control-request-method': 'POST' },
+	});
+}
+
+describe('CORS', () => {
+	let app: FastifyInstance;
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	it('echoes an allowlisted origin and allows credentials (cookies)', async () => {
+		app = buildAppWithCors('https://app.rivus.ai,https://www.rivus.ai');
+		const res = await preflight(app, 'https://app.rivus.ai');
+
+		expect(res.headers['access-control-allow-origin']).toBe('https://app.rivus.ai');
+		expect(res.headers['access-control-allow-credentials']).toBe('true');
+	});
+
+	it('does not authorize an origin outside the allowlist', async () => {
+		app = buildAppWithCors('https://app.rivus.ai,https://www.rivus.ai');
+		const res = await preflight(app, 'https://evil.example');
+
+		expect(res.headers['access-control-allow-origin']).toBeUndefined();
+	});
+
+	it('reflects the request origin when wide-open, still with credentials', async () => {
+		// The dev default `*` can't be sent verbatim on a credentialed request, so the
+		// app reflects the caller's origin instead.
+		app = buildAppWithCors('*');
+		const res = await preflight(app, 'https://anything.example');
+
+		expect(res.headers['access-control-allow-origin']).toBe('https://anything.example');
+		expect(res.headers['access-control-allow-credentials']).toBe('true');
+	});
+});

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -36,7 +36,10 @@
 			"name": "rivus-api-dev",
 			"routes": [{ "pattern": "dev-api.rivus.ai", "custom_domain": true }],
 			"vars": {
-				"CORS_ORIGIN": "*",
+				// The container runs NODE_ENV=production, where credentialed CORS
+				// forbids a `*` wildcard (it would authorize every origin). Restrict to
+				// Rivus subdomains, which covers dev-app.rivus.ai.
+				"CORS_ORIGIN": "*.rivus.ai",
 				// Base URL for the accept-invite / sign-in-code links in emails.
 				"APP_URL": "https://dev-app.rivus.ai"
 			},

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -91,9 +91,19 @@ export default function RootLayout() {
 
 /** Show the auth screens until there's a session, then the dashboard shell. */
 function Gate() {
-	const { session } = useAuth();
+	const { session, restoring } = useAuth();
 	const pathname = usePathname();
 	const onAuthRoute = isAuthPath(pathname);
+
+	// On web load we check the session cookie first; hold on a spinner so a valid
+	// session doesn't flash the sign-in screen before `me()` resolves.
+	if (restoring) {
+		return (
+			<View style={styles.loading}>
+				<ActivityIndicator color={colors.brandPurple} />
+			</View>
+		);
+	}
 
 	if (!session) {
 		// Signed out: /login, /signup and /accept-invite render their own screen;

--- a/packages/app/app/billing.tsx
+++ b/packages/app/app/billing.tsx
@@ -11,7 +11,6 @@ const PLAN_LABELS: Record<Billing['plan'], string> = {
 
 export default function BillingScreen() {
 	const { session, client } = useAuth();
-	const token = session?.token;
 	const isOwner = session?.role === 'owner';
 
 	const [billing, setBilling] = useState<Billing | null>(null);
@@ -19,20 +18,20 @@ export default function BillingScreen() {
 	const [error, setError] = useState<string | null>(null);
 
 	const load = useCallback(async () => {
-		if (!token || !isOwner) {
+		if (!session || !isOwner) {
 			setLoading(false);
 			return;
 		}
 		setLoading(true);
 		setError(null);
 		try {
-			setBilling(await client.getBilling(token));
+			setBilling(await client.getBilling(session.token));
 		} catch (caught) {
 			setError(caught instanceof ApiError ? caught.message : 'Could not load billing.');
 		} finally {
 			setLoading(false);
 		}
-	}, [client, token, isOwner]);
+	}, [client, session, isOwner]);
 
 	useEffect(() => {
 		load();

--- a/packages/app/app/team.tsx
+++ b/packages/app/app/team.tsx
@@ -32,7 +32,6 @@ function rolePillColors(role: Role): { color: string; background: string } {
 
 export default function TeamScreen() {
 	const { session, client } = useAuth();
-	const token = session?.token;
 	const canInvite = session?.role === 'owner' || session?.role === 'manager';
 	// Owners may grant any role; managers may only add Members.
 	const roleOptions: { label: string; value: Role }[] =
@@ -57,13 +56,13 @@ export default function TeamScreen() {
 	const [sending, setSending] = useState(false);
 
 	const load = useCallback(async () => {
-		if (!token) {
+		if (!session) {
 			return;
 		}
 		setLoading(true);
 		setError(null);
 		try {
-			const data = await client.listMembers(token);
+			const data = await client.listMembers(session.token);
 			setMembers(data.members);
 			setInvites(data.invites);
 		} catch (caught) {
@@ -71,20 +70,20 @@ export default function TeamScreen() {
 		} finally {
 			setLoading(false);
 		}
-	}, [client, token]);
+	}, [client, session]);
 
 	useEffect(() => {
 		load();
 	}, [load]);
 
 	async function onInvite() {
-		if (!token || sending) {
+		if (!session || sending) {
 			return;
 		}
 		setInviteError(null);
 		setSending(true);
 		try {
-			const invite = await client.inviteMember(token, {
+			const invite = await client.inviteMember(session.token, {
 				email: inviteEmail.trim(),
 				name: inviteName.trim(),
 				role: inviteRole,

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -492,4 +492,45 @@ describe('createApiClient', () => {
 		const client = createApiClient(BASE);
 		expect(client.baseUrl).toBe(BASE);
 	});
+
+	describe('cookie (credentials) mode', () => {
+		it('sends credentials and omits the bearer header when no token is given', async () => {
+			const session = { user: makeUser(), account: makeAccount(), role: 'owner' as const };
+			fetchMock.mockResolvedValueOnce(jsonResponse(session));
+
+			const client = createApiClient(BASE, fetchMock, { withCredentials: true });
+			const result = await client.me();
+
+			expect(result).toEqual(session);
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/auth/me`);
+			expect(init.credentials).toBe('include');
+			// In cookie mode the request authenticates via the cookie, not a header.
+			expect(init.headers).not.toHaveProperty('Authorization');
+		});
+
+		it('posts to the logout endpoint with credentials', async () => {
+			fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'signed_out' }));
+
+			const client = createApiClient(BASE, fetchMock, { withCredentials: true });
+			await client.logout();
+
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/auth/logout`);
+			expect(init.method).toBe('POST');
+			expect(init.credentials).toBe('include');
+		});
+
+		it('does not set credentials in the default (native bearer) mode', async () => {
+			fetchMock.mockResolvedValueOnce(
+				jsonResponse({ status: 'ok', uptime: 1, timestamp: new Date().toISOString() }),
+			);
+
+			const client = createApiClient(BASE, fetchMock);
+			await client.health();
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(init.credentials).toBeUndefined();
+		});
+	});
 });

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -137,6 +137,10 @@ const sessionResponseSchema = z.object({
 });
 export type Session = z.infer<typeof sessionResponseSchema>;
 
+const signedOutResponseSchema = z.object({
+	status: z.literal('signed_out'),
+});
+
 const memberResponseSchema = z.object({
 	userId: userId(),
 	email: z.string(),
@@ -232,7 +236,14 @@ export interface RivusApiClient {
 	/** Exchange a one-time code (signup or login) for a session. */
 	verifyCode(input: VerifyCodeInput): Promise<AuthResponse>;
 	acceptInvite(input: AcceptInviteInput): Promise<AuthResponse>;
-	me(token: string): Promise<Session>;
+	/**
+	 * Return the current session. The token is optional: web clients authenticate
+	 * via the session cookie (sent automatically in credentials mode), so they call
+	 * this with no argument to rehydrate after a reload.
+	 */
+	me(token?: string): Promise<Session>;
+	/** Clear the server-side session cookie (web sign-out). */
+	logout(): Promise<void>;
 	listMembers(token: string): Promise<MemberList>;
 	inviteMember(token: string, input: InviteMemberInput): Promise<Invite>;
 	/** Update the account's business settings (owner only). */
@@ -249,12 +260,33 @@ function normalizeBaseUrl(baseUrl: string): string {
 	return baseUrl.replace(/\/+$/, '');
 }
 
-export function createApiClient(baseUrl: string, fetchImpl: FetchLike = fetch): RivusApiClient {
+/** Optional knobs for {@link createApiClient}. */
+export interface ApiClientOptions {
+	/**
+	 * Send cookies with every request (`credentials: 'include'`). Web clients use
+	 * this so the API's HttpOnly session cookie rides along; the bearer token then
+	 * becomes optional and is omitted when empty. Native clients leave this off and
+	 * authenticate with the bearer header.
+	 */
+	withCredentials?: boolean;
+}
+
+export function createApiClient(
+	baseUrl: string,
+	fetchImpl: FetchLike = fetch,
+	options: ApiClientOptions = {},
+): RivusApiClient {
 	const root = normalizeBaseUrl(baseUrl);
+	const credentials: RequestCredentials | undefined = options.withCredentials
+		? 'include'
+		: undefined;
 
 	/** Perform a request, parse JSON, and turn non-2xx into a typed ApiError. */
 	async function request<T>(path: string, schema: z.ZodType<T>, init?: RequestInit): Promise<T> {
-		const response = await fetchImpl(`${root}${path}`, init);
+		const response = await fetchImpl(
+			`${root}${path}`,
+			credentials ? { ...init, credentials } : init,
+		);
 		const raw = await response.text();
 		const body = raw.length > 0 ? safeJsonParse(raw) : undefined;
 
@@ -278,8 +310,11 @@ export function createApiClient(baseUrl: string, fetchImpl: FetchLike = fetch): 
 		return { method, headers, body: JSON.stringify(payload) };
 	}
 
-	function authHeaders(token: string): Record<string, string> {
-		return { Authorization: `Bearer ${token}` };
+	// Only attach a bearer header when there's actually a token. In web cookie mode
+	// the token is empty, and sending `Authorization: Bearer ` (malformed) would make
+	// the API reject the request instead of falling back to the session cookie.
+	function authHeaders(token?: string): Record<string, string> {
+		return token ? { Authorization: `Bearer ${token}` } : {};
 	}
 
 	return {
@@ -311,11 +346,15 @@ export function createApiClient(baseUrl: string, fetchImpl: FetchLike = fetch): 
 			return request('/v1/auth/accept-invite', authResponseSchema, jsonInit('POST', payload));
 		},
 
-		me(token: string) {
+		me(token?: string) {
 			return request('/v1/auth/me', sessionResponseSchema, {
 				method: 'GET',
 				headers: authHeaders(token),
 			});
+		},
+
+		async logout() {
+			await request('/v1/auth/logout', signedOutResponseSchema, { method: 'POST' });
 		},
 
 		listMembers(token: string) {

--- a/packages/app/src/auth/AuthContext.tsx
+++ b/packages/app/src/auth/AuthContext.tsx
@@ -1,5 +1,6 @@
 import type { LoginInput, UpdateAccountInput, VerifyCodeInput } from '@rivus/core';
-import { createContext, type ReactNode, useContext, useMemo, useState } from 'react';
+import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+import { Platform } from 'react-native';
 import {
 	type AuthResponse,
 	type CodeSentResponse,
@@ -9,10 +10,23 @@ import {
 } from '@/src/api/client';
 import { getApiBaseUrl } from '@/src/api/config';
 
+/**
+ * Web keeps the session in an HttpOnly cookie the API sets at sign-in, so the
+ * client sends credentials and never holds the token in JS. Native has no cookie
+ * jar, so it keeps using the bearer token returned in the response body.
+ */
+const IS_WEB = Platform.OS === 'web';
+
 export interface AuthContextValue {
 	/** The active session, or `null` when signed out. */
 	session: AuthResponse | null;
-	/** Shared API client (screens use `session.token` for authed calls). */
+	/**
+	 * True while we're restoring a session on startup (web checks the cookie via
+	 * `me()`). The gate shows a spinner until this clears so a valid session never
+	 * flashes the sign-in screen.
+	 */
+	restoring: boolean;
+	/** Shared API client (authed calls pass `session.token`; web ignores it and uses the cookie). */
 	client: RivusApiClient;
 	/** Request a sign-in code for an existing account. */
 	signIn: (input: LoginInput) => Promise<CodeSentResponse>;
@@ -31,17 +45,62 @@ export interface AuthContextValue {
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 /**
- * Holds the signed-in session in memory and exposes the auth actions. The
- * session is intentionally not persisted yet — a reload returns to the sign-in
- * screen (wiring SecureStore/AsyncStorage is a follow-up).
+ * Holds the signed-in session and exposes the auth actions.
+ *
+ * On **web** the session survives reloads: the API sets an HttpOnly cookie at
+ * sign-in, and on startup we ask `me()` who we are (the cookie rides along) before
+ * deciding whether to show the dashboard. The token is never kept in JS — the
+ * cookie is the credential. On **native** the session is still in-memory only
+ * (persisting it in SecureStore is a follow-up), so a cold start returns to the
+ * sign-in screen.
  */
 export function AuthProvider({ children }: { children: ReactNode }) {
-	const client = useMemo(() => createApiClient(getApiBaseUrl()), []);
+	const client = useMemo(
+		() => createApiClient(getApiBaseUrl(), undefined, { withCredentials: IS_WEB }),
+		[],
+	);
 	const [session, setSession] = useState<AuthResponse | null>(null);
+	// Only web has a cookie to restore; native starts signed out with nothing to check.
+	const [restoring, setRestoring] = useState(IS_WEB);
 
-	const value = useMemo<AuthContextValue>(
-		() => ({
+	useEffect(() => {
+		if (!IS_WEB) {
+			return;
+		}
+		let active = true;
+		client
+			.me()
+			.then((me) => {
+				if (active) {
+					// No token on web — the cookie authenticates subsequent calls.
+					setSession({ token: '', ...me });
+				}
+			})
+			.catch(() => {
+				// No cookie, or it expired / was revoked: stay signed out.
+			})
+			.finally(() => {
+				if (active) {
+					setRestoring(false);
+				}
+			});
+		return () => {
+			active = false;
+		};
+	}, [client]);
+
+	const value = useMemo<AuthContextValue>(() => {
+		// On web the token must never be retained in JS; the cookie is the credential.
+		const adopt = (res: AuthResponse): AuthResponse => (IS_WEB ? { ...res, token: '' } : res);
+		// JS can't clear an HttpOnly cookie, so ask the API to expire it on sign-out.
+		const clearCookie = () => {
+			if (IS_WEB) {
+				void client.logout().catch(() => {});
+			}
+		};
+		return {
 			session,
+			restoring,
 			client,
 			signIn(input) {
 				return client.login(input);
@@ -50,10 +109,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 				return client.signup(input);
 			},
 			async verifyCode(input) {
-				setSession(await client.verifyCode(input));
+				setSession(adopt(await client.verifyCode(input)));
 			},
 			async acceptInvite(token) {
-				setSession(await client.acceptInvite({ token }));
+				setSession(adopt(await client.acceptInvite({ token })));
 			},
 			async updateAccount(input) {
 				if (!session) {
@@ -69,13 +128,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 				await client.cancelAccount(session.token);
 				// The account is now canceled, so every authed call would 401 — drop the session.
 				setSession(null);
+				clearCookie();
 			},
 			signOut() {
 				setSession(null);
+				clearCookie();
 			},
-		}),
-		[client, session],
-	);
+		};
+	}, [client, session, restoring]);
 
 	return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/packages/app/src/auth/AuthContext.tsx
+++ b/packages/app/src/auth/AuthContext.tsx
@@ -92,12 +92,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 	const value = useMemo<AuthContextValue>(() => {
 		// On web the token must never be retained in JS; the cookie is the credential.
 		const adopt = (res: AuthResponse): AuthResponse => (IS_WEB ? { ...res, token: '' } : res);
-		// JS can't clear an HttpOnly cookie, so ask the API to expire it on sign-out.
-		const clearCookie = () => {
-			if (IS_WEB) {
-				void client.logout().catch(() => {});
-			}
-		};
 		return {
 			session,
 			restoring,
@@ -126,13 +120,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 					return;
 				}
 				await client.cancelAccount(session.token);
-				// The account is now canceled, so every authed call would 401 — drop the session.
+				// The account is now canceled, so the cookie's token will 401 on the next
+				// request and `me()` won't restore it — drop the session, and clear the
+				// (now inert) cookie best-effort.
 				setSession(null);
-				clearCookie();
+				if (IS_WEB) {
+					void client.logout().catch(() => {});
+				}
 			},
-			signOut() {
+			async signOut() {
+				// On web, only drop the session once the API has actually cleared the
+				// HttpOnly cookie. Otherwise a failed logout would look successful while the
+				// cookie survived, and the next reload's `me()` would sign us back in.
+				if (IS_WEB) {
+					try {
+						await client.logout();
+					} catch {
+						// Couldn't reach the API to clear the cookie — stay signed in rather
+						// than show a false "signed out" that a reload would silently undo.
+						return;
+					}
+				}
 				setSession(null);
-				clearCookie();
 			},
 		};
 	}, [client, session, restoring]);

--- a/packages/docs/site/openapi.json
+++ b/packages/docs/site/openapi.json
@@ -98,9 +98,9 @@
         }
       }
     },
-    "/v1/auth/register": {
+    "/v1/auth/signup": {
       "post": {
-        "summary": "Register a new account",
+        "summary": "Begin signup — emails a one-time code to confirm the address",
         "tags": [
           "auth"
         ],
@@ -112,37 +112,63 @@
                 "type": "object",
                 "properties": {
                   "email": {
-                    "type": "string",
-                    "maxLength": 254,
-                    "format": "email",
-                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
-                  },
-                  "password": {
-                    "type": "string",
-                    "minLength": 8,
-                    "maxLength": 200
+                    "type": "string"
                   },
                   "name": {
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 120
+                  },
+                  "business": {
+                    "type": "object",
+                    "properties": {
+                      "businessName": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 160
+                      },
+                      "phone": {
+                        "default": "",
+                        "type": "string",
+                        "maxLength": 40
+                      },
+                      "address": {
+                        "default": "",
+                        "type": "string",
+                        "maxLength": 300
+                      },
+                      "website": {
+                        "default": "",
+                        "type": "string",
+                        "maxLength": 2048
+                      },
+                      "timezone": {
+                        "default": "UTC",
+                        "type": "string",
+                        "maxLength": 64
+                      }
+                    },
+                    "required": [
+                      "businessName"
+                    ]
                   }
                 },
                 "required": [
-                  "password",
-                  "name"
+                  "email",
+                  "name",
+                  "business"
                 ]
               }
             }
           }
         },
         "responses": {
-          "201": {
+          "202": {
             "description": "Default Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AuthResponse"
+                  "$ref": "#/components/schemas/CodeSent"
                 }
               }
             }
@@ -172,7 +198,7 @@
     },
     "/v1/auth/login": {
       "post": {
-        "summary": "Log in and receive a JWT",
+        "summary": "Request a one-time sign-in code",
         "tags": [
           "auth"
         ],
@@ -184,19 +210,64 @@
                 "type": "object",
                 "properties": {
                   "email": {
-                    "type": "string",
-                    "maxLength": 254,
-                    "format": "email",
-                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
-                  },
-                  "password": {
-                    "type": "string",
-                    "minLength": 8,
-                    "maxLength": 200
+                    "type": "string"
                   }
                 },
                 "required": [
-                  "password"
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CodeSent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/auth/verify": {
+      "post": {
+        "summary": "Verify a one-time code and receive a session",
+        "tags": [
+          "auth"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string"
+                  },
+                  "code": {
+                    "type": "string",
+                    "pattern": "^\\d{6}$"
+                  }
+                },
+                "required": [
+                  "email",
+                  "code"
                 ]
               }
             }
@@ -213,7 +284,37 @@
               }
             }
           },
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -228,7 +329,7 @@
     },
     "/v1/auth/me": {
       "get": {
-        "summary": "Return the currently authenticated user",
+        "summary": "Return the current user, account, and role",
         "tags": [
           "auth"
         ],
@@ -243,7 +344,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/User"
+                  "$ref": "#/components/schemas/Session"
                 }
               }
             }
@@ -261,9 +362,668 @@
         }
       }
     },
+    "/v1/auth/accept-invite": {
+      "post": {
+        "summary": "Accept an invitation and join an account",
+        "tags": [
+          "auth"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "token": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "token"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/auth/logout": {
+      "post": {
+        "summary": "Sign out — clears the session cookie",
+        "tags": [
+          "auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SignedOut"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/members/": {
+      "get": {
+        "summary": "List members and pending invites for your account",
+        "tags": [
+          "members"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemberList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/members/invites": {
+      "post": {
+        "summary": "Invite a teammate (Owner, Manager, or Member) to your account",
+        "tags": [
+          "members"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "owner",
+                      "manager",
+                      "member"
+                    ]
+                  }
+                },
+                "required": [
+                  "email",
+                  "name",
+                  "role"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Invite"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/members/invites/{inviteId}": {
+      "delete": {
+        "summary": "Revoke a pending invite",
+        "tags": [
+          "members"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "inviteId",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/members/{userId}/role": {
+      "patch": {
+        "summary": "Change a member's role (owner only)",
+        "tags": [
+          "members"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "owner",
+                      "manager",
+                      "member"
+                    ]
+                  }
+                },
+                "required": [
+                  "role"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "userId",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Member"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/members/{userId}": {
+      "delete": {
+        "summary": "Remove a member from your account",
+        "tags": [
+          "members"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "userId",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/account/": {
+      "patch": {
+        "summary": "Update account business settings (owner only)",
+        "tags": [
+          "account"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "businessName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "phone": {
+                    "type": "string",
+                    "maxLength": 40
+                  },
+                  "address": {
+                    "type": "string",
+                    "maxLength": 300
+                  },
+                  "website": {
+                    "type": "string",
+                    "maxLength": 2048
+                  },
+                  "timezone": {
+                    "type": "string",
+                    "maxLength": 64
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/account/cancel": {
+      "post": {
+        "summary": "Cancel the account — a soft delete that locks it (owner only)",
+        "tags": [
+          "account"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/billing/": {
+      "get": {
+        "summary": "Billing summary for the account (owner only)",
+        "tags": [
+          "billing"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Billing"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/items/": {
       "get": {
-        "summary": "List your items",
+        "summary": "List your account's items",
         "tags": [
           "items"
         ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
 
   packages/api:
     dependencies:
+      '@fastify/cookie':
+        specifier: ^11.0.2
+        version: 11.0.2
       '@fastify/cors':
         specifier: ^11.2.0
         version: 11.2.0
@@ -2059,6 +2062,9 @@ packages:
 
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cookie@11.0.2':
+    resolution: {integrity: sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==}
 
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
@@ -9237,6 +9243,11 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       fast-uri: 3.1.2
+
+  '@fastify/cookie@11.0.2':
+    dependencies:
+      cookie: 1.1.1
+      fastify-plugin: 5.1.0
 
   '@fastify/cors@11.2.0':
     dependencies:


### PR DESCRIPTION
## Why

Testing the app on web, you get logged out on **every page reload**. The cause isn't token expiry or the API — it's that the signed-in session lived **only in React in-memory state**:

```ts
// packages/app/src/auth/AuthContext.tsx (before)
const [session, setSession] = useState<AuthResponse | null>(null);
```

The code even called this out: *"the session is intentionally not persisted yet — a reload returns to the sign-in screen."* On web, a full reload (refresh, URL navigation, reopened tab, dev hot-reload) wipes that state to `null`, and the gate immediately renders the sign-in screen. In-app navigation was fine; only reloads logged you out.

## Approach

Persist the session the secure way — a **first-party HttpOnly cookie**. Because `app.rivus.ai` and `api.rivus.ai` are same-site subdomains of `rivus.ai`, the cookie is first-party (`SameSite=Lax` is enough, and it dodges third-party-cookie restrictions). The token is never kept in JS on web; the cookie is the credential. **Native is unchanged** — it keeps using the bearer token.

## Changes

**API**
- Register `@fastify/cookie`; point `@fastify/jwt` at a `rivus_session` cookie, so `authenticate()` reads the token from the `Authorization` header (native) **or** the cookie (web).
- Issue the `HttpOnly; SameSite=Lax; Secure`-in-prod cookie on `verify` and `accept-invite`, with `maxAge` derived from the JWT's own `exp`. The token still ships in the response body for native.
- Add `POST /v1/auth/logout` to clear the cookie (JS can't clear an HttpOnly cookie).
- Allow credentialed CORS: reflect the origin when wide-open (dev), otherwise echo the configured allowlist, and send `Access-Control-Allow-Credentials`.

**App**
- `createApiClient` gains a `withCredentials` option: send `credentials: 'include'` and omit the bearer header when there's no token. Added `logout()`; made `me()` token-optional.
- On web, `AuthProvider` runs in cookie mode, never retains the token in JS, **rehydrates the session via `me()` on startup**, and clears the cookie on `signOut`/`cancelAccount`. A `restoring` flag holds the gate on a spinner so a valid session doesn't flash the sign-in screen.
- `billing`/`team` gate authed calls on `session` rather than the (now empty-on-web) token.

## Tests / checks
- New API tests: cookie is set on verify, `/me` authenticates via cookie alone, logout clears it, and credentialed CORS (allowlist echo + wide-open reflect).
- New client tests: cookie mode sends credentials / omits the bearer header, `logout()`, and default native mode is unchanged.
- `pnpm lint && pnpm type-check && pnpm test` all green (299 tests); coverage thresholds hold. OpenAPI regenerated + synced to docs for the new route.

## Follow-up
Native session persistence (token in `expo-secure-store`) is intentionally **not** included — it can't be runtime-verified in this environment. Native still works (bearer transport unchanged) but, like before, doesn't yet persist across a cold app start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YL7gwKrT49ELE29N73PFCX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YL7gwKrT49ELE29N73PFCX)_