### PR TITLE
feat(knowledge): AI duplicate-FAQ detection with merge on Add FAQ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,18 @@ NODE_ENV=development
 EMAIL_FROM=Rivus <hello@rivus.ai>
 # Base URL of the app; used to build the accept link in invitation emails.
 APP_URL=https://app.rivus.ai
+# AI duplicate-FAQ check (knowledge base). Runs through the AI SDK, so any
+# provider whose key is set can serve it — OpenAI is the primary, the rest are
+# backups (tried in order). When no key is set the check is a no-op, so the
+# "Add FAQ" flow simply never reports a duplicate.
+# OPENAI_API_KEY=sk-...
+# OPENAI_MODEL=gpt-5.4-mini
+# GOOGLE_GENERATIVE_AI_API_KEY=...
+# GEMINI_MODEL=gemini-2.5-flash
+# XAI_API_KEY=xai-...
+# XAI_MODEL=grok-4-fast
+# ANTHROPIC_API_KEY=sk-ant-...
+# ANTHROPIC_MODEL=claude-haiku-4-5
 
 # --- @rivus/website -----------------------------------------------------------
 # Base URL the marketing site uses to reach the API.

--- a/.github/workflows/deploy-development.yaml
+++ b/.github/workflows/deploy-development.yaml
@@ -123,6 +123,8 @@ jobs:
       # Passwordless auth emails the sign-in code, so the container (NODE_ENV=
       # production) refuses to boot without this.
       DEV_RESEND_API_KEY: ${{ secrets.DEV_RESEND_API_KEY }}
+      # Optional: enables the AI duplicate-FAQ check. Unset → the check is a no-op.
+      DEV_OPENAI_API_KEY: ${{ secrets.DEV_OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
@@ -136,3 +138,8 @@ jobs:
           printf '%s' "$DEV_MONGODB_URI" | pnpm --filter @rivus/api exec wrangler secret put MONGODB_URI --env development
           printf '%s' "$DEV_JWT_SECRET" | pnpm --filter @rivus/api exec wrangler secret put JWT_SECRET --env development
           printf '%s' "$DEV_RESEND_API_KEY" | pnpm --filter @rivus/api exec wrangler secret put RESEND_API_KEY --env development
+      # Optional AI key — pushed only when the GitHub secret is set.
+      - name: Sync optional AI secret
+        if: ${{ env.DEV_OPENAI_API_KEY != '' }}
+        run: |
+          printf '%s' "$DEV_OPENAI_API_KEY" | pnpm --filter @rivus/api exec wrangler secret put OPENAI_API_KEY --env development

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -125,6 +125,8 @@ jobs:
       PROD_MONGODB_URI: ${{ secrets.PROD_MONGODB_URI }}
       PROD_JWT_SECRET: ${{ secrets.PROD_JWT_SECRET }}
       PROD_RESEND_API_KEY: ${{ secrets.PROD_RESEND_API_KEY }}
+      # Optional: enables the AI duplicate-FAQ check. Unset → the check is a no-op.
+      PROD_OPENAI_API_KEY: ${{ secrets.PROD_OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
@@ -147,3 +149,9 @@ jobs:
           printf '%s' "$PROD_MONGODB_URI" | pnpm --filter @rivus/api exec wrangler secret put MONGODB_URI --env production
           printf '%s' "$PROD_JWT_SECRET" | pnpm --filter @rivus/api exec wrangler secret put JWT_SECRET --env production
           printf '%s' "$PROD_RESEND_API_KEY" | pnpm --filter @rivus/api exec wrangler secret put RESEND_API_KEY --env production
+      # Optional AI key — pushed only when set, so an unset secret never reaches the
+      # container as an empty value (which would fail loadConfig's min(1) and crash-loop it).
+      - name: Sync optional AI secret
+        if: ${{ env.PROD_OPENAI_API_KEY != '' }}
+        run: |
+          printf '%s' "$PROD_OPENAI_API_KEY" | pnpm --filter @rivus/api exec wrangler secret put OPENAI_API_KEY --env production

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -111,6 +111,19 @@ secret exists), the **production** `deploy-api` job **fails fast** if either
 `PROD_MONGODB_URI` or `PROD_JWT_SECRET` is missing — the container always boots
 with `NODE_ENV=production` and would crash-loop without them.
 
+### Optional secrets (AI duplicate-FAQ detection)
+
+| Secret                 | Environment | Notes                                                     |
+| ---------------------- | ----------- | --------------------------------------------------------- |
+| `DEV_OPENAI_API_KEY`   | development | OpenAI key for the knowledge-base duplicate check. Pushed as the `OPENAI_API_KEY` Worker secret by `deploy-api`. |
+| `PROD_OPENAI_API_KEY`  | production  | Same, for production. |
+
+These are **optional**: the `deploy-api` job pushes `OPENAI_API_KEY` only when the
+secret is set, and when no key is present the "is this a duplicate?" check simply
+no-ops (FAQs are still created normally). The model defaults to `gpt-5.4-mini`; since
+the model id isn't sensitive, override it — if needed — by adding `OPENAI_MODEL` to
+the relevant environment's `vars` in `packages/api/wrangler.jsonc` rather than as a secret.
+
 The production API also restricts CORS to Rivus origins: `CORS_ORIGIN` is set to
 `https://rivus.ai,*.rivus.ai`, which the API parses into the exact apex origin
 plus a regex matching any `*.rivus.ai` subdomain. The deployed development

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1647,6 +1647,76 @@
         }
       }
     },
