### PR TITLE
feat(app): autocomplete the address field in account settings

### DIFF
--- a/packages/app/app/settings.tsx
+++ b/packages/app/app/settings.tsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, View } from 'react-native';
 import { ApiError } from '@/src/api/client';
+import { getGoogleMapsApiKey } from '@/src/api/config';
 import { deviceTimezone, listTimezones } from '@/src/api/timezones';
 import { useAuth } from '@/src/auth/AuthContext';
+import { AddressAutocomplete } from '@/src/components/AddressAutocomplete';
 import {
 	Card,
 	GradientButton,
@@ -43,6 +45,12 @@ export default function SettingsScreen() {
 		() => listTimezones().map((zone) => ({ label: zone.replace(/_/g, ' '), value: zone })),
 		[],
 	);
+
+	// The Maps key is HTTP-referrer restricted to web origins, so native requests
+	// (no referer) would be rejected on every keystroke. Gate autocomplete to web
+	// and let the field fall back to a plain text input elsewhere — same as the
+	// signup form (see AuthScreen).
+	const mapsApiKey = useMemo(() => (Platform.OS === 'web' ? getGoogleMapsApiKey() : null), []);
 
 	if (!session) {
 		return null;
@@ -101,7 +109,11 @@ export default function SettingsScreen() {
 	}
 
 	return (
-		<ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+		<ScrollView
+			contentContainerStyle={styles.content}
+			keyboardShouldPersistTaps="handled"
+			showsVerticalScrollIndicator={false}
+		>
 			<Txt style={styles.h1}>Account settings</Txt>
 			<Txt style={styles.subtitle}>Business details for {session.account.name}.</Txt>
 
@@ -125,11 +137,12 @@ export default function SettingsScreen() {
 						placeholder="+1 (206) 555-0100"
 						keyboardType="phone-pad"
 					/>
-					<TextField
+					<AddressAutocomplete
 						label="Address"
 						value={address}
 						onChangeText={setAddress}
 						placeholder="1 Main St, Seattle, WA"
+						apiKey={mapsApiKey}
 					/>
 					<TextField
 						label="Website"


### PR DESCRIPTION
## What & why

The account settings form used a plain text input for the business address, while the **signup** form already offers Google Places autocomplete. This makes the two inconsistent — editing your address after signup gave no suggestions.

This PR reuses the existing `AddressAutocomplete` component on the settings screen so editing the address in **Account settings** gets the same suggestions as signup.

## Changes

- `packages/app/app/settings.tsx`: swap the address `TextField` for `AddressAutocomplete`, passing the web-gated Maps API key.
- Mirror the signup gating exactly: the Maps key is HTTP-referrer restricted to web origins, so autocomplete is enabled only on web (`Platform.OS === 'web'`) and the field gracefully degrades to a plain text input on native — identical to `AuthScreen`.
- Add `keyboardShouldPersistTaps="handled"` to the form's `ScrollView` so tapping a suggestion in the dropdown registers reliably (matching the signup screen).

No new dependencies and no new logic — the network/parsing layer (`src/api/places.ts`) and the component are already in place and tested; this just wires the same component into a second screen.

## Testing

- `pnpm lint` — clean (197 files, no fixes)
- `pnpm --filter @rivus/app type-check` — passes
- `pnpm --filter @rivus/app test` — 66 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017V86cNrEAuCj6uxMjMJUpB

---
_Generated by [Claude Code](https://claude.ai/code/session_017V86cNrEAuCj6uxMjMJUpB)_