### PR TITLE
feat: end-to-end FAQ resource (core, api, database, app)

### DIFF
--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1505,6 +1505,358 @@
           }
         }
       }
+    },
+    "/v1/faqs/": {
+      "get": {
+        "summary": "List your account's FAQs",
+        "tags": [
+          "faqs"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FaqList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create an FAQ",
+        "tags": [
+          "faqs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "answer": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 4000
+                  },
+                  "category": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 80
+                  },
+                  "status": {
+                    "default": "published",
+                    "type": "string",
+                    "enum": [
+                      "published",
+                      "draft"
+                    ]
+                  }
+                },
+                "required": [
+                  "question",
+                  "answer"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Faq"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/faqs/{id}": {
+      "get": {
+        "summary": "Fetch one of your FAQs",
+        "tags": [
+          "faqs"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Faq"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update one of your FAQs",
+        "tags": [
+          "faqs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "answer": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 4000
+                  },
+                  "category": {
+                    "type": "string",
+                    "maxLength": 80
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "published",
+                      "draft"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Faq"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete one of your FAQs",
+        "tags": [
+          "faqs"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -15,6 +15,7 @@ import { accountRoutes } from './routes/account';
 import { adminRoutes } from './routes/admin';
 import { authRoutes } from './routes/auth';
 import { billingRoutes } from './routes/billing';
+import { faqRoutes } from './routes/faqs';
 import { healthRoutes } from './routes/health';
 import { itemRoutes } from './routes/items';
 import { memberRoutes } from './routes/members';
@@ -155,6 +156,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	app.register(adminRoutes, { prefix: '/v1/admin' });
 	app.register(billingRoutes, { prefix: '/v1/billing' });
 	app.register(itemRoutes, { prefix: '/v1/items' });
+	app.register(faqRoutes, { prefix: '/v1/faqs' });
 
 	return app;
 }

--- a/packages/api/src/db/models/faq.model.ts
+++ b/packages/api/src/db/models/faq.model.ts
@@ -1,0 +1,24 @@
+import { model, Schema, type Types } from 'mongoose';
+
+export interface FaqDocument {
+	accountId: Types.ObjectId;
+	question: string;
+	answer: string;
+	category: string;
+	status: 'published' | 'draft';
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+const faqSchema = new Schema<FaqDocument>(
+	{
+		accountId: { type: Schema.Types.ObjectId, ref: 'Account', required: true, index: true },
+		question: { type: String, required: true, trim: true },
+		answer: { type: String, required: true, trim: true },
+		category: { type: String, default: '', trim: true },
+		status: { type: String, enum: ['published', 'draft'], default: 'published' },
+	},
+	{ timestamps: true },
+);
+
+export const FaqModel = model<FaqDocument>('Faq', faqSchema);

--- a/packages/api/src/http-schemas.ts
+++ b/packages/api/src/http-schemas.ts
@@ -1,4 +1,4 @@
-import { accountStatusSchema, itemStatusSchema, roleSchema } from '@rivus/core';
+import { accountStatusSchema, faqStatusSchema, itemStatusSchema, roleSchema } from '@rivus/core';
 import { z } from 'zod';
 
 /** Public user projection — never includes the password hash. */
@@ -132,6 +132,26 @@ export const itemListResponseSchema = z
 		meta: paginationMetaSchema,
 	})
 	.meta({ id: 'ItemList' });
+
+export const faqResponseSchema = z
+	.object({
+		id: z.string(),
+		accountId: z.string(),
+		question: z.string(),
+		answer: z.string(),
+		category: z.string(),
+		status: faqStatusSchema,
+		createdAt: z.string(),
+		updatedAt: z.string(),
+	})
+	.meta({ id: 'Faq' });
+
+export const faqListResponseSchema = z
+	.object({
+		data: z.array(faqResponseSchema),
+		meta: paginationMetaSchema,
+	})
+	.meta({ id: 'FaqList' });
 
 /** A page of companies (accounts) for the staff company switcher. */
 export const accountListResponseSchema = z

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -12,7 +12,7 @@ import { NoopMailer } from './services/email';
  */
 async function main(): Promise<void> {
 	const config = loadConfig({ ...process.env, NODE_ENV: 'test' });
-	const { users, accounts, memberships, invites, onboarding, items, verificationCodes } =
+	const { users, accounts, memberships, invites, onboarding, items, faqs, verificationCodes } =
 		createInMemoryRepositories();
 	const app = buildApp({
 		config,
@@ -22,6 +22,7 @@ async function main(): Promise<void> {
 		invites,
 		onboarding,
 		items,
+		faqs,
 		verificationCodes,
 		mailer: new NoopMailer(),
 		ping: async () => ({ ready: true }),

--- a/packages/api/src/repositories/memory.ts
+++ b/packages/api/src/repositories/memory.ts
@@ -2,7 +2,10 @@ import { randomUUID } from 'node:crypto';
 import {
 	type Account,
 	type AccountId,
+	type CreateFaqInput,
 	type CreateItemInput,
+	type Faq,
+	type FaqId,
 	type Invite,
 	type InviteId,
 	type Item,
@@ -12,6 +15,7 @@ import {
 	normalizePagination,
 	pageToSkip,
 	type Role,
+	type UpdateFaqInput,
 	type UpdateItemInput,
 	type UserId,
 } from '@rivus/core';
@@ -20,9 +24,11 @@ import type {
 	AcceptInviteInput,
 	AcceptInviteResult,
 	AccountRepository,
+	FaqRepository,
 	InviteRepository,
 	ItemRepository,
 	ListAccountsOptions,
+	ListFaqsOptions,
 	ListItemsOptions,
 	MembershipRepository,
 	NewAccount,
@@ -53,6 +59,7 @@ export interface InMemoryData {
 	memberships: Map<string, Membership>;
 	invites: Map<string, Invite>;
 	items: Map<string, Item>;
+	faqs: Map<string, Faq>;
 	/** Active one-time codes, keyed by normalized email (one per email). */
 	verificationCodes: Map<string, StoredVerificationCode>;
 }
@@ -64,6 +71,7 @@ export function createInMemoryData(): InMemoryData {
 		memberships: new Map(),
 		invites: new Map(),
 		items: new Map(),
+		faqs: new Map(),
 		verificationCodes: new Map(),
 	};
 }
@@ -505,6 +513,64 @@ export class InMemoryItemRepository implements ItemRepository {
 	}
 }
 
+/** In-memory FAQ store, scoped by account. */
+export class InMemoryFaqRepository implements FaqRepository {
+	constructor(private readonly data: InMemoryData) {}
+
+	async create(accountId: AccountId, input: CreateFaqInput): Promise<Faq> {
+		const timestamp = now();
+		const faq: Faq = {
+			id: randomUUID() as FaqId,
+			accountId,
+			question: input.question,
+			answer: input.answer,
+			category: input.category,
+			status: input.status,
+			createdAt: timestamp,
+			updatedAt: timestamp,
+		};
+		this.data.faqs.set(faq.id, faq);
+		return structuredClone(faq);
+	}
+
+	async list(options: ListFaqsOptions): Promise<{ faqs: Faq[]; total: number }> {
+		// Map preserves insertion order, so reversing yields a deterministic
+		// newest-first ordering even when timestamps collide within a millisecond.
+		const owned = [...this.data.faqs.values()]
+			.filter((faq) => faq.accountId === options.accountId)
+			.reverse();
+		const { pageSize } = normalizePagination(options.page, options.pageSize);
+		const skip = pageToSkip(options.page, options.pageSize);
+		return {
+			faqs: owned.slice(skip, skip + pageSize).map((faq) => structuredClone(faq)),
+			total: owned.length,
+		};
+	}
+
+	async findById(accountId: AccountId, id: FaqId): Promise<Faq | null> {
+		const faq = this.data.faqs.get(id);
+		return faq && faq.accountId === accountId ? structuredClone(faq) : null;
+	}
+
+	async update(accountId: AccountId, id: FaqId, input: UpdateFaqInput): Promise<Faq | null> {
+		const faq = this.data.faqs.get(id);
+		if (!faq || faq.accountId !== accountId) {
+			return null;
+		}
+		const updated: Faq = { ...faq, ...input, updatedAt: now() };
+		this.data.faqs.set(id, updated);
+		return structuredClone(updated);
+	}
+
+	async delete(accountId: AccountId, id: FaqId): Promise<boolean> {
+		const faq = this.data.faqs.get(id);
+		if (!faq || faq.accountId !== accountId) {
+			return false;
+		}
+		return this.data.faqs.delete(id);
+	}
+}
+
 export interface InMemoryRepositories {
 	data: InMemoryData;
 	users: InMemoryUserRepository;
@@ -512,6 +578,7 @@ export interface InMemoryRepositories {
 	memberships: InMemoryMembershipRepository;
 	invites: InMemoryInviteRepository;
 	items: InMemoryItemRepository;
+	faqs: InMemoryFaqRepository;
 	verificationCodes: InMemoryVerificationCodeRepository;
 	onboarding: InMemoryOnboardingRepository;
 }
@@ -525,7 +592,18 @@ export function createInMemoryRepositories(
 	const memberships = new InMemoryMembershipRepository(data);
 	const invites = new InMemoryInviteRepository(data);
 	const items = new InMemoryItemRepository(data);
+	const faqs = new InMemoryFaqRepository(data);
 	const verificationCodes = new InMemoryVerificationCodeRepository(data);
 	const onboarding = new InMemoryOnboardingRepository(users, accounts, memberships, invites);
-	return { data, users, accounts, memberships, invites, items, verificationCodes, onboarding };
+	return {
+		data,
+		users,
+		accounts,
+		memberships,
+		invites,
+		items,
+		faqs,
+		verificationCodes,
+		onboarding,
+	};
 }

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -1,7 +1,10 @@
 import {
 	type Account,
 	type AccountId,
+	type CreateFaqInput,
 	type CreateItemInput,
+	type Faq,
+	type FaqId,
 	type Invite,
 	type InviteId,
 	type Item,
@@ -11,11 +14,13 @@ import {
 	normalizePagination,
 	pageToSkip,
 	type Role,
+	type UpdateFaqInput,
 	type UpdateItemInput,
 	type UserId,
 } from '@rivus/core';
 import mongoose, { type ClientSession, type HydratedDocument, Types } from 'mongoose';
 import { type AccountDocument, AccountModel } from '../db/models/account.model';
+import { type FaqDocument, FaqModel } from '../db/models/faq.model';
 import { type InviteDocument, InviteModel } from '../db/models/invite.model';
 import { type ItemDocument, ItemModel } from '../db/models/item.model';
 import { type MembershipDocument, MembershipModel } from '../db/models/membership.model';
@@ -29,9 +34,11 @@ import type {
 	AcceptInviteInput,
 	AcceptInviteResult,
 	AccountRepository,
+	FaqRepository,
 	InviteRepository,
 	ItemRepository,
 	ListAccountsOptions,
+	ListFaqsOptions,
 	ListItemsOptions,
 	MembershipRepository,
 	NewAccount,
@@ -129,6 +136,19 @@ function mapItem(doc: HydratedDocument<ItemDocument>): Item {
 		accountId: doc.accountId.toString() as AccountId,
 		name: doc.name,
 		description: doc.description,
+		status: doc.status,
+		createdAt: doc.createdAt.toISOString(),
+		updatedAt: doc.updatedAt.toISOString(),
+	};
+}
+
+function mapFaq(doc: HydratedDocument<FaqDocument>): Faq {
+	return {
+		id: doc._id.toString() as FaqId,
+		accountId: doc.accountId.toString() as AccountId,
+		question: doc.question,
+		answer: doc.answer,
+		category: doc.category,
 		status: doc.status,
 		createdAt: doc.createdAt.toISOString(),
 		updatedAt: doc.updatedAt.toISOString(),
@@ -633,6 +653,61 @@ export class MongoItemRepository implements ItemRepository {
 			return false;
 		}
 		const result = await ItemModel.deleteOne({
+			_id: id,
+			accountId: new Types.ObjectId(accountId),
+		}).exec();
+		return result.deletedCount === 1;
+	}
+}
+
+export class MongoFaqRepository implements FaqRepository {
+	async create(accountId: AccountId, input: CreateFaqInput): Promise<Faq> {
+		const doc = await FaqModel.create({ accountId: new Types.ObjectId(accountId), ...input });
+		return mapFaq(doc);
+	}
+
+	async list(options: ListFaqsOptions): Promise<{ faqs: Faq[]; total: number }> {
+		if (!Types.ObjectId.isValid(options.accountId)) {
+			return { faqs: [], total: 0 };
+		}
+		const { pageSize } = normalizePagination(options.page, options.pageSize);
+		const skip = pageToSkip(options.page, options.pageSize);
+		const filter = { accountId: new Types.ObjectId(options.accountId) };
+		const [docs, total] = await Promise.all([
+			FaqModel.find(filter).sort({ createdAt: -1, _id: -1 }).skip(skip).limit(pageSize).exec(),
+			FaqModel.countDocuments(filter).exec(),
+		]);
+		return { faqs: docs.map(mapFaq), total };
+	}
+
+	async findById(accountId: AccountId, id: FaqId): Promise<Faq | null> {
+		if (!Types.ObjectId.isValid(id) || !Types.ObjectId.isValid(accountId)) {
+			return null;
+		}
+		const doc = await FaqModel.findOne({
+			_id: id,
+			accountId: new Types.ObjectId(accountId),
+		}).exec();
+		return doc ? mapFaq(doc) : null;
+	}
+
+	async update(accountId: AccountId, id: FaqId, input: UpdateFaqInput): Promise<Faq | null> {
+		if (!Types.ObjectId.isValid(id) || !Types.ObjectId.isValid(accountId)) {
+			return null;
+		}
+		const doc = await FaqModel.findOneAndUpdate(
+			{ _id: id, accountId: new Types.ObjectId(accountId) },
+			{ $set: input },
+			{ new: true },
+		).exec();
+		return doc ? mapFaq(doc) : null;
+	}
+
+	async delete(accountId: AccountId, id: FaqId): Promise<boolean> {
+		if (!Types.ObjectId.isValid(id) || !Types.ObjectId.isValid(accountId)) {
+			return false;
+		}
+		const result = await FaqModel.deleteOne({
 			_id: id,
 			accountId: new Types.ObjectId(accountId),
 		}).exec();

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -2,13 +2,17 @@ import type {
 	Account,
 	AccountBusinessInput,
 	AccountId,
+	CreateFaqInput,
 	CreateItemInput,
+	Faq,
+	FaqId,
 	Invite,
 	InviteId,
 	Item,
 	ItemId,
 	Membership,
 	Role,
+	UpdateFaqInput,
 	UpdateItemInput,
 	User,
 	UserId,
@@ -200,4 +204,18 @@ export interface ItemRepository {
 	findById(accountId: AccountId, id: ItemId): Promise<Item | null>;
 	update(accountId: AccountId, id: ItemId, input: UpdateItemInput): Promise<Item | null>;
 	delete(accountId: AccountId, id: ItemId): Promise<boolean>;
+}
+
+export interface ListFaqsOptions {
+	accountId: AccountId;
+	page: number;
+	pageSize: number;
+}
+
+export interface FaqRepository {
+	create(accountId: AccountId, input: CreateFaqInput): Promise<Faq>;
+	list(options: ListFaqsOptions): Promise<{ faqs: Faq[]; total: number }>;
+	findById(accountId: AccountId, id: FaqId): Promise<Faq | null>;
+	update(accountId: AccountId, id: FaqId, input: UpdateFaqInput): Promise<Faq | null>;
+	delete(accountId: AccountId, id: FaqId): Promise<boolean>;
 }

--- a/packages/api/src/routes/faqs.ts
+++ b/packages/api/src/routes/faqs.ts
@@ -1,0 +1,141 @@
+import {
+	type AccountId,
+	buildPaginationMeta,
+	createFaqSchema,
+	type FaqId,
+	paginationQuerySchema,
+	updateFaqSchema,
+} from '@rivus/core';
+import type { FastifyPluginAsync } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+	errorResponseSchema,
+	faqListResponseSchema,
+	faqResponseSchema,
+	idParamsSchema,
+} from '../http-schemas';
+
+export const faqRoutes: FastifyPluginAsync = async (fastify) => {
+	const app = fastify.withTypeProvider<ZodTypeProvider>();
+	const { faqs } = app.deps;
+
+	// Every FAQ route requires a valid JWT.
+	app.addHook('onRequest', fastify.authenticate);
+
+	app.get(
+		'/',
+		{
+			schema: {
+				tags: ['faqs'],
+				summary: "List your account's FAQs",
+				security: [{ bearerAuth: [] }],
+				querystring: paginationQuerySchema,
+				response: { 200: faqListResponseSchema, 401: errorResponseSchema },
+			},
+		},
+		async (request) => {
+			const accountId = request.user.accountId as AccountId;
+			const { page, pageSize } = request.query;
+			const { faqs: data, total } = await faqs.list({ accountId, page, pageSize });
+			return { data, meta: buildPaginationMeta({ page, pageSize, total }) };
+		},
+	);
+
+	app.post(
+		'/',
+		{
+			schema: {
+				tags: ['faqs'],
+				summary: 'Create an FAQ',
+				security: [{ bearerAuth: [] }],
+				body: createFaqSchema,
+				response: { 201: faqResponseSchema, 400: errorResponseSchema, 401: errorResponseSchema },
+			},
+		},
+		async (request, reply) => {
+			const faq = await faqs.create(request.user.accountId as AccountId, request.body);
+			return reply.code(201).send(faq);
+		},
+	);
+
+	app.get(
+		'/:id',
+		{
+			schema: {
+				tags: ['faqs'],
+				summary: 'Fetch one of your FAQs',
+				security: [{ bearerAuth: [] }],
+				params: idParamsSchema,
+				response: { 200: faqResponseSchema, 404: errorResponseSchema, 401: errorResponseSchema },
+			},
+		},
+		async (request) => {
+			const faq = await faqs.findById(
+				request.user.accountId as AccountId,
+				request.params.id as FaqId,
+			);
+			if (!faq) {
+				throw app.httpErrors.notFound('FAQ not found');
+			}
+			return faq;
+		},
+	);
+
+	app.patch(
+		'/:id',
+		{
+			schema: {
+				tags: ['faqs'],
+				summary: 'Update one of your FAQs',
+				security: [{ bearerAuth: [] }],
+				params: idParamsSchema,
+				body: updateFaqSchema,
+				response: {
+					200: faqResponseSchema,
+					400: errorResponseSchema,
+					404: errorResponseSchema,
+					401: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const faq = await faqs.update(
+				request.user.accountId as AccountId,
+				request.params.id as FaqId,
+				request.body,
+			);
+			if (!faq) {
+				throw app.httpErrors.notFound('FAQ not found');
+			}
+			return faq;
+		},
+	);
+
+	app.delete(
+		'/:id',
+		{
+			schema: {
+				tags: ['faqs'],
+				summary: 'Delete one of your FAQs',
+				security: [{ bearerAuth: [] }],
+				params: idParamsSchema,
+				response: {
+					204: z.null(),
+					401: errorResponseSchema,
+					404: errorResponseSchema,
+				},
+			},
+		},
+		async (request, reply) => {
+			const deleted = await faqs.delete(
+				request.user.accountId as AccountId,
+				request.params.id as FaqId,
+			);
+			if (!deleted) {
+				throw app.httpErrors.notFound('FAQ not found');
+			}
+			return reply.code(204).send(null);
+		},
+	);
+};

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -4,6 +4,7 @@ import { loadConfig } from './config';
 import { checkDatabaseReady, connectMongoose, disconnectMongoose } from './db/mongoose';
 import {
 	MongoAccountRepository,
+	MongoFaqRepository,
 	MongoInviteRepository,
 	MongoItemRepository,
 	MongoMembershipRepository,
@@ -26,6 +27,7 @@ export async function start(): Promise<void> {
 		invites: new MongoInviteRepository(),
 		onboarding: new MongoOnboardingRepository(),
 		items: new MongoItemRepository(),
+		faqs: new MongoFaqRepository(),
 		verificationCodes: new MongoVerificationCodeRepository(),
 		mailer: createMailer(config),
 		// Real readiness: run an actual query so "connected but unauthorized" reports

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -3,6 +3,7 @@ import type { FastifyReply, FastifyRequest } from 'fastify';
 import type { Config } from './config';
 import type {
 	AccountRepository,
+	FaqRepository,
 	InviteRepository,
 	ItemRepository,
 	MembershipRepository,
@@ -28,6 +29,7 @@ export interface AppDeps {
 	invites: InviteRepository;
 	onboarding: OnboardingRepository;
 	items: ItemRepository;
+	faqs: FaqRepository;
 	/** Stores one-time sign-in codes for passwordless auth. */
 	verificationCodes: VerificationCodeRepository;
 	/** Sends transactional email (invitations and sign-in codes). */

--- a/packages/api/test/faqs.test.ts
+++ b/packages/api/test/faqs.test.ts
@@ -1,0 +1,216 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { authHeader, buildTestApp, signupOwner } from './helpers';
+
+describe('faqs', () => {
+	let app: FastifyInstance;
+	let token: string;
+
+	beforeEach(async () => {
+		app = await buildTestApp();
+		token = (await signupOwner(app)).token;
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	async function createFaq(question: string, extra: Record<string, unknown> = {}) {
+		return app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: { question, answer: 'Because we said so.', ...extra },
+		});
+	}
+
+	it('requires authentication', async () => {
+		const response = await app.inject({ method: 'GET', url: '/v1/faqs' });
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('creates an FAQ with defaults', async () => {
+		const response = await createFaq('Do you offer free estimates?');
+
+		expect(response.statusCode).toBe(201);
+		expect(response.json()).toMatchObject({
+			question: 'Do you offer free estimates?',
+			answer: 'Because we said so.',
+			category: '',
+			status: 'published',
+		});
+		expect(response.json().id).toBeTypeOf('string');
+	});
+
+	it('keeps a provided category and status', async () => {
+		const response = await createFaq('What are your hours?', {
+			category: 'Scheduling',
+			status: 'draft',
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(response.json()).toMatchObject({ category: 'Scheduling', status: 'draft' });
+	});
+
+	it('rejects a create with no question (400)', async () => {
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: { answer: 'An answer with no question.' },
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects a create with no answer (400)', async () => {
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: { question: 'A question with no answer?' },
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('lists FAQs newest-first with pagination metadata', async () => {
+		await createFaq('one');
+		await createFaq('two');
+		await createFaq('three');
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/v1/faqs?page=1&pageSize=2',
+			headers: authHeader(token),
+		});
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.data).toHaveLength(2);
+		expect(body.meta).toMatchObject({
+			page: 1,
+			pageSize: 2,
+			total: 3,
+			totalPages: 2,
+			hasNextPage: true,
+			hasPreviousPage: false,
+		});
+		expect(body.data[0].question).toBe('three');
+	});
+
+	it('fetches a single FAQ by id', async () => {
+		const created = await createFaq('findable');
+		const id = created.json().id;
+
+		const response = await app.inject({
+			method: 'GET',
+			url: `/v1/faqs/${id}`,
+			headers: authHeader(token),
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().id).toBe(id);
+	});
+
+	it('returns 404 for an unknown id', async () => {
+		const response = await app.inject({
+			method: 'GET',
+			url: '/v1/faqs/does-not-exist',
+			headers: authHeader(token),
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	it('updates an FAQ', async () => {
+		const created = await createFaq('before');
+		const id = created.json().id;
+
+		const response = await app.inject({
+			method: 'PATCH',
+			url: `/v1/faqs/${id}`,
+			headers: authHeader(token),
+			payload: { status: 'draft' },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toMatchObject({ question: 'before', status: 'draft' });
+	});
+
+	it('rejects an empty update (400)', async () => {
+		const created = await createFaq('immutable');
+		const id = created.json().id;
+
+		const response = await app.inject({
+			method: 'PATCH',
+			url: `/v1/faqs/${id}`,
+			headers: authHeader(token),
+			payload: {},
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('deletes an FAQ, after which it is gone', async () => {
+		const created = await createFaq('temporary');
+		const id = created.json().id;
+
+		const deleteResponse = await app.inject({
+			method: 'DELETE',
+			url: `/v1/faqs/${id}`,
+			headers: authHeader(token),
+		});
+		expect(deleteResponse.statusCode).toBe(204);
+
+		const getResponse = await app.inject({
+			method: 'GET',
+			url: `/v1/faqs/${id}`,
+			headers: authHeader(token),
+		});
+		expect(getResponse.statusCode).toBe(404);
+	});
+
+	it('does not leak FAQs across owners', async () => {
+		const created = await createFaq('private');
+		const id = created.json().id;
+
+		const otherToken = (await signupOwner(app)).token;
+		const response = await app.inject({
+			method: 'GET',
+			url: `/v1/faqs/${id}`,
+			headers: authHeader(otherToken),
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	it('does not let another owner update an FAQ', async () => {
+		const created = await createFaq('private');
+		const id = created.json().id;
+		const otherToken = (await signupOwner(app)).token;
+
+		const response = await app.inject({
+			method: 'PATCH',
+			url: `/v1/faqs/${id}`,
+			headers: authHeader(otherToken),
+			payload: { question: 'hijacked' },
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	it('does not let another owner delete an FAQ', async () => {
+		const created = await createFaq('private');
+		const id = created.json().id;
+		const otherToken = (await signupOwner(app)).token;
+
+		const response = await app.inject({
+			method: 'DELETE',
+			url: `/v1/faqs/${id}`,
+			headers: authHeader(otherToken),
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+});

--- a/packages/api/test/helpers.ts
+++ b/packages/api/test/helpers.ts
@@ -27,7 +27,7 @@ const TEST_CONFIG = {
 } as NodeJS.ProcessEnv;
 
 export async function buildTestApp(overrides: Partial<AppDeps> = {}): Promise<FastifyInstance> {
-	const { users, accounts, memberships, invites, onboarding, items, verificationCodes } =
+	const { users, accounts, memberships, invites, onboarding, items, faqs, verificationCodes } =
 		createInMemoryRepositories();
 	const app = buildApp({
 		config: loadConfig(TEST_CONFIG),
@@ -37,6 +37,7 @@ export async function buildTestApp(overrides: Partial<AppDeps> = {}): Promise<Fa
 		invites,
 		onboarding,
 		items,
+		faqs,
 		verificationCodes,
 		// A recording mailer by default so helpers can read back the emailed code.
 		mailer: new RecordingMailer(),
@@ -56,7 +57,8 @@ export async function buildTestAppWithRepos(): Promise<{
 	repos: InMemoryRepositories;
 }> {
 	const repos = createInMemoryRepositories();
-	const { users, accounts, memberships, invites, onboarding, items, verificationCodes } = repos;
+	const { users, accounts, memberships, invites, onboarding, items, faqs, verificationCodes } =
+		repos;
 	const app = buildApp({
 		config: loadConfig(TEST_CONFIG),
 		users,
@@ -65,6 +67,7 @@ export async function buildTestAppWithRepos(): Promise<{
 		invites,
 		onboarding,
 		items,
+		faqs,
 		verificationCodes,
 		mailer: new RecordingMailer(),
 		ping: async () => ({ ready: true }),

--- a/packages/app/app/knowledge.tsx
+++ b/packages/app/app/knowledge.tsx
@@ -1,14 +1,145 @@
-import { useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import type { FaqStatus } from '@rivus/core';
+import { useCallback, useEffect, useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, View } from 'react-native';
+import { ApiError, type Faq } from '@/src/api/client';
+import { useAuth } from '@/src/auth/AuthContext';
 import { RivusSymbol } from '@/src/brand/RivusLogo';
 import { BrandGradient } from '@/src/components/Gradient';
-import { GradientButton, Icon, Pill, Txt } from '@/src/components/ui';
-import { faqCategories, faqs } from '@/src/data/demo';
+import {
+	Card,
+	GradientButton,
+	Icon,
+	OutlineButton,
+	Pill,
+	Segmented,
+	TextField,
+	Txt,
+} from '@/src/components/ui';
 import { colors, font, radii } from '@/src/theme/tokens';
 
+const STATUS_OPTIONS: { label: string; value: FaqStatus }[] = [
+	{ label: 'Published', value: 'published' },
+	{ label: 'Draft', value: 'draft' },
+];
+
 export default function KnowledgeScreen() {
+	const { session, client } = useAuth();
+
+	const [list, setList] = useState<Faq[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
 	const [active, setActive] = useState('All');
-	const visible = active === 'All' ? faqs : faqs.filter((f) => f.cat === active);
+
+	const [formOpen, setFormOpen] = useState(false);
+	const [editing, setEditing] = useState<Faq | null>(null);
+	const [question, setQuestion] = useState('');
+	const [answer, setAnswer] = useState('');
+	const [category, setCategory] = useState('');
+	const [status, setStatus] = useState<FaqStatus>('published');
+	const [formError, setFormError] = useState<string | null>(null);
+	const [saving, setSaving] = useState(false);
+	const [deleting, setDeleting] = useState(false);
+
+	const load = useCallback(async () => {
+		if (!session) {
+			return;
+		}
+		setLoading(true);
+		setError(null);
+		try {
+			// One page of 100 is plenty for an account's FAQ set; pagination metadata is
+			// returned but the knowledge base is small enough to show in full.
+			const data = await client.listFaqs(session.token, { pageSize: 100 });
+			setList(data.data);
+		} catch (caught) {
+			setError(caught instanceof ApiError ? caught.message : 'Could not load your FAQs.');
+		} finally {
+			setLoading(false);
+		}
+	}, [client, session]);
+
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	function openCreate() {
+		setEditing(null);
+		setQuestion('');
+		setAnswer('');
+		setCategory('');
+		setStatus('published');
+		setFormError(null);
+		setFormOpen(true);
+	}
+
+	function openEdit(faq: Faq) {
+		setEditing(faq);
+		setQuestion(faq.question);
+		setAnswer(faq.answer);
+		setCategory(faq.category);
+		setStatus(faq.status);
+		setFormError(null);
+		setFormOpen(true);
+	}
+
+	function closeForm() {
+		setFormOpen(false);
+		setFormError(null);
+	}
+
+	async function onSave() {
+		if (!session || saving) {
+			return;
+		}
+		setFormError(null);
+		setSaving(true);
+		try {
+			const input = {
+				question: question.trim(),
+				answer: answer.trim(),
+				category: category.trim(),
+				status,
+			};
+			if (editing) {
+				await client.updateFaq(session.token, editing.id, input);
+			} else {
+				await client.createFaq(session.token, input);
+			}
+			closeForm();
+			await load();
+		} catch (caught) {
+			setFormError(caught instanceof Error ? caught.message : 'Could not save the FAQ.');
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	async function onDelete() {
+		if (!session || !editing || deleting) {
+			return;
+		}
+		setFormError(null);
+		setDeleting(true);
+		try {
+			await client.deleteFaq(session.token, editing.id);
+			closeForm();
+			await load();
+		} catch (caught) {
+			setFormError(caught instanceof ApiError ? caught.message : 'Could not delete the FAQ.');
+		} finally {
+			setDeleting(false);
+		}
+	}
+
+	if (!session) {
+		return null;
+	}
+
+	const categories = [
+		'All',
+		...Array.from(new Set(list.map((faq) => faq.category).filter(Boolean))).sort(),
+	];
+	const visible = active === 'All' ? list : list.filter((faq) => faq.category === active);
 
 	return (
 		<ScrollView contentContainerStyle={styles.scroll}>
@@ -20,7 +151,7 @@ export default function KnowledgeScreen() {
 							The FAQs Rivus uses to answer your customers. Post once — Rivus handles the rest.
 						</Txt>
 					</View>
-					<GradientButton label="Add FAQ" icon="plus" />
+					<GradientButton label="Add FAQ" icon="plus" onPress={openCreate} />
 				</View>
 
 				<View style={styles.banner}>
@@ -46,43 +177,129 @@ export default function KnowledgeScreen() {
 					</Pressable>
 				</View>
 
-				<View style={styles.filters}>
-					{faqCategories.map((cat) => {
-						const on = cat === active;
-						return (
-							<Pressable
-								key={cat}
-								onPress={() => setActive(cat)}
-								style={[styles.filter, on && styles.filterOn]}
-							>
-								<Txt style={[styles.filterTxt, on && styles.filterTxtOn]}>{cat}</Txt>
+				{formOpen ? (
+					<Card style={styles.form}>
+						<View style={styles.formHead}>
+							<Txt style={styles.formTitle}>{editing ? 'Edit FAQ' : 'New FAQ'}</Txt>
+							<Pressable onPress={closeForm} accessibilityRole="button">
+								<Icon name="x" size={18} color={colors.textMuted} />
 							</Pressable>
-						);
-					})}
-				</View>
+						</View>
+						<TextField
+							label="Question"
+							value={question}
+							onChangeText={setQuestion}
+							placeholder="How much does a service call cost?"
+						/>
+						<TextField
+							label="Answer"
+							value={answer}
+							onChangeText={setAnswer}
+							placeholder="Our standard diagnostic visit is $89…"
+							multiline
+							style={styles.answerInput}
+						/>
+						<TextField
+							label="Category"
+							value={category}
+							onChangeText={setCategory}
+							placeholder="Pricing"
+							hint="Optional — groups FAQs in the filter bar."
+							autoCapitalize="words"
+						/>
+						<View style={styles.fieldWrap}>
+							<Txt style={styles.fieldLabel}>Status</Txt>
+							<Segmented options={STATUS_OPTIONS} value={status} onChange={setStatus} />
+						</View>
 
-				<View style={{ gap: 12 }}>
-					{visible.map((f) => (
-						<View key={f.q} style={styles.faq}>
-							<View style={styles.faqHead}>
-								<View style={styles.faqQ}>
-									<Pill label={f.cat} color={colors.brandPurple} background={colors.purpleTint} />
-									<Txt style={styles.faqQuestion} numberOfLines={1}>
-										{f.q}
+						{formError ? <Txt style={styles.errorTxt}>{formError}</Txt> : null}
+
+						<View style={styles.btnRow}>
+							<GradientButton
+								label={saving ? 'Saving…' : editing ? 'Save changes' : 'Add FAQ'}
+								icon="check"
+								onPress={onSave}
+								style={styles.btnGrow}
+							/>
+							<OutlineButton label="Cancel" onPress={closeForm} style={styles.btnGrow} />
+						</View>
+						{editing ? (
+							<OutlineButton
+								label={deleting ? 'Deleting…' : 'Delete FAQ'}
+								onPress={onDelete}
+								style={styles.deleteBtn}
+							/>
+						) : null}
+					</Card>
+				) : null}
+
+				{list.length > 0 ? (
+					<View style={styles.filters}>
+						{categories.map((cat) => {
+							const on = cat === active;
+							return (
+								<Pressable
+									key={cat}
+									onPress={() => setActive(cat)}
+									style={[styles.filter, on && styles.filterOn]}
+								>
+									<Txt style={[styles.filterTxt, on && styles.filterTxtOn]}>{cat}</Txt>
+								</Pressable>
+							);
+						})}
+					</View>
+				) : null}
+
+				{loading ? (
+					<ActivityIndicator color={colors.brandPurple} style={styles.loading} />
+				) : error ? (
+					<Txt style={styles.errorTxt}>{error}</Txt>
+				) : visible.length === 0 ? (
+					<Txt style={styles.empty}>
+						{list.length === 0
+							? 'No FAQs yet. Add your first one so Rivus can start answering with it.'
+							: 'No FAQs in this category.'}
+					</Txt>
+				) : (
+					<View style={{ gap: 12 }}>
+						{visible.map((faq) => (
+							<View key={faq.id} style={styles.faq}>
+								<View style={styles.faqHead}>
+									<View style={styles.faqQ}>
+										<Pill
+											label={faq.category || 'General'}
+											color={colors.brandPurple}
+											background={colors.purpleTint}
+										/>
+										<Txt style={styles.faqQuestion} numberOfLines={1}>
+											{faq.question}
+										</Txt>
+									</View>
+									<Pressable
+										style={styles.editBtn}
+										onPress={() => openEdit(faq)}
+										accessibilityRole="button"
+									>
+										<Icon name="edit-3" size={17} color={colors.textFaint} />
+									</Pressable>
+								</View>
+								<Txt style={styles.faqAnswer}>{faq.answer}</Txt>
+								<View style={styles.faqFoot}>
+									{faq.status === 'published' ? (
+										<BrandGradient style={styles.faqFootMark} />
+									) : (
+										<View style={[styles.faqFootMark, styles.faqFootMarkDraft]} />
+									)}
+									<Txt style={styles.faqFootTxt}>
+										{faq.status === 'published'
+											? 'Published — Rivus answers with this'
+											: 'Draft — not in use yet'}
 									</Txt>
 								</View>
-								<Pressable style={styles.editBtn}>
-									<Icon name="edit-3" size={17} color={colors.textFaint} />
-								</Pressable>
 							</View>
-							<Txt style={styles.faqAnswer}>{f.a}</Txt>
-							<View style={styles.faqFoot}>
-								<BrandGradient style={styles.faqFootMark} />
-								<Txt style={styles.faqFootTxt}>{f.uses}</Txt>
-							</View>
-						</View>
-					))}
-				</View>
+						))}
+					</View>
+				)}
 			</View>
 		</ScrollView>
 	);
@@ -160,6 +377,20 @@ const styles = StyleSheet.create({
 	},
 	suggestedBtnTxt: { fontFamily: font.semibold, fontSize: 12.5, color: colors.brandPurple },
 
+	form: { gap: 14, marginBottom: 22 },
+	formHead: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+	},
+	formTitle: { fontFamily: font.semibold, fontSize: 15, color: colors.text },
+	fieldWrap: { gap: 6 },
+	fieldLabel: { fontFamily: font.semibold, fontSize: 12.5, color: colors.textSub },
+	answerInput: { minHeight: 92, textAlignVertical: 'top' },
+	btnRow: { flexDirection: 'row', gap: 10, flexWrap: 'wrap' },
+	btnGrow: { flexGrow: 1, flexBasis: 140 },
+	deleteBtn: { borderColor: 'rgba(240,88,75,0.4)' },
+
 	filters: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 16 },
 	filter: {
 		paddingVertical: 6,
@@ -170,6 +401,14 @@ const styles = StyleSheet.create({
 	filterOn: { backgroundColor: colors.text },
 	filterTxt: { fontFamily: font.medium, fontSize: 12.5, color: colors.textSub },
 	filterTxtOn: { fontFamily: font.semibold, color: '#fff' },
+
+	loading: { paddingVertical: 24 },
+	empty: {
+		fontFamily: font.regular,
+		fontSize: 13,
+		color: colors.textMuted,
+		paddingVertical: 16,
+	},
 
 	faq: {
 		backgroundColor: colors.surface,
@@ -205,5 +444,7 @@ const styles = StyleSheet.create({
 		paddingTop: 11,
 	},
 	faqFootMark: { width: 14, height: 14, borderRadius: 4 },
+	faqFootMarkDraft: { backgroundColor: colors.textHint },
 	faqFootTxt: { fontFamily: font.regular, fontSize: 11.5, color: colors.textFaint },
+	errorTxt: { fontFamily: font.medium, fontSize: 12.5, color: colors.redInk },
 });

--- a/packages/app/app/knowledge.tsx
+++ b/packages/app/app/knowledge.tsx
@@ -47,10 +47,19 @@ export default function KnowledgeScreen() {
 		setLoading(true);
 		setError(null);
 		try {
-			// One page of 100 is plenty for an account's FAQ set; pagination metadata is
-			// returned but the knowledge base is small enough to show in full.
-			const data = await client.listFaqs(session.token, { pageSize: 100 });
-			setList(data.data);
+			// The API caps pageSize at 100 and this screen has no pagination/search UI,
+			// so page through everything — otherwise FAQs past the first 100 would vanish
+			// from the list with no way to edit or delete them.
+			const all: Faq[] = [];
+			let page = 1;
+			let hasNext = true;
+			while (hasNext) {
+				const { data, meta } = await client.listFaqs(session.token, { page, pageSize: 100 });
+				all.push(...data);
+				hasNext = meta.hasNextPage;
+				page += 1;
+			}
+			setList(all);
 		} catch (caught) {
 			setError(caught instanceof ApiError ? caught.message : 'Could not load your FAQs.');
 		} finally {

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import type { AccountId } from '@rivus/core';
+import type { AccountId, FaqId } from '@rivus/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError, createApiClient, ValidationError } from './client';
 
@@ -59,6 +59,20 @@ function makeItem() {
 		name: faker.commerce.productName(),
 		description: faker.commerce.productDescription(),
 		status: 'active' as const,
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+function makeFaq() {
+	const now = new Date().toISOString();
+	return {
+		id: faker.string.uuid(),
+		accountId: faker.string.uuid(),
+		question: `${faker.lorem.sentence().replace(/\.$/, '')}?`,
+		answer: faker.lorem.paragraph(),
+		category: faker.helpers.arrayElement(['Pricing', 'Scheduling', '']),
+		status: 'published' as const,
 		createdAt: now,
 		updatedAt: now,
 	};
@@ -451,6 +465,153 @@ describe('createApiClient', () => {
 			const client = createApiClient(BASE, fetchMock);
 			const result = await client.listItems('token');
 			expect(result.data).toEqual([]);
+		});
+	});
+
+	describe('listFaqs', () => {
+		it('returns parsed FAQs and sends the bearer auth header', async () => {
+			const faqs = [makeFaq(), makeFaq()];
+			const response = {
+				data: faqs,
+				meta: {
+					page: 1,
+					pageSize: 20,
+					total: faqs.length,
+					totalPages: 1,
+					hasNextPage: false,
+					hasPreviousPage: false,
+				},
+			};
+			fetchMock.mockResolvedValueOnce(jsonResponse(response));
+
+			const client = createApiClient(BASE, fetchMock);
+			const token = faker.string.alphanumeric(32);
+			const result = await client.listFaqs(token);
+
+			expect(result.data).toEqual(faqs);
+			expect(result.meta.total).toBe(faqs.length);
+
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/faqs?page=1&pageSize=20`);
+			expect(init.headers).toMatchObject({ Authorization: `Bearer ${token}` });
+		});
+
+		it('forwards custom pagination query params', async () => {
+			const response = {
+				data: [],
+				meta: {
+					page: 2,
+					pageSize: 100,
+					total: 0,
+					totalPages: 0,
+					hasNextPage: false,
+					hasPreviousPage: false,
+				},
+			};
+			fetchMock.mockResolvedValueOnce(jsonResponse(response));
+
+			const client = createApiClient(BASE, fetchMock);
+			await client.listFaqs('token', { page: 2, pageSize: 100 });
+
+			const [url] = fetchMock.mock.calls[0] as [string];
+			expect(url).toBe(`${BASE}/v1/faqs?page=2&pageSize=100`);
+		});
+	});
+
+	describe('createFaq', () => {
+		it('posts an FAQ with the bearer token and returns it', async () => {
+			const faq = makeFaq();
+			fetchMock.mockResolvedValueOnce(jsonResponse(faq, { status: 201 }));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.createFaq('owner-token', {
+				question: faq.question,
+				answer: faq.answer,
+				category: faq.category,
+				status: 'published',
+			});
+
+			expect(result).toEqual(faq);
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/faqs`);
+			expect(init.method).toBe('POST');
+			expect(init.headers).toMatchObject({
+				Authorization: 'Bearer owner-token',
+				'Content-Type': 'application/json',
+			});
+			expect(JSON.parse(init.body as string)).toMatchObject({
+				question: faq.question,
+				answer: faq.answer,
+			});
+		});
+
+		it('rejects an FAQ with no question/answer before hitting the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(
+				client.createFaq('tok', { question: '', answer: '', category: '', status: 'published' }),
+			).rejects.toThrow();
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('updateFaq', () => {
+		it('PATCHes the FAQ with the bearer token and returns it', async () => {
+			const faq = { ...makeFaq(), status: 'draft' as const };
+			fetchMock.mockResolvedValueOnce(jsonResponse(faq));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.updateFaq('owner-token', faq.id as FaqId, { status: 'draft' });
+
+			expect(result.status).toBe('draft');
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/faqs/${faq.id}`);
+			expect(init.method).toBe('PATCH');
+			expect(JSON.parse(init.body as string)).toEqual({ status: 'draft' });
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer owner-token' });
+		});
+
+		it('url-encodes the FAQ id', async () => {
+			fetchMock.mockResolvedValueOnce(jsonResponse(makeFaq()));
+
+			const client = createApiClient(BASE, fetchMock);
+			await client.updateFaq('tok', 'a/b c' as FaqId, { category: 'Pricing' });
+
+			const [url] = fetchMock.mock.calls[0] as [string];
+			expect(url).toBe(`${BASE}/v1/faqs/a%2Fb%20c`);
+		});
+
+		it('rejects an empty update before hitting the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.updateFaq('tok', 'id' as FaqId, {})).rejects.toThrow();
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('deleteFaq', () => {
+		it('DELETEs the FAQ with the bearer token and resolves on 204', async () => {
+			fetchMock.mockResolvedValueOnce(jsonResponse(undefined, { status: 204 }));
+
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.deleteFaq('owner-token', 'faq-1' as FaqId)).resolves.toBeUndefined();
+
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/faqs/faq-1`);
+			expect(init.method).toBe('DELETE');
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer owner-token' });
+		});
+
+		it('throws an ApiError when the FAQ is gone (404)', async () => {
+			fetchMock.mockResolvedValueOnce(
+				jsonResponse(
+					{ error: 'Not Found', message: 'FAQ not found', statusCode: 404 },
+					{ status: 404 },
+				),
+			);
+
+			const client = createApiClient(BASE, fetchMock);
+			const error = await client.deleteFaq('tok', 'missing' as never).catch((e) => e);
+			expect(error).toBeInstanceOf(ApiError);
+			expect(error.status).toBe(404);
 		});
 	});
 

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -552,6 +552,24 @@ describe('createApiClient', () => {
 			).rejects.toThrow();
 			expect(fetchMock).not.toHaveBeenCalled();
 		});
+
+		it('accepts just a question and answer, filling category/status defaults', async () => {
+			const faq = makeFaq();
+			fetchMock.mockResolvedValueOnce(jsonResponse(faq, { status: 201 }));
+
+			const client = createApiClient(BASE, fetchMock);
+			// category/status omitted — the schema defaults them, so the client must not
+			// require them at the type level and must send the defaulted values.
+			await client.createFaq('tok', { question: faq.question, answer: faq.answer });
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(JSON.parse(init.body as string)).toMatchObject({
+				question: faq.question,
+				answer: faq.answer,
+				category: '',
+				status: 'published',
+			});
+		});
 	});
 
 	describe('updateFaq', () => {

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -4,7 +4,6 @@ import {
 	type AccountId,
 	acceptInviteSchema,
 	accountStatusSchema,
-	type CreateFaqInput,
 	createFaqSchema,
 	type Faq,
 	type FaqId,
@@ -35,6 +34,13 @@ import { z } from 'zod';
 
 /** Signup accepts the schema's *input* (business defaults like timezone optional). */
 export type SignupBody = z.input<typeof signupSchema>;
+
+/**
+ * createFaq accepts the schema's *input*: `category` and `status` have schema
+ * defaults the API fills, so callers may omit them (don't force the parsed
+ * *output* type, which would make them required).
+ */
+export type CreateFaqBody = z.input<typeof createFaqSchema>;
 
 // `@rivus/core` brands its ids so a user id can't be passed where an item id is
 // expected. The wire format is a plain string; these helpers validate as strings
@@ -303,7 +309,7 @@ export interface RivusApiClient {
 	/** List the account's FAQs (the knowledge base Rivus answers from). */
 	listFaqs(token: string, query?: Partial<PaginationQuery>): Promise<FaqListResponse>;
 	/** Create an FAQ for the account. */
-	createFaq(token: string, input: CreateFaqInput): Promise<Faq>;
+	createFaq(token: string, input: CreateFaqBody): Promise<Faq>;
 	/** Update one of the account's FAQs. */
 	updateFaq(token: string, id: FaqId, input: UpdateFaqInput): Promise<Faq>;
 	/** Delete one of the account's FAQs. */
@@ -477,7 +483,7 @@ export function createApiClient(
 			});
 		},
 
-		async createFaq(token: string, input: CreateFaqInput) {
+		async createFaq(token: string, input: CreateFaqBody) {
 			const payload = parseInput(createFaqSchema, input);
 			return request('/v1/faqs', faqResponseSchema, jsonInit('POST', payload, token));
 		},

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -4,6 +4,11 @@ import {
 	type AccountId,
 	acceptInviteSchema,
 	accountStatusSchema,
+	type CreateFaqInput,
+	createFaqSchema,
+	type Faq,
+	type FaqId,
+	faqStatusSchema,
 	type InviteMemberInput,
 	type Item,
 	type ItemId,
@@ -18,9 +23,11 @@ import {
 	roleSchema,
 	signupSchema,
 	type UpdateAccountInput,
+	type UpdateFaqInput,
 	type User,
 	type UserId,
 	updateAccountSchema,
+	updateFaqSchema,
 	type VerifyCodeInput,
 	verifyCodeSchema,
 } from '@rivus/core';
@@ -33,6 +40,7 @@ export type SignupBody = z.input<typeof signupSchema>;
 // expected. The wire format is a plain string; these helpers validate as strings
 // while preserving the brand in the inferred type.
 const itemId = () => z.string().min(1) as unknown as z.ZodType<ItemId>;
+const faqId = () => z.string().min(1) as unknown as z.ZodType<FaqId>;
 const accountId = () => z.string().min(1) as unknown as z.ZodType<AccountId>;
 const userId = () => z.string().min(1) as unknown as z.ZodType<UserId>;
 
@@ -210,6 +218,31 @@ export interface ItemListResponse {
 	meta: PaginationMeta;
 }
 
+const faqResponseSchema = z.object({
+	id: faqId(),
+	accountId: accountId(),
+	question: z.string(),
+	answer: z.string(),
+	category: z.string(),
+	status: faqStatusSchema,
+	createdAt: z.string(),
+	updatedAt: z.string(),
+}) satisfies z.ZodType<Faq>;
+
+const faqListResponseSchema = z.object({
+	data: z.array(faqResponseSchema),
+	meta: paginationMetaSchema,
+});
+
+export interface FaqListResponse {
+	data: Faq[];
+	meta: PaginationMeta;
+}
+
+// A 204 No Content response (FAQ delete) has an empty body; the request helper
+// passes `undefined` to the schema, so accept exactly that.
+const noContentSchema = z.undefined();
+
 // A page of companies (accounts) for the staff company switcher.
 const accountListResponseSchema = z.object({
 	data: z.array(accountResponseSchema),
@@ -267,6 +300,14 @@ export interface RivusApiClient {
 	/** Read the account's billing summary (owner only). */
 	getBilling(token: string): Promise<Billing>;
 	listItems(token: string, query?: Partial<PaginationQuery>): Promise<ItemListResponse>;
+	/** List the account's FAQs (the knowledge base Rivus answers from). */
+	listFaqs(token: string, query?: Partial<PaginationQuery>): Promise<FaqListResponse>;
+	/** Create an FAQ for the account. */
+	createFaq(token: string, input: CreateFaqInput): Promise<Faq>;
+	/** Update one of the account's FAQs. */
+	updateFaq(token: string, id: FaqId, input: UpdateFaqInput): Promise<Faq>;
+	/** Delete one of the account's FAQs. */
+	deleteFaq(token: string, id: FaqId): Promise<void>;
 	/**
 	 * List/search every company, for the staff company switcher. Restricted to Rivus
 	 * staff server-side (a regular customer gets 403).
@@ -424,6 +465,39 @@ export function createApiClient(
 			});
 		},
 
+		async listFaqs(token: string, query?: Partial<PaginationQuery>) {
+			const { page, pageSize } = parseInput(paginationQuerySchema, query ?? {});
+			const search = new URLSearchParams({
+				page: String(page),
+				pageSize: String(pageSize),
+			});
+			return request(`/v1/faqs?${search.toString()}`, faqListResponseSchema, {
+				method: 'GET',
+				headers: authHeaders(token),
+			});
+		},
+
+		async createFaq(token: string, input: CreateFaqInput) {
+			const payload = parseInput(createFaqSchema, input);
+			return request('/v1/faqs', faqResponseSchema, jsonInit('POST', payload, token));
+		},
+
+		async updateFaq(token: string, id: FaqId, input: UpdateFaqInput) {
+			const payload = parseInput(updateFaqSchema, input);
+			return request(
+				`/v1/faqs/${encodeURIComponent(id)}`,
+				faqResponseSchema,
+				jsonInit('PATCH', payload, token),
+			);
+		},
+
+		async deleteFaq(token: string, id: FaqId) {
+			await request(`/v1/faqs/${encodeURIComponent(id)}`, noContentSchema, {
+				method: 'DELETE',
+				headers: authHeaders(token),
+			});
+		},
+
 		async listCompanies(token: string, query?: CompanyListQuery) {
 			const { page, pageSize } = parseInput(paginationQuerySchema, {
 				page: query?.page,
@@ -458,4 +532,4 @@ function safeJsonParse(raw: string): unknown {
 	}
 }
 
-export type { Account, Item, PaginationMeta, Role, User };
+export type { Account, Faq, Item, PaginationMeta, Role, User };

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -4,12 +4,14 @@ import {
 	acceptInviteSchema,
 	accountBusinessSchema,
 	accountStatusSchema,
+	createFaqSchema,
 	createItemSchema,
 	inviteMemberSchema,
 	loginSchema,
 	paginationQuerySchema,
 	signupSchema,
 	updateAccountSchema,
+	updateFaqSchema,
 	updateItemSchema,
 	updateMemberRoleSchema,
 	verifyCodeSchema,
@@ -216,6 +218,41 @@ describe('updateItemSchema', () => {
 
 	it('rejects an empty update', () => {
 		expect(() => updateItemSchema.parse({})).toThrow();
+	});
+});
+
+describe('createFaqSchema', () => {
+	it('applies defaults for category and status', () => {
+		expect(
+			createFaqSchema.parse({ question: 'Do you offer free estimates?', answer: 'Yes, always.' }),
+		).toMatchObject({ category: '', status: 'published' });
+	});
+
+	it('requires both a question and an answer', () => {
+		expect(() => createFaqSchema.parse({ question: 'Anyone home?' })).toThrow();
+		expect(() => createFaqSchema.parse({ answer: 'No question here.' })).toThrow();
+	});
+
+	it('prompts in plain language when the question is blank', () => {
+		const result = createFaqSchema.safeParse({ question: '   ', answer: 'A' });
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe('Question is required.');
+	});
+
+	it('rejects an unknown status', () => {
+		expect(() =>
+			createFaqSchema.parse({ question: 'Q?', answer: 'A.', status: 'archived' }),
+		).toThrow();
+	});
+});
+
+describe('updateFaqSchema', () => {
+	it('accepts a partial update', () => {
+		expect(updateFaqSchema.parse({ status: 'draft' })).toEqual({ status: 'draft' });
+	});
+
+	it('rejects an empty update', () => {
+		expect(() => updateFaqSchema.parse({})).toThrow();
 	});
 });
 

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -186,6 +186,35 @@ export const updateItemSchema = z
 	});
 export type UpdateItemInput = z.infer<typeof updateItemSchema>;
 
+export const faqStatusSchema = z.enum(['published', 'draft'], {
+	error: 'Status must be either published or draft.',
+});
+
+export const createFaqSchema = z.object({
+	question: requiredText('Question', 300),
+	answer: requiredText('Answer', 4000),
+	category: optionalText('Category', 80).default(''),
+	status: faqStatusSchema.default('published'),
+});
+export type CreateFaqInput = z.infer<typeof createFaqSchema>;
+
+/**
+ * Every field optional, but at least one must be present — mirrors
+ * {@link updateItemSchema}. No `.default()`s (unlike create) so a partial update
+ * only touches the fields the caller actually sent.
+ */
+export const updateFaqSchema = z
+	.object({
+		question: requiredText('Question', 300).optional(),
+		answer: requiredText('Answer', 4000).optional(),
+		category: optionalText('Category', 80).optional(),
+		status: faqStatusSchema.optional(),
+	})
+	.refine((value) => Object.values(value).some((field) => field !== undefined), {
+		error: 'Provide at least one field to update.',
+	});
+export type UpdateFaqInput = z.infer<typeof updateFaqSchema>;
+
 /** Query string for list endpoints; coerces `?page=2&pageSize=50`. */
 export const paginationQuerySchema = z.object({
 	page: z.coerce.number().int().min(1, { error: 'Page must be 1 or greater.' }).default(1),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,6 +6,7 @@ export type Id<TBrand extends string> = string & { readonly __brand: TBrand };
 
 export type UserId = Id<'User'>;
 export type ItemId = Id<'Item'>;
+export type FaqId = Id<'Faq'>;
 export type AccountId = Id<'Account'>;
 export type MembershipId = Id<'Membership'>;
 export type InviteId = Id<'Invite'>;
@@ -94,6 +95,26 @@ export interface Item {
 	name: string;
 	description: string;
 	status: ItemStatus;
+	createdAt: IsoDateString;
+	updatedAt: IsoDateString;
+}
+
+/**
+ * Whether an FAQ is live. `published` FAQs are the ones Rivus draws on to answer
+ * customers; `draft` keeps an answer staged but unused until it's ready.
+ */
+export type FaqStatus = 'published' | 'draft';
+
+/** A question-and-answer entry in an account's knowledge base. */
+export interface Faq {
+	id: FaqId;
+	/** The account that owns this FAQ; all members share the account's FAQs. */
+	accountId: AccountId;
+	question: string;
+	answer: string;
+	/** Free-text grouping (e.g. "Pricing", "Scheduling"); empty when uncategorized. */
+	category: string;
+	status: FaqStatus;
 	createdAt: IsoDateString;
 	updatedAt: IsoDateString;
 }

--- a/packages/docs/site/docs/api.md
+++ b/packages/docs/site/docs/api.md
@@ -69,3 +69,35 @@ endpoints are paginated with `?page=` and `?pageSize=` and return a `meta` block
   }
 }
 ```
+
+## FAQs
+
+FAQs are the question-and-answer entries Rivus draws on to answer your customers.
+They are account-scoped (shared by every member) and support full CRUD under
+`/v1/faqs`. Each FAQ has a `question`, an `answer`, an optional `category`, and a
+`status` of `published` (live) or `draft` (staged but not used yet). The list
+endpoint is paginated just like Items.
+
+```bash
+# Create an FAQ (status defaults to "published", category to "")
+curl -s -X POST http://localhost:4000/v1/faqs \
+  -H "authorization: Bearer $TOKEN" -H 'content-type: application/json' \
+  -d '{
+    "question": "How much does a service call cost?",
+    "answer": "Our standard diagnostic visit is $89, credited toward any same-day repair.",
+    "category": "Pricing"
+  }'
+
+# List your FAQs (paginated)
+curl -s "http://localhost:4000/v1/faqs?page=1&pageSize=20" \
+  -H "authorization: Bearer $TOKEN"
+
+# Update one (any subset of fields; e.g. take it offline)
+curl -s -X PATCH http://localhost:4000/v1/faqs/<id> \
+  -H "authorization: Bearer $TOKEN" -H 'content-type: application/json' \
+  -d '{"status":"draft"}'
+
+# Delete one
+curl -s -X DELETE http://localhost:4000/v1/faqs/<id> \
+  -H "authorization: Bearer $TOKEN"
+```

--- a/packages/docs/site/openapi.json
+++ b/packages/docs/site/openapi.json
@@ -976,6 +976,150 @@
         }
       }
     },
+    "/v1/admin/companies": {
+      "get": {
+        "summary": "List/search every company (Rivus staff only)",
+        "tags": [
+          "admin"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 160
+            },
+            "in": "query",
+            "name": "search",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/companies/{id}/switch": {
+      "post": {
+        "summary": "Switch the active company, re-issuing the session (Rivus staff only)",
+        "tags": [
+          "admin"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/billing/": {
       "get": {
         "summary": "Billing summary for the account (owner only)",
@@ -1307,6 +1451,358 @@
         "summary": "Delete one of your items",
         "tags": [
           "items"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/faqs/": {
+      "get": {
+        "summary": "List your account's FAQs",
+        "tags": [
+          "faqs"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FaqList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create an FAQ",
+        "tags": [
+          "faqs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "answer": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 4000
+                  },
+                  "category": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 80
+                  },
+                  "status": {
+                    "default": "published",
+                    "type": "string",
+                    "enum": [
+                      "published",
+                      "draft"
+                    ]
+                  }
+                },
+                "required": [
+                  "question",
+                  "answer"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Faq"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/faqs/{id}": {
+      "get": {
+        "summary": "Fetch one of your FAQs",
+        "tags": [
+          "faqs"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Faq"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update one of your FAQs",
+        "tags": [
+          "faqs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "answer": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 4000
+                  },
+                  "category": {
+                    "type": "string",
+                    "maxLength": 80
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "published",
+                      "draft"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Faq"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete one of your FAQs",
+        "tags": [
+          "faqs"
         ],
         "parameters": [
           {


### PR DESCRIPTION
## What & why

The "Knowledge" FAQ feature was designed and marketed but had **no backend** — the app rendered hard-coded mock FAQs from `demo.ts`, and there was no data model, REST API, or client wiring. This makes FAQs **fully functional end to end**, mirroring the existing account-scoped `items` resource 1:1.

A FAQ is a per-account question/answer entry: `question`, `answer`, optional `category`, and a `status` of `published` (live — what Rivus would answer from) or `draft` (staged but unused). Auth-gated and account-isolated exactly like items.

## Changes

**`@rivus/core`** — `Faq` / `FaqId` / `FaqStatus` types and `createFaqSchema` / `updateFaqSchema` (reusing the existing `requiredText` / `optionalText` helpers and the `itemStatusSchema` split), plus schema tests.

**`@rivus/api`** — `FaqModel` (Mongoose), a `FaqRepository` interface with **both** in-memory and Mongo implementations, HTTP response schemas, and a JWT-guarded CRUD route at `/v1/faqs` (`GET` list paginated, `POST`, `GET/:id`, `PATCH/:id`, `DELETE/:id`). Wired through `AppDeps`, the Mongo server, OpenAPI generation, and test helpers. Covered by `test/faqs.test.ts` (defaults, validation 400s, 404s, cross-account isolation) mirroring the items tests.

**`@rivus/app`** — `listFaqs` / `createFaq` / `updateFaq` / `deleteFaq` on the API client (with unit tests), and a live **Knowledge screen** with add / edit / delete, category filters derived from the data, and a published/draft toggle. The decorative stats banner and AI-suggestion card are **kept as static flourish** by design.

**`@rivus/docs`** — regenerated OpenAPI spec (now includes `/v1/faqs` and `/v1/faqs/{id}`) synced into the docs site, plus an "FAQs" usage section. The docs spec sync also picked up pre-existing drift (the committed copy was missing the `/v1/admin/companies` paths).

## Verification

All CI gates pass locally:

- `pnpm lint` — clean (Biome)
- `pnpm type-check` — all 6 packages
- `pnpm test` — **371 tests pass** (core 71, api 168, app 75, website 43, worker 14)
- `pnpm build` — core + api bundle cleanly
- Coverage stays above thresholds without changes: API 96.9% stmts / 90.8% branches; app client 100% / 96.6%.

No new dependencies; no worker/website changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SranNxkkiL1bsVeiyUERc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01SranNxkkiL1bsVeiyUERc8)_