+    "/v1/faqs/similar": {
+      "post": {
+        "summary": "Check whether a similar FAQ already exists (AI-assisted)",
+        "tags": [
+          "faqs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "answer": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 4000
+                  }
+                },
+                "required": [
+                  "question"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FaqSimilarity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/faqs/{id}": {
       "get": {
         "summary": "Fetch one of your FAQs",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,6 +20,10 @@
 		"clean": "rm -rf dist coverage"
 	},
 	"dependencies": {
+		"@ai-sdk/anthropic": "^3.0.85",
+		"@ai-sdk/google": "^3.0.83",
+		"@ai-sdk/openai": "^3.0.73",
+		"@ai-sdk/xai": "^3.0.96",
 		"@fastify/cookie": "^11.0.2",
 		"@fastify/cors": "^11.2.0",
 		"@fastify/helmet": "^13.0.2",
@@ -28,6 +32,7 @@
 		"@fastify/swagger": "^9.7.0",
 		"@fastify/swagger-ui": "^6.0.0",
 		"@rivus/core": "workspace:*",
+		"ai": "^6.0.208",
 		"close-with-grace": "^2.5.0",
 		"fastify": "^5.8.5",
 		"fastify-plugin": "^6.0.0",

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -25,6 +25,20 @@ const envSchema = z
 		EMAIL_FROM: z.string().min(3).default('Rivus <hello@rivus.ai>'),
 		// Base URL of the app, used to build the link in invitation emails.
 		APP_URL: z.string().url().default('https://app.rivus.ai'),
+		// --- AI (duplicate-FAQ detection) ---
+		// The knowledge base's "is this a duplicate?" check runs through the AI SDK,
+		// so any provider whose key is set can serve it. OpenAI is the primary; the
+		// rest act as backups (tried in order when an earlier provider errors). When
+		// no key is set the check is a no-op (the "Add FAQ" flow never reports a
+		// duplicate), so none of these are required and none gate production boot.
+		OPENAI_API_KEY: z.string().min(1).optional(),
+		OPENAI_MODEL: z.string().min(1).default('gpt-5.4-mini'),
+		GOOGLE_GENERATIVE_AI_API_KEY: z.string().min(1).optional(),
+		GEMINI_MODEL: z.string().min(1).default('gemini-2.5-flash'),
+		XAI_API_KEY: z.string().min(1).optional(),
+		XAI_MODEL: z.string().min(1).default('grok-4-fast'),
+		ANTHROPIC_API_KEY: z.string().min(1).optional(),
+		ANTHROPIC_MODEL: z.string().min(1).default('claude-haiku-4-5'),
 	})
 	.superRefine((env, ctx) => {
 		// In production, refuse to boot with the well-known dev secret or a weak one.

--- a/packages/api/src/http-schemas.ts
+++ b/packages/api/src/http-schemas.ts
@@ -153,6 +153,19 @@ export const faqListResponseSchema = z
 	})
 	.meta({ id: 'FaqList' });
 
+/**
+ * Result of the AI duplicate check run before creating an FAQ. `match` is the
+ * existing FAQ a new one would duplicate (or null when none is similar), and
+ * `merged` is the AI-combined question/answer the client offers as an update.
+ */
+export const faqSimilarityResponseSchema = z
+	.object({
+		match: faqResponseSchema.nullable(),
+		reason: z.string(),
+		merged: z.object({ question: z.string(), answer: z.string() }).nullable(),
+	})
+	.meta({ id: 'FaqSimilarity' });
+
 /** A page of companies (accounts) for the staff company switcher. */
 export const accountListResponseSchema = z
 	.object({

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -4,6 +4,7 @@ import { buildApp } from './app';
 import { loadConfig } from './config';
 import { createInMemoryRepositories } from './repositories/memory';
 import { NoopMailer } from './services/email';
+import { NoopFaqSimilarityService } from './services/faq-similarity';
 
 /**
  * Boot the app with in-memory repositories (no database needed) purely to read
@@ -25,6 +26,7 @@ async function main(): Promise<void> {
 		faqs,
 		verificationCodes,
 		mailer: new NoopMailer(),
+		faqSimilarity: new NoopFaqSimilarityService(),
 		ping: async () => ({ ready: true }),
 	});
 

--- a/packages/api/src/routes/faqs.ts
+++ b/packages/api/src/routes/faqs.ts
@@ -2,7 +2,9 @@ import {
 	type AccountId,
 	buildPaginationMeta,
 	createFaqSchema,
+	type Faq,
 	type FaqId,
+	faqSimilarityQuerySchema,
 	paginationQuerySchema,
 	updateFaqSchema,
 } from '@rivus/core';
@@ -13,12 +15,16 @@ import {
 	errorResponseSchema,
 	faqListResponseSchema,
 	faqResponseSchema,
+	faqSimilarityResponseSchema,
 	idParamsSchema,
 } from '../http-schemas';
 
+/** Cap how many of the account's FAQs we feed the duplicate check. */
+const SIMILARITY_CANDIDATE_LIMIT = 200;
+
 export const faqRoutes: FastifyPluginAsync = async (fastify) => {
 	const app = fastify.withTypeProvider<ZodTypeProvider>();
-	const { faqs } = app.deps;
+	const { faqs, faqSimilarity } = app.deps;
 
 	// Every FAQ route requires a valid JWT.
 	app.addHook('onRequest', fastify.authenticate);
@@ -56,6 +62,53 @@ export const faqRoutes: FastifyPluginAsync = async (fastify) => {
 		async (request, reply) => {
 			const faq = await faqs.create(request.user.accountId as AccountId, request.body);
 			return reply.code(201).send(faq);
+		},
+	);
+
+	// Registered before `/:id` so the literal path isn't shadowed by the param route.
+	app.post(
+		'/similar',
+		{
+			schema: {
+				tags: ['faqs'],
+				summary: 'Check whether a similar FAQ already exists (AI-assisted)',
+				security: [{ bearerAuth: [] }],
+				body: faqSimilarityQuerySchema,
+				response: {
+					200: faqSimilarityResponseSchema,
+					400: errorResponseSchema,
+					401: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const accountId = request.user.accountId as AccountId;
+			const { question, answer } = request.body;
+
+			// Gather the account's FAQs as candidates (paging the 100-capped list),
+			// bounded so the prompt stays small.
+			const candidates: Faq[] = [];
+			let page = 1;
+			while (candidates.length < SIMILARITY_CANDIDATE_LIMIT) {
+				const { faqs: data, total } = await faqs.list({ accountId, page, pageSize: 100 });
+				candidates.push(...data);
+				if (data.length === 0 || candidates.length >= total) {
+					break;
+				}
+				page += 1;
+			}
+
+			const match = await faqSimilarity.findSimilar({ question, answer }, candidates);
+			if (!match) {
+				return { match: null, reason: '', merged: null };
+			}
+			// Re-resolve the id against this account as a final guard before returning.
+			const existing = await faqs.findById(accountId, match.faqId);
+			if (!existing) {
+				return { match: null, reason: '', merged: null };
+			}
+			const merged = await faqSimilarity.mergeSuggestion({ question, answer }, existing);
+			return { match: existing, reason: match.reason, merged };
 		},
 	);
 

--- a/packages/api/src/routes/faqs.ts
+++ b/packages/api/src/routes/faqs.ts
@@ -2,7 +2,6 @@ import {
 	type AccountId,
 	buildPaginationMeta,
 	createFaqSchema,
-	type Faq,
 	type FaqId,
 	faqSimilarityQuerySchema,
 	paginationQuerySchema,
@@ -19,8 +18,10 @@ import {
 	idParamsSchema,
 } from '../http-schemas';
 
-/** Cap how many of the account's FAQs we feed the duplicate check. */
-const SIMILARITY_CANDIDATE_LIMIT = 200;
+// Matches the service's own candidate cap and the list is newest-first, so a
+// single page covers exactly what the duplicate check will consider — fetching
+// more would only load rows the service discards.
+const SIMILARITY_CANDIDATE_LIMIT = 50;
 
 export const faqRoutes: FastifyPluginAsync = async (fastify) => {
 	const app = fastify.withTypeProvider<ZodTypeProvider>();
@@ -85,18 +86,12 @@ export const faqRoutes: FastifyPluginAsync = async (fastify) => {
 			const accountId = request.user.accountId as AccountId;
 			const { question, answer } = request.body;
 
-			// Gather the account's FAQs as candidates (paging the 100-capped list),
-			// bounded so the prompt stays small.
-			const candidates: Faq[] = [];
-			let page = 1;
-			while (candidates.length < SIMILARITY_CANDIDATE_LIMIT) {
-				const { faqs: data, total } = await faqs.list({ accountId, page, pageSize: 100 });
-				candidates.push(...data);
-				if (data.length === 0 || candidates.length >= total) {
-					break;
-				}
-				page += 1;
-			}
+			// The newest page of FAQs is the candidate set the duplicate check scores.
+			const { faqs: candidates } = await faqs.list({
+				accountId,
+				page: 1,
+				pageSize: SIMILARITY_CANDIDATE_LIMIT,
+			});
 
 			const match = await faqSimilarity.findSimilar({ question, answer }, candidates);
 			if (!match) {

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -12,6 +12,7 @@ import {
 	MongoUserRepository,
 	MongoVerificationCodeRepository,
 } from './repositories/mongo';
+import { createFaqSimilarityService } from './services/faq-similarity';
 import { createMailer } from './services/resend-mailer';
 
 /** Connect to Mongo, build the app with Mongo-backed repositories, and listen. */
@@ -30,6 +31,7 @@ export async function start(): Promise<void> {
 		faqs: new MongoFaqRepository(),
 		verificationCodes: new MongoVerificationCodeRepository(),
 		mailer: createMailer(config),
+		faqSimilarity: createFaqSimilarityService(config),
 		// Real readiness: run an actual query so "connected but unauthorized" reports
 		// unready (503, with the reason) instead of falsely healthy.
 		ping: checkDatabaseReady,

--- a/packages/api/src/services/faq-similarity.ts
+++ b/packages/api/src/services/faq-similarity.ts
@@ -1,0 +1,274 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createXai } from '@ai-sdk/xai';
+import type { Faq, FaqId } from '@rivus/core';
+import { generateObject, type LanguageModel } from 'ai';
+import { z } from 'zod';
+import type { Config } from '../config';
+
+/**
+ * When checking a new FAQ for duplicates we only ever send the existing FAQs'
+ * questions (not their answers), and we cap how many we send, to keep the prompt
+ * small and the token cost bounded. `MAX_OUTPUT_TOKENS` likewise caps the reply.
+ */
+const MAX_CANDIDATES = 50;
+const MAX_OUTPUT_TOKENS = 600;
+/** Below this the match is too weak to interrupt the user with a modal. */
+const MIN_CONFIDENCE = 0.6;
+
+/** What the model returns when asked to find a near-duplicate. */
+const similaritySchema = z.object({
+	faqId: z.string().nullable(),
+	confidence: z.number(),
+	reason: z.string(),
+});
+
+/** What the model returns when asked to combine two FAQs into one. */
+const mergeSchema = z.object({
+	question: z.string(),
+	answer: z.string(),
+});
+
+export interface FaqSimilarityMatch {
+	faqId: FaqId;
+	/** 0..1 — how confident the model is that this is a duplicate. */
+	confidence: number;
+	/** One short sentence explaining the match, shown in the modal. */
+	reason: string;
+}
+
+export interface FaqMergeSuggestion {
+	question: string;
+	answer: string;
+}
+
+export interface FaqSimilarityService {
+	/**
+	 * Return the existing FAQ that is the closest semantic duplicate of `input`,
+	 * or `null` when none is similar enough (or the check can't run). Never throws.
+	 */
+	findSimilar(
+		input: { question: string; answer: string },
+		candidates: Faq[],
+	): Promise<FaqSimilarityMatch | null>;
+	/**
+	 * Combine the new input with an existing FAQ into one improved FAQ. Never
+	 * throws — falls back to a deterministic combine if the model is unavailable.
+	 */
+	mergeSuggestion(
+		input: { question: string; answer: string },
+		existing: Faq,
+	): Promise<FaqMergeSuggestion>;
+}
+
+/**
+ * The single AI call this service makes, narrowed to what we use. Injectable so
+ * tests can drive the logic (fallback ordering, guards, parsing) without a model
+ * or the network. Defaults to the AI SDK's {@link generateObject}.
+ */
+export type GenerateObjectFn = <T>(options: {
+	model: LanguageModel;
+	schema: z.ZodType<T>;
+	schemaName?: string;
+	system?: string;
+	prompt: string;
+	maxOutputTokens?: number;
+}) => Promise<{ object: T }>;
+
+const defaultGenerateObject: GenerateObjectFn = async (options) => {
+	const { object } = await generateObject({
+		model: options.model,
+		schema: options.schema,
+		schemaName: options.schemaName,
+		system: options.system,
+		prompt: options.prompt,
+		maxOutputTokens: options.maxOutputTokens,
+	});
+	return { object };
+};
+
+const SIMILARITY_SYSTEM =
+	'You deduplicate a customer-support FAQ knowledge base. Decide whether the NEW FAQ ' +
+	'is a semantic near-duplicate of one of the EXISTING FAQs — the same underlying ' +
+	'question, even if worded differently. Return the id of the single best matching ' +
+	'existing FAQ with a confidence in [0,1], or faqId=null if none is a near-duplicate. ' +
+	'Give a one-sentence reason.';
+
+const MERGE_SYSTEM =
+	'You merge two overlapping customer-support FAQs into one clear, non-redundant FAQ. ' +
+	'Combine the information from both answers, keep it accurate and concise, remove ' +
+	'duplication, and prefer the clearer phrasing. Return a single question and a single ' +
+	'combined answer.';
+
+/**
+ * AI-backed duplicate detection. Tries each model in order, so callers can pass a
+ * primary plus backups from other providers; if every model fails the call
+ * degrades to `null` (find) or a deterministic combine (merge) rather than
+ * throwing into the request path.
+ */
+export class AiFaqSimilarityService implements FaqSimilarityService {
+	private readonly models: LanguageModel[];
+	private readonly generate: GenerateObjectFn;
+
+	constructor(options: { models: LanguageModel[]; generate?: GenerateObjectFn }) {
+		this.models = options.models;
+		this.generate = options.generate ?? defaultGenerateObject;
+	}
+
+	/** Try each model in turn; return the first success, or null if all fail. */
+	private async generateWithFallback<T>(options: {
+		schema: z.ZodType<T>;
+		schemaName: string;
+		system: string;
+		prompt: string;
+	}): Promise<T | null> {
+		for (const model of this.models) {
+			try {
+				const { object } = await this.generate({
+					model,
+					schema: options.schema,
+					schemaName: options.schemaName,
+					system: options.system,
+					prompt: options.prompt,
+					maxOutputTokens: MAX_OUTPUT_TOKENS,
+				});
+				return object;
+			} catch {
+				// This provider failed — fall through to the next backup model.
+			}
+		}
+		return null;
+	}
+
+	async findSimilar(
+		input: { question: string; answer: string },
+		candidates: Faq[],
+	): Promise<FaqSimilarityMatch | null> {
+		if (candidates.length === 0) {
+			return null;
+		}
+		// Newest-first from the caller; keep the most recent and send only the
+		// fields needed to judge similarity (no answers — keeps the prompt small).
+		const shortlist = candidates.slice(0, MAX_CANDIDATES);
+		const ids = new Set<string>(shortlist.map((faq) => faq.id));
+		const existing = shortlist.map((faq) => ({
+			id: faq.id,
+			question: faq.question,
+			category: faq.category,
+		}));
+
+		const result = await this.generateWithFallback({
+			schema: similaritySchema,
+			schemaName: 'faq_similarity',
+			system: SIMILARITY_SYSTEM,
+			prompt:
+				`New FAQ:\nQuestion: ${input.question}\n` +
+				`Answer: ${input.answer || '(none provided)'}\n\n` +
+				`Existing FAQs (JSON array of {id, question, category}):\n${JSON.stringify(existing)}`,
+		});
+
+		if (!result || result.faqId === null) {
+			return null;
+		}
+		// Guard against a hallucinated / stale id: only accept ids we actually sent.
+		if (!ids.has(result.faqId)) {
+			return null;
+		}
+		const confidence = Math.max(0, Math.min(1, result.confidence));
+		if (confidence < MIN_CONFIDENCE) {
+			return null;
+		}
+		return { faqId: result.faqId as FaqId, confidence, reason: result.reason };
+	}
+
+	async mergeSuggestion(
+		input: { question: string; answer: string },
+		existing: Faq,
+	): Promise<FaqMergeSuggestion> {
+		const result = await this.generateWithFallback({
+			schema: mergeSchema,
+			schemaName: 'faq_merge',
+			system: MERGE_SYSTEM,
+			prompt:
+				`Existing FAQ:\nQuestion: ${existing.question}\nAnswer: ${existing.answer}\n\n` +
+				`New FAQ the user just wrote:\nQuestion: ${input.question}\nAnswer: ${input.answer}`,
+		});
+
+		if (result?.question.trim() && result.answer.trim()) {
+			return { question: result.question.trim(), answer: result.answer.trim() };
+		}
+		return fallbackMerge(input, existing);
+	}
+}
+
+/**
+ * Deterministic merge used when no model is available: keep the existing
+ * question, and append the user's new answer when it adds something not already
+ * present.
+ */
+function fallbackMerge(
+	input: { question: string; answer: string },
+	existing: Faq,
+): FaqMergeSuggestion {
+	const newAnswer = input.answer.trim();
+	const answer =
+		newAnswer && !existing.answer.includes(newAnswer)
+			? `${existing.answer}\n\n${newAnswer}`.trim()
+			: existing.answer;
+	return { question: existing.question, answer };
+}
+
+/** A no-op service: reports no duplicates and merges by passing the input through. */
+export class NoopFaqSimilarityService implements FaqSimilarityService {
+	async findSimilar(): Promise<FaqSimilarityMatch | null> {
+		return null;
+	}
+
+	async mergeSuggestion(input: { question: string; answer: string }): Promise<FaqMergeSuggestion> {
+		return { question: input.question, answer: input.answer };
+	}
+}
+
+/**
+ * Build the duplicate-FAQ service from config. Each provider whose API key is set
+ * is added to an ordered model list — OpenAI is the primary, with Google, xAI,
+ * and Anthropic as backups (used in that order when an earlier provider errors).
+ * When no key is set at all, returns a {@link NoopFaqSimilarityService} so the
+ * feature degrades to "never a duplicate" and the API still boots.
+ */
+export function createFaqSimilarityService(
+	config: Pick<
+		Config,
+		| 'OPENAI_API_KEY'
+		| 'OPENAI_MODEL'
+		| 'GOOGLE_GENERATIVE_AI_API_KEY'
+		| 'GEMINI_MODEL'
+		| 'XAI_API_KEY'
+		| 'XAI_MODEL'
+		| 'ANTHROPIC_API_KEY'
+		| 'ANTHROPIC_MODEL'
+	>,
+): FaqSimilarityService {
+	const models: LanguageModel[] = [];
+	if (config.OPENAI_API_KEY) {
+		models.push(createOpenAI({ apiKey: config.OPENAI_API_KEY })(config.OPENAI_MODEL));
+	}
+	if (config.GOOGLE_GENERATIVE_AI_API_KEY) {
+		models.push(
+			createGoogleGenerativeAI({ apiKey: config.GOOGLE_GENERATIVE_AI_API_KEY })(
+				config.GEMINI_MODEL,
+			),
+		);
+	}
+	if (config.XAI_API_KEY) {
+		models.push(createXai({ apiKey: config.XAI_API_KEY })(config.XAI_MODEL));
+	}
+	if (config.ANTHROPIC_API_KEY) {
+		models.push(createAnthropic({ apiKey: config.ANTHROPIC_API_KEY })(config.ANTHROPIC_MODEL));
+	}
+	if (models.length === 0) {
+		return new NoopFaqSimilarityService();
+	}
+	return new AiFaqSimilarityService({ models });
+}

--- a/packages/api/src/services/faq-similarity.ts
+++ b/packages/api/src/services/faq-similarity.ts
@@ -43,6 +43,11 @@ export interface FaqMergeSuggestion {
 	answer: string;
 }
 
+/** Minimal logger surface — compatible with `console` and Fastify's pino logger. */
+export interface FaqSimilarityLogger {
+	warn(message: string): void;
+}
+
 export interface FaqSimilarityService {
 	/**
 	 * Return the existing FAQ that is the closest semantic duplicate of `input`,
@@ -110,10 +115,16 @@ const MERGE_SYSTEM =
 export class AiFaqSimilarityService implements FaqSimilarityService {
 	private readonly models: LanguageModel[];
 	private readonly generate: GenerateObjectFn;
+	private readonly logger?: FaqSimilarityLogger;
 
-	constructor(options: { models: LanguageModel[]; generate?: GenerateObjectFn }) {
+	constructor(options: {
+		models: LanguageModel[];
+		generate?: GenerateObjectFn;
+		logger?: FaqSimilarityLogger;
+	}) {
 		this.models = options.models;
 		this.generate = options.generate ?? defaultGenerateObject;
+		this.logger = options.logger;
 	}
 
 	/** Try each model in turn; return the first success, or null if all fail. */
@@ -134,8 +145,12 @@ export class AiFaqSimilarityService implements FaqSimilarityService {
 					maxOutputTokens: MAX_OUTPUT_TOKENS,
 				});
 				return object;
-			} catch {
-				// This provider failed — fall through to the next backup model.
+			} catch (error) {
+				// This provider failed — log it (so a misconfigured primary is visible
+				// in production) and fall through to the next backup model.
+				this.logger?.warn(
+					`FAQ duplicate check: ${options.schemaName} request failed, trying next provider — ${String(error)}`,
+				);
 			}
 		}
 		return null;
@@ -195,8 +210,12 @@ export class AiFaqSimilarityService implements FaqSimilarityService {
 				`New FAQ the user just wrote:\nQuestion: ${input.question}\nAnswer: ${input.answer}`,
 		});
 
-		if (result?.question.trim() && result.answer.trim()) {
-			return { question: result.question.trim(), answer: result.answer.trim() };
+		if (result) {
+			const question = result.question.trim();
+			const answer = result.answer.trim();
+			if (question && answer) {
+				return { question, answer };
+			}
 		}
 		return fallbackMerge(input, existing);
 	}
@@ -270,5 +289,7 @@ export function createFaqSimilarityService(
 	if (models.length === 0) {
 		return new NoopFaqSimilarityService();
 	}
-	return new AiFaqSimilarityService({ models });
+	// `console` is captured by the platform's log pipeline; provider failures on
+	// this best-effort path shouldn't be silent in production.
+	return new AiFaqSimilarityService({ models, logger: console });
 }

--- a/packages/api/src/services/faq-similarity.ts
+++ b/packages/api/src/services/faq-similarity.ts
@@ -16,6 +16,11 @@ const MAX_CANDIDATES = 50;
 const MAX_OUTPUT_TOKENS = 600;
 /** Below this the match is too weak to interrupt the user with a modal. */
 const MIN_CONFIDENCE = 0.6;
+// Merged suggestions feed back into the FAQ form, so cap them to the same limits
+// as createFaqSchema/updateFaqSchema — otherwise the pre-filled "update existing"
+// text (e.g. two near-max answers combined) would be rejected on save.
+const MAX_QUESTION_LENGTH = 300;
+const MAX_ANSWER_LENGTH = 4000;
 
 /** What the model returns when asked to find a near-duplicate. */
 const similaritySchema = z.object({
@@ -214,10 +219,10 @@ export class AiFaqSimilarityService implements FaqSimilarityService {
 			const question = result.question.trim();
 			const answer = result.answer.trim();
 			if (question && answer) {
-				return { question, answer };
+				return clampToFaqLimits({ question, answer });
 			}
 		}
-		return fallbackMerge(input, existing);
+		return clampToFaqLimits(fallbackMerge(input, existing));
 	}
 }
 
@@ -236,6 +241,14 @@ function fallbackMerge(
 			? `${existing.answer}\n\n${newAnswer}`.trim()
 			: existing.answer;
 	return { question: existing.question, answer };
+}
+
+/** Trim merged text to the FAQ field limits so the pre-filled form saves cleanly. */
+function clampToFaqLimits(suggestion: FaqMergeSuggestion): FaqMergeSuggestion {
+	return {
+		question: suggestion.question.slice(0, MAX_QUESTION_LENGTH),
+		answer: suggestion.answer.slice(0, MAX_ANSWER_LENGTH),
+	};
 }
 
 /** A no-op service: reports no duplicates and merges by passing the input through. */

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -12,6 +12,7 @@ import type {
 	VerificationCodeRepository,
 } from './repositories/types';
 import type { Mailer } from './services/email';
+import type { FaqSimilarityService } from './services/faq-similarity';
 
 /** Result of a readiness check: whether dependencies are usable, and why not. */
 export interface ReadinessResult {
@@ -34,6 +35,8 @@ export interface AppDeps {
 	verificationCodes: VerificationCodeRepository;
 	/** Sends transactional email (invitations and sign-in codes). */
 	mailer: Mailer;
+	/** AI check for near-duplicate FAQs (a no-op when no provider key is set). */
+	faqSimilarity: FaqSimilarityService;
 	/** Readiness check for downstream dependencies (e.g. the database). */
 	ping: () => Promise<ReadinessResult>;
 }

--- a/packages/api/test/cors.test.ts
+++ b/packages/api/test/cors.test.ts
@@ -4,6 +4,7 @@ import { buildApp } from '../src/app';
 import { loadConfig } from '../src/config';
 import { SESSION_COOKIE } from '../src/plugins/auth';
 import { createInMemoryRepositories } from '../src/repositories/memory';
+import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
 import { authHeader, RecordingMailer, signupOwner } from './helpers';
 
 /** Build an app with a specific CORS_ORIGIN so we can exercise both origin branches. */
@@ -17,6 +18,7 @@ function buildAppWithCors(corsOrigin: string): FastifyInstance {
 		} as NodeJS.ProcessEnv),
 		...repos,
 		mailer: new RecordingMailer(),
+		faqSimilarity: new NoopFaqSimilarityService(),
 		ping: async () => ({ ready: true }),
 	});
 }
@@ -34,6 +36,7 @@ function buildProdApp(corsOrigin: string): FastifyInstance {
 		} as NodeJS.ProcessEnv),
 		...repos,
 		mailer: new RecordingMailer(),
+		faqSimilarity: new NoopFaqSimilarityService(),
 		ping: async () => ({ ready: true }),
 	});
 }

