### PR TITLE
feat(app): reframe invite modal around the emailed link

### DIFF
--- a/packages/app/src/components/InviteCreatedModal.tsx
+++ b/packages/app/src/components/InviteCreatedModal.tsx
@@ -82,9 +82,9 @@ function CopyField({ label, value }: { label: string; value: string }) {
 }
 
 /**
- * Success dialog shown after an invite is created. Surfaces the full
- * accept-invitation link (with the code embedded in the URL) plus the bare code,
- * each copyable, so the inviter can share whichever is convenient.
+ * Success dialog shown after an invite is created. Confirms the invitation
+ * email was sent and offers the full accept-invitation link (with the code
+ * embedded in the URL), copyable, as a fallback the inviter can share directly.
  */
 export function InviteCreatedModal({
 	invite,
@@ -127,10 +127,10 @@ export function InviteCreatedModal({
 							<Feather name="user-check" size={24} color="#fff" />
 						</BrandGradient>
 
-						<Txt style={styles.title}>Invitation ready</Txt>
+						<Txt style={styles.title}>Invitation sent</Txt>
 						<Txt style={styles.subtitle}>
-							Share this link with <Txt style={styles.subtitleStrong}>{shown.email}</Txt> so they
-							can join {accountName}.
+							We emailed <Txt style={styles.subtitleStrong}>{shown.email}</Txt> a link to join{' '}
+							{accountName}. If it doesn’t arrive, you can share this link with them:
 						</Txt>
 
 						<Pill
@@ -141,7 +141,6 @@ export function InviteCreatedModal({
 						/>
 
 						<CopyField label="Invite link" value={acceptUrl} />
-						<CopyField label="Invite code" value={shown.token} />
 
 						<GradientButton label="Done" onPress={onClose} style={styles.done} />
 					</Pressable>


### PR DESCRIPTION
Follow-up tweaks to the invite success modal (added in #37), per request.

## Changes
- **Removed the "Invite code" field** — the modal now shows only the full accept-invitation link.
- **Reworded the copy** to lead with the email: the modal now confirms we emailed the invitee a join link, and offers the link as a fallback to share if it doesn't arrive.
  - Title: "Invitation ready" → **"Invitation sent"**
  - Body: ~~"Share this link with {email} so they can join {account}."~~ → **"We emailed {email} a link to join {account}. If it doesn't arrive, you can share this link with them:"**

The full shareable link (with the code embedded in the URL) and its one-tap Copy button are unchanged.

## Verification
`pnpm lint && pnpm type-check && pnpm test` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aKkcRE8Rj1q1MmUgsqsBS

---
_Generated by [Claude Code](https://claude.ai/code/session_013aKkcRE8Rj1q1MmUgsqsBS)_