### PR TITLE
fix(api): allow PATCH/DELETE in CORS preflight

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -119,6 +119,14 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 		// the configured allowlist.
 		origin: corsOrigin === '*' ? true : corsOrigin,
 		credentials: true,
+		// `@fastify/cors` v11 narrowed its default `methods` to `GET,HEAD,POST`, so
+		// preflight for any other verb answers without it in
+		// `Access-Control-Allow-Methods` — the browser then blocks the real request
+		// and `fetch` rejects with "Failed to fetch". The web app's writes are
+		// cross-origin (app.rivus.ai → api.rivus.ai) and preflighted, so without
+		// this every PATCH (edit FAQ, update account) and DELETE (remove FAQ) fails.
+		// Advertise exactly the verbs the API serves.
+		methods: ['GET', 'HEAD', 'POST', 'PATCH', 'DELETE'],
 	});
 
 	// CSRF defense for cookie-authenticated writes. The session cookie rides along

--- a/packages/api/test/cors.test.ts
+++ b/packages/api/test/cors.test.ts
@@ -66,6 +66,27 @@ describe('CORS', () => {
 		expect(res.headers['access-control-allow-credentials']).toBe('true');
 	});
 
+	it('advertises the write verbs the API serves (PATCH, DELETE) in preflight', async () => {
+		// `@fastify/cors` v11 narrowed its default `methods` to `GET,HEAD,POST`. Without
+		// an explicit list, a cross-origin PATCH/DELETE preflight (editing or deleting an
+		// FAQ, updating account settings) is answered without that verb in
+		// `Access-Control-Allow-Methods`, so the browser blocks the real request and
+		// `fetch` rejects with "Failed to fetch". Preflight an authenticated route — the
+		// FAQ edit path — to mirror where that surfaced.
+		app = buildAppWithCors('https://app.rivus.ai');
+		const res = await app.inject({
+			method: 'OPTIONS',
+			url: '/v1/faqs/some-id',
+			headers: {
+				origin: 'https://app.rivus.ai',
+				'access-control-request-method': 'PATCH',
+			},
+		});
+		const allowed = String(res.headers['access-control-allow-methods'] ?? '');
+		expect(allowed).toContain('PATCH');
+		expect(allowed).toContain('DELETE');
+	});
+
 	it('does not authorize an origin outside the allowlist', async () => {
 		app = buildAppWithCors('https://app.rivus.ai,https://www.rivus.ai');
 		const res = await preflight(app, 'https://evil.example');


### PR DESCRIPTION
## What

Editing a knowledge entry (FAQ) failed with **"Failed to fetch"** on the web app (per the reported screenshot). The same fault blocked deleting an FAQ and updating account settings.

## Root cause

`Failed to fetch` is the browser's `fetch` `TypeError` — the request never completes. It's surfaced verbatim by the Knowledge screen's save handler (`caught.message`), so it's a network/CORS-level failure, not an HTTP error response.

The web app's writes are cross-origin (`app.rivus.ai` → `api.rivus.ai`) and sent with credentials, so the browser issues a **CORS preflight** for `PATCH`/`DELETE`. `@fastify/cors` **v11** narrowed its default `methods` to just `GET,HEAD,POST`, and `app.ts` registered the plugin without an explicit `methods` list. The preflight therefore answered:

```
Access-Control-Allow-Methods: GET,HEAD,POST
```

`PATCH` (and `DELETE`/`PUT`) aren't in that list, so the browser blocks the real request before it's sent → `fetch` rejects with `Failed to fetch`.

This never showed up in tests because:
- `app.inject` doesn't enforce CORS (only a real browser does), so the route-level tests pass.
- The existing CORS test only preflighted the **public** `/v1/auth/login` route and asserted `allow-origin`/`allow-credentials`, never `allow-methods`.

## Fix

Explicitly configure `@fastify/cors` with the verbs the API actually serves:

```ts
methods: ['GET', 'HEAD', 'POST', 'PATCH', 'DELETE'],
```

## Test

Added a regression test that preflights `PATCH /v1/faqs/:id` (the FAQ edit path) and asserts `Access-Control-Allow-Methods` includes `PATCH` and `DELETE`. Verified it fails before the fix (`expected 'GET,HEAD,POST' to contain 'PATCH'`) and passes after.

`pnpm lint && pnpm type-check && pnpm test` all green (core 71, api 187, app 80, website 43, worker 14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WH2amwGXGXqoQQSMwxW4mg

---
_Generated by [Claude Code](https://claude.ai/code/session_01WH2amwGXGXqoQQSMwxW4mg)_