--- a/packages/api/test/faq-similarity.test.ts
+++ b/packages/api/test/faq-similarity.test.ts
@@ -1,0 +1,176 @@
+import type { AccountId, Faq, FaqId } from '@rivus/core';
+import type { LanguageModel } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	AiFaqSimilarityService,
+	type FaqSimilarityService,
+	type GenerateObjectFn,
+	NoopFaqSimilarityService,
+} from '../src/services/faq-similarity';
+
+function makeFaq(overrides: Partial<Faq> = {}): Faq {
+	const now = new Date('2026-01-01T00:00:00.000Z').toISOString();
+	return {
+		id: 'faq-1' as FaqId,
+		accountId: 'acct-1' as AccountId,
+		question: 'How much is a service call?',
+		answer: 'Our standard diagnostic visit is $89.',
+		category: 'Pricing',
+		status: 'published',
+		createdAt: now,
+		updatedAt: now,
+		...overrides,
+	};
+}
+
+/**
+ * A fake for the injected object-generator. The generic {@link GenerateObjectFn}
+ * can't be satisfied by a concrete mock (its `object` would have to be every `T`
+ * at once), so we cast at the boundary and keep the raw mock for assertions.
+ */
+function fakeGenerate(impl: (options: { model: LanguageModel; prompt: string }) => unknown) {
+	const mock = vi.fn(impl as (...args: unknown[]) => unknown);
+	return { generate: mock as unknown as GenerateObjectFn, mock };
+}
+
+// Two interchangeable placeholder models; the fake `generate` branches on them
+// to exercise provider-fallback ordering without touching a real model.
+const PRIMARY = 'primary' as unknown as LanguageModel;
+const BACKUP = 'backup' as unknown as LanguageModel;
+
+const NEW_INPUT = { question: 'What does a service call cost?', answer: 'It is $89 to come out.' };
+
+describe('AiFaqSimilarityService.findSimilar', () => {
+	it('returns the matched candidate and sends questions but not answers', async () => {
+		const candidates = [
+			makeFaq({ id: 'faq-1' as FaqId, question: 'Do you offer weekend hours?' }),
+			makeFaq({
+				id: 'faq-2' as FaqId,
+				question: 'How much is a service call?',
+				answer: 'SECRET-ANSWER-TEXT',
+			}),
+		];
+		const { generate, mock } = fakeGenerate(() => ({
+			object: { faqId: 'faq-2', confidence: 0.92, reason: 'Same pricing question.' },
+		}));
+		const service = new AiFaqSimilarityService({ models: [PRIMARY], generate });
+
+		const result = await service.findSimilar(NEW_INPUT, candidates);
+
+		expect(result).toEqual({ faqId: 'faq-2', confidence: 0.92, reason: 'Same pricing question.' });
+		const options = mock.mock.calls[0]?.[0] as { schemaName?: string; prompt: string };
+		expect(options.schemaName).toBe('faq_similarity');
+		expect(options.prompt).toContain('How much is a service call?');
+		expect(options.prompt).toContain(NEW_INPUT.question);
+		// Candidate answers must never be sent — only id/question/category.
+		expect(options.prompt).not.toContain('SECRET-ANSWER-TEXT');
+	});
+
+	it('returns null when the model reports no match', async () => {
+		const { generate } = fakeGenerate(() => ({
+			object: { faqId: null, confidence: 0, reason: 'No duplicate.' },
+		}));
+		const service = new AiFaqSimilarityService({ models: [PRIMARY], generate });
+
+		expect(await service.findSimilar(NEW_INPUT, [makeFaq()])).toBeNull();
+	});
+
+	it('rejects a hallucinated id that was never in the candidate set', async () => {
+		const { generate } = fakeGenerate(() => ({
+			object: { faqId: 'faq-999', confidence: 0.99, reason: 'made up' },
+		}));
+		const service = new AiFaqSimilarityService({ models: [PRIMARY], generate });
+
+		expect(await service.findSimilar(NEW_INPUT, [makeFaq({ id: 'faq-1' as FaqId })])).toBeNull();
+	});
+
+	it('rejects a match below the confidence floor', async () => {
+		const { generate } = fakeGenerate(() => ({
+			object: { faqId: 'faq-1', confidence: 0.3, reason: 'weak' },
+		}));
+		const service = new AiFaqSimilarityService({ models: [PRIMARY], generate });
+
+		expect(await service.findSimilar(NEW_INPUT, [makeFaq({ id: 'faq-1' as FaqId })])).toBeNull();
+	});
+
+	it('short-circuits with no model call when there are no candidates', async () => {
+		const { generate, mock } = fakeGenerate(() => ({ object: null }));
+		const service = new AiFaqSimilarityService({ models: [PRIMARY], generate });
+
+		expect(await service.findSimilar(NEW_INPUT, [])).toBeNull();
+		expect(mock).not.toHaveBeenCalled();
+	});
+
+	it('returns null (never throws) when the only model fails', async () => {
+		const { generate } = fakeGenerate(() => {
+			throw new Error('provider down');
+		});
+		const service = new AiFaqSimilarityService({ models: [PRIMARY], generate });
+
+		await expect(service.findSimilar(NEW_INPUT, [makeFaq()])).resolves.toBeNull();
+	});
+
+	it('falls back to the next model when the primary errors', async () => {
+		const { generate, mock } = fakeGenerate(({ model }) => {
+			if (model === PRIMARY) {
+				throw new Error('primary down');
+			}
+			return { object: { faqId: 'faq-1', confidence: 0.8, reason: 'backup matched' } };
+		});
+		const service = new AiFaqSimilarityService({ models: [PRIMARY, BACKUP], generate });
+
+		const result = await service.findSimilar(NEW_INPUT, [makeFaq({ id: 'faq-1' as FaqId })]);
+
+		expect(result?.faqId).toBe('faq-1');
+		expect(mock).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('AiFaqSimilarityService.mergeSuggestion', () => {
+	it('returns the model-combined question and answer (trimmed)', async () => {
+		const { generate } = fakeGenerate(() => ({
+			object: { question: '  Combined question?  ', answer: '  Combined answer.  ' },
+		}));
+		const service = new AiFaqSimilarityService({ models: [PRIMARY], generate });
+
+		const result = await service.mergeSuggestion(NEW_INPUT, makeFaq());
+
+		expect(result).toEqual({ question: 'Combined question?', answer: 'Combined answer.' });
+	});
+
+	it('falls back to a deterministic combine when the model fails', async () => {
+		const { generate } = fakeGenerate(() => {
+			throw new Error('down');
+		});
+		const service = new AiFaqSimilarityService({ models: [PRIMARY], generate });
+		const existing = makeFaq({ answer: 'Existing answer.' });
+
+		const result = await service.mergeSuggestion(
+			{ question: 'q', answer: 'Brand new detail.' },
+			existing,
+		);
+
+		expect(result.question).toBe(existing.question);
+		expect(result.answer).toContain('Existing answer.');
+		expect(result.answer).toContain('Brand new detail.');
+	});
+
+	it('falls back when the model returns blank text', async () => {
+		const { generate } = fakeGenerate(() => ({ object: { question: '', answer: '' } }));
+		const service = new AiFaqSimilarityService({ models: [PRIMARY], generate });
+		const existing = makeFaq({ answer: 'Kept answer.' });
+
+		const result = await service.mergeSuggestion({ question: 'q', answer: '' }, existing);
+
+		expect(result).toEqual({ question: existing.question, answer: 'Kept answer.' });
+	});
+});
+
+describe('NoopFaqSimilarityService', () => {
+	it('never finds a match and passes input through on merge', async () => {
+		const service: FaqSimilarityService = new NoopFaqSimilarityService();
+
+		expect(await service.findSimilar(NEW_INPUT, [makeFaq()])).toBeNull();
+		expect(await service.mergeSuggestion(NEW_INPUT, makeFaq())).toEqual(NEW_INPUT);
+	});
+});

--- a/packages/api/test/faq-similarity.test.ts
+++ b/packages/api/test/faq-similarity.test.ts
@@ -164,6 +164,33 @@ describe('AiFaqSimilarityService.mergeSuggestion', () => {
 
 		expect(result).toEqual({ question: existing.question, answer: 'Kept answer.' });
 	});
+
+	it('clamps a model-merged answer to the FAQ length limit', async () => {
+		const { generate } = fakeGenerate(() => ({
+			object: { question: 'Combined?', answer: 'z'.repeat(5000) },
+		}));
+		const service = new AiFaqSimilarityService({ models: [PRIMARY], generate });
+
+		const result = await service.mergeSuggestion(NEW_INPUT, makeFaq());
+
+		expect(result.answer.length).toBe(4000);
+		expect(result.question).toBe('Combined?');
+	});
+
+	it('clamps an oversized deterministic-fallback answer', async () => {
+		const { generate } = fakeGenerate(() => {
+			throw new Error('down');
+		});
+		const service = new AiFaqSimilarityService({ models: [PRIMARY], generate });
+		const existing = makeFaq({ answer: 'x'.repeat(3800) });
+
+		const result = await service.mergeSuggestion(
+			{ question: 'q', answer: 'y'.repeat(500) },
+			existing,
+		);
+
+		expect(result.answer.length).toBe(4000);
+	});
 });
 
 describe('NoopFaqSimilarityService', () => {

--- a/packages/api/test/faqs.test.ts
+++ b/packages/api/test/faqs.test.ts
@@ -1,5 +1,7 @@
+import type { FaqId } from '@rivus/core';
 import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { FaqSimilarityService } from '../src/services/faq-similarity';
 import { authHeader, buildTestApp, signupOwner } from './helpers';
 
 describe('faqs', () => {
@@ -212,5 +214,120 @@ describe('faqs', () => {
 		});
 
 		expect(response.statusCode).toBe(404);
+	});
+});
+
+describe('POST /v1/faqs/similar', () => {
+	it('requires authentication', async () => {
+		const app = await buildTestApp();
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/similar',
+			payload: { question: 'Anything?' },
+		});
+		expect(response.statusCode).toBe(401);
+		await app.close();
+	});
+
+	it('rejects a check with no question (400)', async () => {
+		const app = await buildTestApp();
+		const token = (await signupOwner(app)).token;
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/similar',
+			headers: authHeader(token),
+			payload: { question: '' },
+		});
+		expect(response.statusCode).toBe(400);
+		await app.close();
+	});
+
+	it('reports no duplicate with the default (no-op) service', async () => {
+		const app = await buildTestApp();
+		const token = (await signupOwner(app)).token;
+		await app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: { question: 'How much is a service call?', answer: 'It is $89.' },
+		});
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/similar',
+			headers: authHeader(token),
+			payload: { question: 'What does a service call cost?', answer: 'It costs $89.' },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ match: null, reason: '', merged: null });
+		await app.close();
+	});
+
+	it('returns the matched FAQ and merged suggestion when the AI finds a duplicate', async () => {
+		let matchId: string | null = null;
+		const stub: FaqSimilarityService = {
+			async findSimilar() {
+				return matchId
+					? { faqId: matchId as FaqId, confidence: 0.9, reason: 'Same pricing question.' }
+					: null;
+			},
+			async mergeSuggestion() {
+				return { question: 'Merged question?', answer: 'Merged answer.' };
+			},
+		};
+		const app = await buildTestApp({ faqSimilarity: stub });
+		const token = (await signupOwner(app)).token;
+		const created = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: { question: 'How much is a service call?', answer: 'It is $89.' },
+		});
+		matchId = created.json().id;
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/similar',
+			headers: authHeader(token),
+			payload: { question: 'What does a service call cost?', answer: 'It costs $89.' },
+		});
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.match.id).toBe(matchId);
+		expect(body.reason).toBe('Same pricing question.');
+		expect(body.merged).toEqual({ question: 'Merged question?', answer: 'Merged answer.' });
+		await app.close();
+	});
+
+	it('drops a match whose id does not belong to the account', async () => {
+		const stub: FaqSimilarityService = {
+			async findSimilar() {
+				return { faqId: 'ghost-id' as FaqId, confidence: 0.99, reason: 'hallucinated' };
+			},
+			async mergeSuggestion() {
+				return { question: '', answer: '' };
+			},
+		};
+		const app = await buildTestApp({ faqSimilarity: stub });
+		const token = (await signupOwner(app)).token;
+		await app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: { question: 'How much is a service call?', answer: 'It is $89.' },
+		});
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/similar',
+			headers: authHeader(token),
+			payload: { question: 'What does a service call cost?' },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ match: null, reason: '', merged: null });
+		await app.close();
 	});
 });

