### PR TITLE
fix(app): clean keyboard-only focus ring instead of the default outline

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -9,6 +9,7 @@ import {
 } from '@expo-google-fonts/montserrat';
 import { Redirect, Slot, usePathname, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { useEffect } from 'react';
 import {
 	ActivityIndicator,
 	Pressable,
@@ -23,6 +24,7 @@ import { AuthScreen } from '@/src/auth/AuthScreen';
 import { RivusWordmark } from '@/src/brand/RivusLogo';
 import { BrandGradient } from '@/src/components/Gradient';
 import { Avatar, Dot, Icon, RivusStatusChip, Txt } from '@/src/components/ui';
+import { installFocusRing } from '@/src/theme/focusRing';
 import { colors, font, radii, SIDEBAR_BREAKPOINT, SIDEBAR_WIDTH } from '@/src/theme/tokens';
 
 type FeatherName = React.ComponentProps<typeof Feather>['name'];
@@ -72,6 +74,12 @@ export default function RootLayout() {
 		Montserrat_600SemiBold,
 		Montserrat_700Bold,
 	});
+
+	// Web only: replace the browser's default focus outline with a clean,
+	// keyboard-only brand ring (see installFocusRing). No-op on native.
+	useEffect(() => {
+		installFocusRing();
+	}, []);
 
 	return (
 		<SafeAreaProvider>

--- a/packages/app/src/components/ui.tsx
+++ b/packages/app/src/components/ui.tsx
@@ -153,7 +153,10 @@ export function GradientButton({
 	style?: StyleProp<ViewStyle>;
 }) {
 	return (
-		<Pressable onPress={onPress} style={({ pressed }) => [pressed && styles.pressed, style]}>
+		<Pressable
+			onPress={onPress}
+			style={({ pressed }) => [styles.gradientBtnWrap, pressed && styles.pressed, style]}
+		>
 			<BrandGradient style={styles.gradientBtn}>
 				{icon ? <Feather name={icon} size={16} color="#fff" /> : null}
 				<Txt style={styles.gradientBtnTxt}>{label}</Txt>
@@ -386,6 +389,11 @@ export const styles = StyleSheet.create({
 	center: {
 		alignItems: 'center',
 		justifyContent: 'center',
+	},
+	// The focusable wrapper carries the same radius as the gradient so the
+	// keyboard focus ring hugs the button's rounded corners.
+	gradientBtnWrap: {
+		borderRadius: radii.lg,
 	},
 	gradientBtn: {
 		flexDirection: 'row',

--- a/packages/app/src/components/ui.tsx
+++ b/packages/app/src/components/ui.tsx
@@ -155,6 +155,7 @@ export function GradientButton({
 	return (
 		<Pressable
 			onPress={onPress}
+			accessibilityRole="button"
 			style={({ pressed }) => [styles.gradientBtnWrap, pressed && styles.pressed, style]}
 		>
 			<BrandGradient style={styles.gradientBtn}>

--- a/packages/app/src/theme/focusRing.ts
+++ b/packages/app/src/theme/focusRing.ts
@@ -15,9 +15,10 @@ import { colors } from './tokens';
 
 const STYLE_ID = 'rivus-focus-ring';
 
-// Scope to genuinely interactive nodes: every RN Pressable renders with a
-// tabindex, inputs render as <input>/<textarea>, and links as <a>.
-const SELECTOR = ':where(a,input,select,textarea,[tabindex])';
+// Scope to genuinely interactive nodes: Pressables with accessibilityRole="button"
+// render as a native <button>, links as <a>, inputs as <input>/<textarea>, and
+// every other Pressable carries a tabindex.
+const SELECTOR = ':where(button,a,input,select,textarea,[tabindex])';
 
 export function installFocusRing(): void {
 	if (Platform.OS !== 'web' || typeof document === 'undefined') {

--- a/packages/app/src/theme/focusRing.ts
+++ b/packages/app/src/theme/focusRing.ts
@@ -1,0 +1,37 @@
+import { Platform } from 'react-native';
+import { colors } from './tokens';
+
+// react-native-web renders Pressables and inputs as focusable DOM nodes, so on
+// web the browser paints its default focus outline when you tab (or click) to
+// them. On a rounded button that outline is a square that pokes out past the
+// corners — the "line around it" you see when tabbing to a gradient button.
+//
+// We can't express `:focus-visible` through RN's StyleSheet, so install one tiny
+// stylesheet: hide the default outline for pointer focus, and draw a clean,
+// on-brand ring for keyboard focus only. `outline` follows each element's
+// border-radius in modern browsers, so the ring matches the control's shape.
+//
+// No-op off the web (and during static rendering, where there's no `document`).
+
+const STYLE_ID = 'rivus-focus-ring';
+
+// Scope to genuinely interactive nodes: every RN Pressable renders with a
+// tabindex, inputs render as <input>/<textarea>, and links as <a>.
+const SELECTOR = ':where(a,input,select,textarea,[tabindex])';
+
+export function installFocusRing(): void {
+	if (Platform.OS !== 'web' || typeof document === 'undefined') {
+		return;
+	}
+	if (document.getElementById(STYLE_ID)) {
+		return;
+	}
+	const style = document.createElement('style');
+	style.id = STYLE_ID;
+	style.textContent =
+		// Pointer focus (mouse/touch): no outline.
+		`${SELECTOR}:focus:not(:focus-visible){outline:none;}` +
+		// Keyboard focus: a 2px brand ring sitting just outside the control.
+		`${SELECTOR}:focus-visible{outline:2px solid ${colors.brandPurple};outline-offset:2px;}`;
+	document.head.appendChild(style);
+}


### PR DESCRIPTION
## What & why

When you tab to the **Send invite** button (and other controls), a stray line appears around it:

![reported](https://github.com/jaredwray/rivus)

That line is the **browser's default focus outline**. On web, `react-native-web` renders `Pressable`s and inputs as focusable DOM nodes (`<div tabindex="0">`, `<input>`, …), so the browser paints its default `:focus` outline. On the rounded `GradientButton` the outline is drawn as a square that pokes out past the rounded corners — hence the bracket-like marks at the corners.

It also showed on **mouse clicks**, not just keyboard, because a focusable `<div>` receives focus on click.

## The fix

- **`src/theme/focusRing.ts`** (new): installs one small **web-only** stylesheet that
  - hides the default outline for pointer (mouse/touch) focus, and
  - draws a clean, on-brand **2px brand-purple ring** for **keyboard focus only** (`:focus-visible`).

  `outline` follows each element's `border-radius` in modern browsers, so the ring matches the control's shape. The helper is a no-op on native and during static rendering (no `document`).
- **`app/_layout.tsx`**: calls `installFocusRing()` once from the root layout via `useEffect`.
- **`src/components/ui.tsx`**: the `GradientButton`'s focusable wrapper now carries the same `borderRadius` as the inner gradient, so its ring hugs the button's rounded corners (previously the radius lived only on the inner gradient).

## Accessibility note

I intentionally **did not remove focus indication entirely** — a visible keyboard focus indicator is required for keyboard navigation (WCAG 2.4.7). Instead the ugly default is replaced with an intentional, on-brand ring that only appears when navigating by keyboard. If you'd prefer to remove it completely, or scope it to just the gradient button, that's a quick follow-up.

## Testing

- `pnpm lint` ✓
- `pnpm type-check` ✓
- `pnpm test` ✓ (app 52, api 138, core 57, website 43, worker 14)

Native is unaffected (the helper early-returns off web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxLiBZ9Tcvg89kH49yVsCC)_