--- a/packages/api/test/helpers.ts
+++ b/packages/api/test/helpers.ts
@@ -5,6 +5,7 @@ import { buildApp } from '../src/app';
 import { loadConfig } from '../src/config';
 import { createInMemoryRepositories, type InMemoryRepositories } from '../src/repositories/memory';
 import type { InviteEmail, Mailer, VerificationEmail } from '../src/services/email';
+import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
 import type { AppDeps } from '../src/types';
 
 /** A mailer that records every send so tests can assert on (and read) delivered email. */
@@ -41,6 +42,8 @@ export async function buildTestApp(overrides: Partial<AppDeps> = {}): Promise<Fa
 		verificationCodes,
 		// A recording mailer by default so helpers can read back the emailed code.
 		mailer: new RecordingMailer(),
+		// Default to the no-op AI service so tests stay hermetic (no model/network).
+		faqSimilarity: new NoopFaqSimilarityService(),
 		ping: async () => ({ ready: true }),
 		...overrides,
 	});
@@ -70,6 +73,7 @@ export async function buildTestAppWithRepos(): Promise<{
 		faqs,
 		verificationCodes,
 		mailer: new RecordingMailer(),
+		faqSimilarity: new NoopFaqSimilarityService(),
 		ping: async () => ({ ready: true }),
 	});
 	await app.ready();

--- a/packages/api/worker/index.ts
+++ b/packages/api/worker/index.ts
@@ -9,6 +9,16 @@ export interface Env {
 	RESEND_API_KEY: string;
 	EMAIL_FROM: string;
 	APP_URL: string;
+	// AI provider keys + model overrides for duplicate-FAQ detection (all optional;
+	// when none is set the check degrades to a no-op).
+	OPENAI_API_KEY?: string;
+	OPENAI_MODEL?: string;
+	GOOGLE_GENERATIVE_AI_API_KEY?: string;
+	GEMINI_MODEL?: string;
+	XAI_API_KEY?: string;
+	XAI_MODEL?: string;
+	ANTHROPIC_API_KEY?: string;
+	ANTHROPIC_MODEL?: string;
 }
 
 /**
@@ -33,6 +43,16 @@ export class ApiContainer extends Container<Env> {
 		...(this.env.RESEND_API_KEY ? { RESEND_API_KEY: this.env.RESEND_API_KEY } : {}),
 		...(this.env.EMAIL_FROM ? { EMAIL_FROM: this.env.EMAIL_FROM } : {}),
 		...(this.env.APP_URL ? { APP_URL: this.env.APP_URL } : {}),
+		...(this.env.OPENAI_API_KEY ? { OPENAI_API_KEY: this.env.OPENAI_API_KEY } : {}),
+		...(this.env.OPENAI_MODEL ? { OPENAI_MODEL: this.env.OPENAI_MODEL } : {}),
+		...(this.env.GOOGLE_GENERATIVE_AI_API_KEY
+			? { GOOGLE_GENERATIVE_AI_API_KEY: this.env.GOOGLE_GENERATIVE_AI_API_KEY }
+			: {}),
+		...(this.env.GEMINI_MODEL ? { GEMINI_MODEL: this.env.GEMINI_MODEL } : {}),
+		...(this.env.XAI_API_KEY ? { XAI_API_KEY: this.env.XAI_API_KEY } : {}),
+		...(this.env.XAI_MODEL ? { XAI_MODEL: this.env.XAI_MODEL } : {}),
+		...(this.env.ANTHROPIC_API_KEY ? { ANTHROPIC_API_KEY: this.env.ANTHROPIC_API_KEY } : {}),
+		...(this.env.ANTHROPIC_MODEL ? { ANTHROPIC_MODEL: this.env.ANTHROPIC_MODEL } : {}),
 	};
 }
 

--- a/packages/app/app/knowledge.tsx
+++ b/packages/app/app/knowledge.tsx
@@ -1,9 +1,10 @@
 import type { FaqStatus } from '@rivus/core';
 import { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Pressable, ScrollView, StyleSheet, View } from 'react-native';
-import { ApiError, type Faq } from '@/src/api/client';
+import { ApiError, type Faq, type FaqSimilarityResult } from '@/src/api/client';
 import { useAuth } from '@/src/auth/AuthContext';
 import { RivusSymbol } from '@/src/brand/RivusLogo';
+import { FaqDuplicateModal } from '@/src/components/FaqDuplicateModal';
 import { BrandGradient } from '@/src/components/Gradient';
 import {
 	Card,
@@ -39,6 +40,12 @@ export default function KnowledgeScreen() {
 	const [formError, setFormError] = useState<string | null>(null);
 	const [saving, setSaving] = useState(false);
 	const [deleting, setDeleting] = useState(false);
+
+	// Duplicate-FAQ modal: a similar existing FAQ the AI found while adding a new one,
+	// plus its combined-text suggestion.
+	const [dupMatch, setDupMatch] = useState<Faq | null>(null);
+	const [dupReason, setDupReason] = useState('');
+	const [dupMerged, setDupMerged] = useState<{ question: string; answer: string } | null>(null);
 
 	const load = useCallback(async () => {
 		if (!session) {
@@ -111,9 +118,29 @@ export default function KnowledgeScreen() {
 			};
 			if (editing) {
 				await client.updateFaq(session.token, editing.id, input);
-			} else {
-				await client.createFaq(session.token, input);
+				closeForm();
+				await load();
+				return;
 			}
+			// Creating a new FAQ: first ask the API whether a near-duplicate already
+			// exists. A failure here must never block the user, so fall through to a
+			// normal create if the check can't run.
+			let similar: FaqSimilarityResult = { match: null, reason: '', merged: null };
+			try {
+				similar = await client.findSimilarFaq(session.token, {
+					question: input.question,
+					answer: input.answer,
+				});
+			} catch {
+				// Best-effort — ignore and create as usual.
+			}
+			if (similar.match) {
+				setDupMatch(similar.match);
+				setDupReason(similar.reason);
+				setDupMerged(similar.merged);
+				return; // The duplicate modal drives the next action.
+			}
+			await client.createFaq(session.token, input);
 			closeForm();
 			await load();
 		} catch (caught) {
@@ -121,6 +148,53 @@ export default function KnowledgeScreen() {
 		} finally {
 			setSaving(false);
 		}
+	}
+
+	function dismissDuplicate() {
+		setDupMatch(null);
+		setDupReason('');
+		setDupMerged(null);
+	}
+
+	/** "Add as new FAQ": create the FAQ as typed, bypassing the duplicate check. */
+	async function proceedCreate() {
+		if (!session || saving) {
+			return;
+		}
+		dismissDuplicate();
+		setFormError(null);
+		setSaving(true);
+		try {
+			await client.createFaq(session.token, {
+				question: question.trim(),
+				answer: answer.trim(),
+				category: category.trim(),
+				status,
+			});
+			closeForm();
+			await load();
+		} catch (caught) {
+			setFormError(caught instanceof Error ? caught.message : 'Could not save the FAQ.');
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	/** "Update existing FAQ": edit the matched FAQ, pre-filled with the merged text. */
+	function updateExistingFaq() {
+		const match = dupMatch;
+		const merged = dupMerged;
+		dismissDuplicate();
+		if (!match) {
+			return;
+		}
+		setEditing(match);
+		setQuestion(merged?.question ?? match.question);
+		setAnswer(merged?.answer ?? match.answer);
+		setCategory(match.category);
+		setStatus(match.status);
+		setFormError(null);
+		setFormOpen(true);
 	}
 
 	async function onDelete() {
@@ -310,6 +384,14 @@ export default function KnowledgeScreen() {
 					</View>
 				)}
 			</View>
+
+			<FaqDuplicateModal
+				match={dupMatch}
+				reason={dupReason}
+				onUpdateExisting={updateExistingFaq}
+				onCreateAnyway={proceedCreate}
+				onClose={dismissDuplicate}
+			/>
 		</ScrollView>
 	);
 }

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -572,6 +572,66 @@ describe('createApiClient', () => {
 		});
 	});
 
+	describe('findSimilarFaq', () => {
+		it('posts the question and returns the parsed match + merged suggestion', async () => {
+			const match = makeFaq();
+			fetchMock.mockResolvedValueOnce(
+				jsonResponse({
+					match,
+					reason: 'Same pricing question.',
+					merged: { question: 'Merged?', answer: 'Merged answer.' },
+				}),
+			);
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.findSimilarFaq('owner-token', {
+				question: 'What does a call cost?',
+				answer: 'It is $89.',
+			});
+
+			expect(result.match).toEqual(match);
+			expect(result.reason).toBe('Same pricing question.');
+			expect(result.merged).toEqual({ question: 'Merged?', answer: 'Merged answer.' });
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/faqs/similar`);
+			expect(init.method).toBe('POST');
+			expect(init.headers).toMatchObject({
+				Authorization: 'Bearer owner-token',
+				'Content-Type': 'application/json',
+			});
+			expect(JSON.parse(init.body as string)).toMatchObject({ question: 'What does a call cost?' });
+		});
+
+		it('parses a "no duplicate" response', async () => {
+			fetchMock.mockResolvedValueOnce(jsonResponse({ match: null, reason: '', merged: null }));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.findSimilarFaq('tok', { question: 'Anything new?' });
+
+			expect(result.match).toBeNull();
+			expect(result.merged).toBeNull();
+		});
+
+		it('defaults a missing answer to an empty string', async () => {
+			fetchMock.mockResolvedValueOnce(jsonResponse({ match: null, reason: '', merged: null }));
+
+			const client = createApiClient(BASE, fetchMock);
+			await client.findSimilarFaq('tok', { question: 'Just a question?' });
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(JSON.parse(init.body as string)).toMatchObject({
+				question: 'Just a question?',
+				answer: '',
+			});
+		});
+
+		it('rejects an empty question before hitting the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.findSimilarFaq('tok', { question: '' })).rejects.toThrow();
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('updateFaq', () => {
 		it('PATCHes the FAQ with the bearer token and returns it', async () => {
 			const faq = { ...makeFaq(), status: 'draft' as const };

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -7,6 +7,7 @@ import {
 	createFaqSchema,
 	type Faq,
 	type FaqId,
+	faqSimilarityQuerySchema,
 	faqStatusSchema,
 	type InviteMemberInput,
 	type Item,
@@ -245,6 +246,22 @@ export interface FaqListResponse {
 	meta: PaginationMeta;
 }
 
+const faqSimilarityResponseSchema = z.object({
+	match: faqResponseSchema.nullable(),
+	reason: z.string(),
+	merged: z.object({ question: z.string(), answer: z.string() }).nullable(),
+});
+
+/** Result of the pre-create duplicate check (see {@link RivusApiClient.findSimilarFaq}). */
+export interface FaqSimilarityResult {
+	/** The existing FAQ a new one would duplicate, or null when none is similar. */
+	match: Faq | null;
+	/** One short sentence explaining the match (empty when there is none). */
+	reason: string;
+	/** AI-combined question/answer to offer as an update (null when no match). */
+	merged: { question: string; answer: string } | null;
+}
+
 // A 204 No Content response (FAQ delete) has an empty body; the request helper
 // passes `undefined` to the schema, so accept exactly that.
 const noContentSchema = z.undefined();
@@ -310,6 +327,15 @@ export interface RivusApiClient {
 	listFaqs(token: string, query?: Partial<PaginationQuery>): Promise<FaqListResponse>;
 	/** Create an FAQ for the account. */
 	createFaq(token: string, input: CreateFaqBody): Promise<Faq>;
+	/**
+	 * Ask the API whether a semantically similar FAQ already exists (AI-assisted),
+	 * before creating a new one. Returns the closest existing FAQ plus an AI-merged
+	 * suggestion, or `{ match: null }` when nothing similar is found.
+	 */
+	findSimilarFaq(
+		token: string,
+		input: { question: string; answer?: string },
+	): Promise<FaqSimilarityResult>;
 	/** Update one of the account's FAQs. */
 	updateFaq(token: string, id: FaqId, input: UpdateFaqInput): Promise<Faq>;
 	/** Delete one of the account's FAQs. */
@@ -486,6 +512,15 @@ export function createApiClient(
 		async createFaq(token: string, input: CreateFaqBody) {
 			const payload = parseInput(createFaqSchema, input);
 			return request('/v1/faqs', faqResponseSchema, jsonInit('POST', payload, token));
+		},
+
+		async findSimilarFaq(token: string, input: { question: string; answer?: string }) {
+			const payload = parseInput(faqSimilarityQuerySchema, input);
+			return request(
+				'/v1/faqs/similar',
+				faqSimilarityResponseSchema,
+				jsonInit('POST', payload, token),
+			);
 		},
 
 		async updateFaq(token: string, id: FaqId, input: UpdateFaqInput) {

--- a/packages/app/src/components/FaqDuplicateModal.tsx
+++ b/packages/app/src/components/FaqDuplicateModal.tsx
@@ -1,0 +1,164 @@
+import { Feather } from '@expo/vector-icons';
+import { useEffect, useState } from 'react';
+import { Modal, Pressable, StyleSheet, View } from 'react-native';
+import type { Faq } from '@/src/api/client';
+import { colors, font, radii, shadowSoft } from '@/src/theme/tokens';
+import { BrandGradient } from './Gradient';
+import { GradientButton, OutlineButton, Pill, Txt } from './ui';
+
+/**
+ * Shown after the AI duplicate check finds an existing FAQ close to the one the
+ * user is adding. Recommends updating that FAQ with the combined text (the
+ * primary action) and offers adding it as a brand-new FAQ instead.
+ */
+export function FaqDuplicateModal({
+	match,
+	reason,
+	onUpdateExisting,
+	onCreateAnyway,
+	onClose,
+}: {
+	match: Faq | null;
+	reason: string;
+	onUpdateExisting: () => void;
+	onCreateAnyway: () => void;
+	onClose: () => void;
+}) {
+	// `match` flips to null the instant the dialog is dismissed. Drive the Modal's
+	// `visible` off that live value, but render from the last non-null match so the
+	// sheet fades out with the backdrop instead of vanishing the moment it closes.
+	const [lastShown, setLastShown] = useState<Faq | null>(null);
+	useEffect(() => {
+		if (match) {
+			setLastShown(match);
+		}
+	}, [match]);
+
+	const shown = match ?? lastShown;
+
+	return (
+		<Modal visible={match !== null} transparent animationType="fade" onRequestClose={onClose}>
+			<Pressable style={styles.backdrop} onPress={onClose}>
+				{shown ? (
+					<Pressable style={styles.sheet} onPress={() => {}}>
+						<Pressable
+							onPress={onClose}
+							accessibilityRole="button"
+							accessibilityLabel="Close"
+							style={styles.close}
+						>
+							<Feather name="x" size={18} color={colors.textMuted} />
+						</Pressable>
+
+						<BrandGradient style={styles.badge}>
+							<Feather name="copy" size={22} color="#fff" />
+						</BrandGradient>
+
+						<Txt style={styles.title}>This looks like an existing FAQ</Txt>
+						<Txt style={styles.subtitle}>
+							{reason
+								? reason
+								: 'You already have a similar FAQ. Update it with your new wording instead of adding a duplicate?'}
+						</Txt>
+
+						<View style={styles.card}>
+							{shown.category ? (
+								<Pill
+									label={shown.category}
+									color={colors.brandPurpleInk}
+									background={colors.purpleTint}
+									style={styles.cardPill}
+								/>
+							) : null}
+							<Txt style={styles.cardQuestion} numberOfLines={2}>
+								{shown.question}
+							</Txt>
+							<Txt style={styles.cardAnswer} numberOfLines={3}>
+								{shown.answer}
+							</Txt>
+						</View>
+
+						<GradientButton
+							label="Update existing FAQ"
+							icon="edit-3"
+							onPress={onUpdateExisting}
+							style={styles.primary}
+						/>
+						<OutlineButton label="Add as new FAQ" onPress={onCreateAnyway} />
+					</Pressable>
+				) : null}
+			</Pressable>
+		</Modal>
+	);
+}
+
+const styles = StyleSheet.create({
+	backdrop: {
+		flex: 1,
+		backgroundColor: 'rgba(15,15,25,0.45)',
+		justifyContent: 'center',
+		alignItems: 'center',
+		padding: 20,
+	},
+	sheet: {
+		width: '100%',
+		maxWidth: 440,
+		backgroundColor: colors.surface,
+		borderRadius: radii.card,
+		padding: 24,
+		gap: 12,
+		...shadowSoft,
+	},
+	close: {
+		position: 'absolute',
+		top: 14,
+		right: 14,
+		padding: 4,
+		borderRadius: radii.sm,
+	},
+	badge: {
+		width: 52,
+		height: 52,
+		borderRadius: radii.xl,
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	title: {
+		fontFamily: font.bold,
+		fontSize: 19,
+		color: colors.text,
+	},
+	subtitle: {
+		fontFamily: font.regular,
+		fontSize: 13.5,
+		lineHeight: 20,
+		color: colors.textMuted,
+		marginTop: -4,
+	},
+	card: {
+		backgroundColor: colors.field,
+		borderWidth: 1,
+		borderColor: colors.borderField,
+		borderRadius: radii.md,
+		padding: 14,
+		gap: 6,
+	},
+	cardPill: {
+		alignSelf: 'flex-start',
+		marginBottom: 2,
+	},
+	cardQuestion: {
+		fontFamily: font.semibold,
+		fontSize: 14,
+		color: colors.text,
+	},
+	cardAnswer: {
+		fontFamily: font.regular,
+		fontSize: 12.5,
+		lineHeight: 18,
+		color: colors.textSub,
+	},
+	primary: {
+		marginTop: 4,
+	},
+});

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -215,6 +215,17 @@ export const updateFaqSchema = z
 	});
 export type UpdateFaqInput = z.infer<typeof updateFaqSchema>;
 
+/**
+ * Body for the "is there already a similar FAQ?" pre-check, sent before creating
+ * a new FAQ. The answer is optional — the question alone is enough to surface a
+ * near-duplicate, but the answer (when present) sharpens the AI's merge.
+ */
+export const faqSimilarityQuerySchema = z.object({
+	question: requiredText('Question', 300),
+	answer: optionalText('Answer', 4000).default(''),
+});
+export type FaqSimilarityQueryInput = z.infer<typeof faqSimilarityQuerySchema>;
+
 /** Query string for list endpoints; coerces `?page=2&pageSize=50`. */
 export const paginationQuerySchema = z.object({
 	page: z.coerce.number().int().min(1, { error: 'Page must be 1 or greater.' }).default(1),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,18 @@ importers:
 
   packages/api:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.85
+        version: 3.0.85(zod@4.4.3)
+      '@ai-sdk/google':
+        specifier: ^3.0.83
+        version: 3.0.83(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: ^3.0.73
+        version: 3.0.73(zod@4.4.3)
+      '@ai-sdk/xai':
+        specifier: ^3.0.96
+        version: 3.0.96(zod@4.4.3)
       '@fastify/cookie':
         specifier: ^11.0.2
         version: 11.0.2
@@ -77,6 +89,9 @@ importers:
       '@rivus/core':
         specifier: workspace:*
         version: link:../core
+      ai:
+        specifier: ^6.0.208
+        version: 6.0.208(zod@4.4.3)
       close-with-grace:
         specifier: ^2.5.0
         version: 2.5.0
@@ -346,8 +361,20 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/anthropic@3.0.85':
+    resolution: {integrity: sha512-fNeDB644l5wbRNQU0FnI+F7UTtOenMnPtACfMPUJaS2zJfuBlseEa1TMg+otHkETZgaJB+6Na51NQEv0+m7czw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.129':
     resolution: {integrity: sha512-KEQpZGJuCksc4iFxYtVHeHHG7yH0izGFzJLmRZlriI0hFIzJF9bT2AzJoaTHUI6minlxtP0WKYh84dP18o/Cuw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@3.0.133':
+    resolution: {integrity: sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -358,8 +385,26 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/google@3.0.83':
+    resolution: {integrity: sha512-Pz7aCX0dy+5x+r4K/37HbLZNaPtPL4q2NduzJW64VffLv5sI9Nb478wAd7PlH2r2asiypJsz/Jerf9draTciUA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@2.0.51':
+    resolution: {integrity: sha512-A6qfyaVs4lxmRxRux6U3ViOa8mMbsSd0OaHghpei2MpiBT6791J4zFH5MN7kaW1tLfQ246rSC2DVTMOavsycjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@3.0.71':
     resolution: {integrity: sha512-j6eBAa5oHFZ4U5CxpIV3T4zXNM/BviodNCZCL1qHkA4aqkwK9iQ18TWYz2DZcXpw4BO5pikKzqpXORxb1EnZGA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.73':
+    resolution: {integrity: sha512-+3x9oxHv9Xp33Iv2L8D+e5hqmZi64jofBKig/9611JKyfV59NdkaDDajtwc0CxOEfARgCVq1BW7dP+526gKOKw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -370,9 +415,21 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.30':
+    resolution: {integrity: sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/xai@3.0.96':
+    resolution: {integrity: sha512-a24jD29cQ3YocP7B4NUvNTb9s5CYR1ao2yU/QncT7QDwwOp4x/lq+6W+BdXGf1VucG7A0dx9jtyIOm6PE4JPyg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -3393,6 +3450,12 @@ packages:
 
   ai@6.0.203:
     resolution: {integrity: sha512-2Qi1ZPGF/FnlvnRqntVgRbUYGeA5ZKFYwTtgu8rcUzMmddArM/nLsvCW69Ip99B1cop6XHRHl+GCKk9t9B+GDA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@6.0.208:
+    resolution: {integrity: sha512-STz+AaZqJ4ZjH7UkpXkbHx+bjgIDOsE8fIUoZjkZ2whoZcfVmG9K/TqEKouJZ03SuZuD7lagntlU3zBhAEkRpQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -7248,10 +7311,23 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/anthropic@3.0.85(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/gateway@3.0.129(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/gateway@3.0.133(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
@@ -7261,10 +7337,28 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/google@3.0.83(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai-compatible@2.0.51(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/openai@3.0.71(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai@3.0.73(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.29(zod@4.4.3)':
@@ -7274,9 +7368,23 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@4.0.30(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/xai@3.0.96(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/openai-compatible': 2.0.51(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      zod: 4.4.3
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -10558,6 +10666,14 @@ snapshots:
       '@ai-sdk/gateway': 3.0.129(zod@4.4.3)
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
+      zod: 4.4.3
+
+  ai@6.0.208(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.133(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
       '@opentelemetry/api': 1.9.1
       zod: 4.4.3
 


### PR DESCRIPTION
## What & why

In the Knowledge section, nothing stopped a user from adding an FAQ that nearly duplicates one they already have, so the knowledge base accumulated overlapping entries that dilute the answers Rivus gives.

Now, when a user taps **Add FAQ**, the API first uses AI to check whether a semantically similar FAQ already exists for their account. If one does, a modal recommends **updating the existing FAQ with the AI-combined text** (shown pre-filled in the editor for review), with a secondary button to **add it as a new FAQ** anyway. If nothing similar is found, the FAQ is created exactly as before.

## How it works

- **`@rivus/core`** — `faqSimilarityQuerySchema` for the pre-create check body (question required, answer optional).
- **`@rivus/api`**
  - New `FaqSimilarityService` (`services/faq-similarity.ts`) built on the **Vercel AI SDK** (`generateObject` with a Zod schema). Models are tried in order: **OpenAI** primary, then **Google (Gemini)**, **xAI**, and **Anthropic** as backups — each activated only when its API key is set. The single AI call is behind an injectable seam so tests run with no network.
  - New endpoint **`POST /v1/faqs/similar`** — gathers the account's FAQs as candidates (paged, capped), asks the service for the closest match, re-resolves the id against the account, and returns `{ match, reason, merged }` where `merged` is the AI-combined question/answer.
  - **Graceful degradation:** no key → no-op service → `{ match: null }`, and the API still boots (the keys are optional and never gate production). Any AI/network error is caught and returns null / a deterministic merge — never thrown into the request path.
  - **Safety:** account-scoped candidates, a hallucinated/cross-account id is rejected in the service *and* re-checked via `findById`, prompts send only id/question/category (no answers) and are size-capped, and a confidence floor avoids weak matches.
- **`@rivus/app`** — `findSimilarFaq` client method + `FaqDuplicateModal`. The Knowledge screen's `onSave` runs the check before creating; "Update existing FAQ" opens the matched FAQ pre-filled with the merge, "Add as new FAQ" bypasses the check, and a failed check falls through to a normal create so the user is never blocked.
- **Config / `.env.example`** — optional `{OPENAI,GOOGLE_GENERATIVE_AI,XAI,ANTHROPIC}_API_KEY` plus per-provider model overrides (`OPENAI_MODEL` defaults to `gpt-5.4-mini`).

## Notes

- New deps (`ai`, `@ai-sdk/{openai,google,xai,anthropic}`) were added through the existing pnpm catalog `minimumReleaseAge` supply-chain gate (caret ranges, ≥7-day-old versions). No catalog versions were changed.
- Provider model defaults are configurable via env; the exact `OPENAI_MODEL` id can be adjusted in one place, and a wrong id/missing key simply degrades to the no-op (FAQs still create).
- `openapi.json` regenerated for the new route (purely additive).

## Testing

`pnpm lint && pnpm type-check && pnpm test` all green (392 tests). Hermetic coverage added for the service (match/no-match/hallucination guard/confidence floor/empty-candidates/provider fallback/merge + fallbacks/no-op), the endpoint (auth, validation, no-op default, injected-match, cross-account id drop), and the app client (`findSimilarFaq`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yL6e4Xu573EzyvmbFU583

---
_Generated by [Claude Code](https://claude.ai/code/session_016yL6e4Xu573EzyvmbFU583)_