### PR TITLE
feat(customers): build customers CRM end-to-end (app, API, database)

### DIFF
--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1927,6 +1927,419 @@
           }
         }
       }
+    },
+    "/v1/customers/": {
+      "get": {
+        "summary": "List your account's customers",
+        "tags": [
+          "customers"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a customer",
+        "tags": [
+          "customers"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "email": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 254
+                  },
+                  "phone": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 40
+                  },
+                  "area": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 120
+                  },
+                  "channel": {
+                    "default": "phone",
+                    "type": "string",
+                    "enum": [
+                      "whatsapp",
+                      "phone",
+                      "email",
+                      "sms"
+                    ]
+                  },
+                  "status": {
+                    "default": "lead",
+                    "type": "string",
+                    "enum": [
+                      "lead",
+                      "quote",
+                      "paid",
+                      "due"
+                    ]
+                  },
+                  "lifetimeValue": {
+                    "default": 0,
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "balance": {
+                    "default": 0,
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "notes": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 2000
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/customers/{id}": {
+      "get": {
+        "summary": "Fetch one of your customers",
+        "tags": [
+          "customers"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update one of your customers",
+        "tags": [
+          "customers"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "email": {
+                    "type": "string",
+                    "maxLength": 254
+                  },
+                  "phone": {
+                    "type": "string",
+                    "maxLength": 40
+                  },
+                  "area": {
+                    "type": "string",
+                    "maxLength": 120
+                  },
+                  "channel": {
+                    "type": "string",
+                    "enum": [
+                      "whatsapp",
+                      "phone",
+                      "email",
+                      "sms"
+                    ]
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "lead",
+                      "quote",
+                      "paid",
+                      "due"
+                    ]
+                  },
+                  "lifetimeValue": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "balance": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "notes": {
+                    "type": "string",
+                    "maxLength": 2000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete one of your customers",
+        "tags": [
+          "customers"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -15,6 +15,7 @@ import { accountRoutes } from './routes/account';
 import { adminRoutes } from './routes/admin';
 import { authRoutes } from './routes/auth';
 import { billingRoutes } from './routes/billing';
+import { customerRoutes } from './routes/customers';
 import { faqRoutes } from './routes/faqs';
 import { healthRoutes } from './routes/health';
 import { itemRoutes } from './routes/items';
@@ -165,6 +166,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	app.register(billingRoutes, { prefix: '/v1/billing' });
 	app.register(itemRoutes, { prefix: '/v1/items' });
 	app.register(faqRoutes, { prefix: '/v1/faqs' });
+	app.register(customerRoutes, { prefix: '/v1/customers' });
 
 	return app;
 }

--- a/packages/api/src/db/models/customer.model.ts
+++ b/packages/api/src/db/models/customer.model.ts
@@ -31,4 +31,10 @@ const customerSchema = new Schema<CustomerDocument>(
 	{ timestamps: true },
 );
 
+// The account-scoped list query filters by `accountId` and sorts by
+// `{ createdAt: -1, _id: -1 }`; a matching compound index lets Mongo serve it
+// from the index instead of an in-memory sort (which fails past the 32MB limit
+// once an account has many customers).
+customerSchema.index({ accountId: 1, createdAt: -1, _id: -1 });
+
 export const CustomerModel = model<CustomerDocument>('Customer', customerSchema);

--- a/packages/api/src/db/models/customer.model.ts
+++ b/packages/api/src/db/models/customer.model.ts
@@ -1,0 +1,34 @@
+import { model, Schema, type Types } from 'mongoose';
+
+export interface CustomerDocument {
+	accountId: Types.ObjectId;
+	name: string;
+	email: string;
+	phone: string;
+	area: string;
+	channel: 'whatsapp' | 'phone' | 'email' | 'sms';
+	status: 'lead' | 'quote' | 'paid' | 'due';
+	lifetimeValue: number;
+	balance: number;
+	notes: string;
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+const customerSchema = new Schema<CustomerDocument>(
+	{
+		accountId: { type: Schema.Types.ObjectId, ref: 'Account', required: true, index: true },
+		name: { type: String, required: true, trim: true },
+		email: { type: String, default: '', trim: true, lowercase: true },
+		phone: { type: String, default: '', trim: true },
+		area: { type: String, default: '', trim: true },
+		channel: { type: String, enum: ['whatsapp', 'phone', 'email', 'sms'], default: 'phone' },
+		status: { type: String, enum: ['lead', 'quote', 'paid', 'due'], default: 'lead' },
+		lifetimeValue: { type: Number, default: 0 },
+		balance: { type: Number, default: 0 },
+		notes: { type: String, default: '', trim: true },
+	},
+	{ timestamps: true },
+);
+
+export const CustomerModel = model<CustomerDocument>('Customer', customerSchema);

--- a/packages/api/src/http-schemas.ts
+++ b/packages/api/src/http-schemas.ts
@@ -1,4 +1,11 @@
-import { accountStatusSchema, faqStatusSchema, itemStatusSchema, roleSchema } from '@rivus/core';
+import {
+	accountStatusSchema,
+	customerChannelSchema,
+	customerStatusSchema,
+	faqStatusSchema,
+	itemStatusSchema,
+	roleSchema,
+} from '@rivus/core';
 import { z } from 'zod';
 
 /** Public user projection — never includes the password hash. */
@@ -152,6 +159,31 @@ export const faqListResponseSchema = z
 		meta: paginationMetaSchema,
 	})
 	.meta({ id: 'FaqList' });
+
+export const customerResponseSchema = z
+	.object({
+		id: z.string(),
+		accountId: z.string(),
+		name: z.string(),
+		email: z.string(),
+		phone: z.string(),
+		area: z.string(),
+		channel: customerChannelSchema,
+		status: customerStatusSchema,
+		lifetimeValue: z.number().int(),
+		balance: z.number().int(),
+		notes: z.string(),
+		createdAt: z.string(),
+		updatedAt: z.string(),
+	})
+	.meta({ id: 'Customer' });
+
+export const customerListResponseSchema = z
+	.object({
+		data: z.array(customerResponseSchema),
+		meta: paginationMetaSchema,
+	})
+	.meta({ id: 'CustomerList' });
 
 /**
  * Result of the AI duplicate check run before creating an FAQ. `match` is the

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -13,8 +13,17 @@ import { NoopFaqSimilarityService } from './services/faq-similarity';
  */
 async function main(): Promise<void> {
 	const config = loadConfig({ ...process.env, NODE_ENV: 'test' });
-	const { users, accounts, memberships, invites, onboarding, items, faqs, verificationCodes } =
-		createInMemoryRepositories();
+	const {
+		users,
+		accounts,
+		memberships,
+		invites,
+		onboarding,
+		items,
+		faqs,
+		customers,
+		verificationCodes,
+	} = createInMemoryRepositories();
 	const app = buildApp({
 		config,
 		users,
@@ -24,6 +33,7 @@ async function main(): Promise<void> {
 		onboarding,
 		items,
 		faqs,
+		customers,
 		verificationCodes,
 		mailer: new NoopMailer(),
 		faqSimilarity: new NoopFaqSimilarityService(),

--- a/packages/api/src/repositories/memory.ts
+++ b/packages/api/src/repositories/memory.ts
@@ -2,8 +2,11 @@ import { randomUUID } from 'node:crypto';
 import {
 	type Account,
 	type AccountId,
+	type CreateCustomerInput,
 	type CreateFaqInput,
 	type CreateItemInput,
+	type Customer,
+	type CustomerId,
 	type Faq,
 	type FaqId,
 	type Invite,
@@ -15,6 +18,7 @@ import {
 	normalizePagination,
 	pageToSkip,
 	type Role,
+	type UpdateCustomerInput,
 	type UpdateFaqInput,
 	type UpdateItemInput,
 	type UserId,
@@ -24,10 +28,12 @@ import type {
 	AcceptInviteInput,
 	AcceptInviteResult,
 	AccountRepository,
+	CustomerRepository,
 	FaqRepository,
 	InviteRepository,
 	ItemRepository,
 	ListAccountsOptions,
+	ListCustomersOptions,
 	ListFaqsOptions,
 	ListItemsOptions,
 	MembershipRepository,
@@ -60,6 +66,7 @@ export interface InMemoryData {
 	invites: Map<string, Invite>;
 	items: Map<string, Item>;
 	faqs: Map<string, Faq>;
+	customers: Map<string, Customer>;
 	/** Active one-time codes, keyed by normalized email (one per email). */
 	verificationCodes: Map<string, StoredVerificationCode>;
 }
@@ -72,6 +79,7 @@ export function createInMemoryData(): InMemoryData {
 		invites: new Map(),
 		items: new Map(),
 		faqs: new Map(),
+		customers: new Map(),
 		verificationCodes: new Map(),
 	};
 }
@@ -571,6 +579,73 @@ export class InMemoryFaqRepository implements FaqRepository {
 	}
 }
 
+/** In-memory customer store, scoped by account. */
+export class InMemoryCustomerRepository implements CustomerRepository {
+	constructor(private readonly data: InMemoryData) {}
+
+	async create(accountId: AccountId, input: CreateCustomerInput): Promise<Customer> {
+		const timestamp = now();
+		const customer: Customer = {
+			id: randomUUID() as CustomerId,
+			accountId,
+			name: input.name,
+			email: input.email,
+			phone: input.phone,
+			area: input.area,
+			channel: input.channel,
+			status: input.status,
+			lifetimeValue: input.lifetimeValue,
+			balance: input.balance,
+			notes: input.notes,
+			createdAt: timestamp,
+			updatedAt: timestamp,
+		};
+		this.data.customers.set(customer.id, customer);
+		return structuredClone(customer);
+	}
+
+	async list(options: ListCustomersOptions): Promise<{ customers: Customer[]; total: number }> {
+		// Map preserves insertion order, so reversing yields a deterministic
+		// newest-first ordering even when timestamps collide within a millisecond.
+		const owned = [...this.data.customers.values()]
+			.filter((customer) => customer.accountId === options.accountId)
+			.reverse();
+		const { pageSize } = normalizePagination(options.page, options.pageSize);
+		const skip = pageToSkip(options.page, options.pageSize);
+		return {
+			customers: owned.slice(skip, skip + pageSize).map((customer) => structuredClone(customer)),
+			total: owned.length,
+		};
+	}
+
+	async findById(accountId: AccountId, id: CustomerId): Promise<Customer | null> {
+		const customer = this.data.customers.get(id);
+		return customer && customer.accountId === accountId ? structuredClone(customer) : null;
+	}
+
+	async update(
+		accountId: AccountId,
+		id: CustomerId,
+		input: UpdateCustomerInput,
+	): Promise<Customer | null> {
+		const customer = this.data.customers.get(id);
+		if (!customer || customer.accountId !== accountId) {
+			return null;
+		}
+		const updated: Customer = { ...customer, ...input, updatedAt: now() };
+		this.data.customers.set(id, updated);
+		return structuredClone(updated);
+	}
+
+	async delete(accountId: AccountId, id: CustomerId): Promise<boolean> {
+		const customer = this.data.customers.get(id);
+		if (!customer || customer.accountId !== accountId) {
+			return false;
+		}
+		return this.data.customers.delete(id);
+	}
+}
+
 export interface InMemoryRepositories {
 	data: InMemoryData;
 	users: InMemoryUserRepository;
@@ -579,6 +654,7 @@ export interface InMemoryRepositories {
 	invites: InMemoryInviteRepository;
 	items: InMemoryItemRepository;
 	faqs: InMemoryFaqRepository;
+	customers: InMemoryCustomerRepository;
 	verificationCodes: InMemoryVerificationCodeRepository;
 	onboarding: InMemoryOnboardingRepository;
 }
@@ -593,6 +669,7 @@ export function createInMemoryRepositories(
 	const invites = new InMemoryInviteRepository(data);
 	const items = new InMemoryItemRepository(data);
 	const faqs = new InMemoryFaqRepository(data);
+	const customers = new InMemoryCustomerRepository(data);
 	const verificationCodes = new InMemoryVerificationCodeRepository(data);
 	const onboarding = new InMemoryOnboardingRepository(users, accounts, memberships, invites);
 	return {
@@ -603,6 +680,7 @@ export function createInMemoryRepositories(
 		invites,
 		items,
 		faqs,
+		customers,
 		verificationCodes,
 		onboarding,
 	};

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -1,8 +1,11 @@
 import {
 	type Account,
 	type AccountId,
+	type CreateCustomerInput,
 	type CreateFaqInput,
 	type CreateItemInput,
+	type Customer,
+	type CustomerId,
 	type Faq,
 	type FaqId,
 	type Invite,
@@ -14,12 +17,14 @@ import {
 	normalizePagination,
 	pageToSkip,
 	type Role,
+	type UpdateCustomerInput,
 	type UpdateFaqInput,
 	type UpdateItemInput,
 	type UserId,
 } from '@rivus/core';
 import mongoose, { type ClientSession, type HydratedDocument, Types } from 'mongoose';
 import { type AccountDocument, AccountModel } from '../db/models/account.model';
+import { type CustomerDocument, CustomerModel } from '../db/models/customer.model';
 import { type FaqDocument, FaqModel } from '../db/models/faq.model';
 import { type InviteDocument, InviteModel } from '../db/models/invite.model';
 import { type ItemDocument, ItemModel } from '../db/models/item.model';
@@ -34,10 +39,12 @@ import type {
 	AcceptInviteInput,
 	AcceptInviteResult,
 	AccountRepository,
+	CustomerRepository,
 	FaqRepository,
 	InviteRepository,
 	ItemRepository,
 	ListAccountsOptions,
+	ListCustomersOptions,
 	ListFaqsOptions,
 	ListItemsOptions,
 	MembershipRepository,
@@ -137,6 +144,24 @@ function mapItem(doc: HydratedDocument<ItemDocument>): Item {
 		name: doc.name,
 		description: doc.description,
 		status: doc.status,
+		createdAt: doc.createdAt.toISOString(),
+		updatedAt: doc.updatedAt.toISOString(),
+	};
+}
+
+function mapCustomer(doc: HydratedDocument<CustomerDocument>): Customer {
+	return {
+		id: doc._id.toString() as CustomerId,
+		accountId: doc.accountId.toString() as AccountId,
+		name: doc.name,
+		email: doc.email,
+		phone: doc.phone,
+		area: doc.area,
+		channel: doc.channel,
+		status: doc.status,
+		lifetimeValue: doc.lifetimeValue,
+		balance: doc.balance,
+		notes: doc.notes,
 		createdAt: doc.createdAt.toISOString(),
 		updatedAt: doc.updatedAt.toISOString(),
 	};
@@ -653,6 +678,65 @@ export class MongoItemRepository implements ItemRepository {
 			return false;
 		}
 		const result = await ItemModel.deleteOne({
+			_id: id,
+			accountId: new Types.ObjectId(accountId),
+		}).exec();
+		return result.deletedCount === 1;
+	}
+}
+
+export class MongoCustomerRepository implements CustomerRepository {
+	async create(accountId: AccountId, input: CreateCustomerInput): Promise<Customer> {
+		const doc = await CustomerModel.create({ accountId: new Types.ObjectId(accountId), ...input });
+		return mapCustomer(doc);
+	}
+
+	async list(options: ListCustomersOptions): Promise<{ customers: Customer[]; total: number }> {
+		if (!Types.ObjectId.isValid(options.accountId)) {
+			return { customers: [], total: 0 };
+		}
+		const { pageSize } = normalizePagination(options.page, options.pageSize);
+		const skip = pageToSkip(options.page, options.pageSize);
+		const filter = { accountId: new Types.ObjectId(options.accountId) };
+		const [docs, total] = await Promise.all([
+			CustomerModel.find(filter).sort({ createdAt: -1, _id: -1 }).skip(skip).limit(pageSize).exec(),
+			CustomerModel.countDocuments(filter).exec(),
+		]);
+		return { customers: docs.map(mapCustomer), total };
+	}
+
+	async findById(accountId: AccountId, id: CustomerId): Promise<Customer | null> {
+		if (!Types.ObjectId.isValid(id) || !Types.ObjectId.isValid(accountId)) {
+			return null;
+		}
+		const doc = await CustomerModel.findOne({
+			_id: id,
+			accountId: new Types.ObjectId(accountId),
+		}).exec();
+		return doc ? mapCustomer(doc) : null;
+	}
+
+	async update(
+		accountId: AccountId,
+		id: CustomerId,
+		input: UpdateCustomerInput,
+	): Promise<Customer | null> {
+		if (!Types.ObjectId.isValid(id) || !Types.ObjectId.isValid(accountId)) {
+			return null;
+		}
+		const doc = await CustomerModel.findOneAndUpdate(
+			{ _id: id, accountId: new Types.ObjectId(accountId) },
+			{ $set: input },
+			{ new: true },
+		).exec();
+		return doc ? mapCustomer(doc) : null;
+	}
+
+	async delete(accountId: AccountId, id: CustomerId): Promise<boolean> {
+		if (!Types.ObjectId.isValid(id) || !Types.ObjectId.isValid(accountId)) {
+			return false;
+		}
+		const result = await CustomerModel.deleteOne({
 			_id: id,
 			accountId: new Types.ObjectId(accountId),
 		}).exec();

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -2,8 +2,11 @@ import type {
 	Account,
 	AccountBusinessInput,
 	AccountId,
+	CreateCustomerInput,
 	CreateFaqInput,
 	CreateItemInput,
+	Customer,
+	CustomerId,
 	Faq,
 	FaqId,
 	Invite,
@@ -12,6 +15,7 @@ import type {
 	ItemId,
 	Membership,
 	Role,
+	UpdateCustomerInput,
 	UpdateFaqInput,
 	UpdateItemInput,
 	User,
@@ -218,4 +222,22 @@ export interface FaqRepository {
 	findById(accountId: AccountId, id: FaqId): Promise<Faq | null>;
 	update(accountId: AccountId, id: FaqId, input: UpdateFaqInput): Promise<Faq | null>;
 	delete(accountId: AccountId, id: FaqId): Promise<boolean>;
+}
+
+export interface ListCustomersOptions {
+	accountId: AccountId;
+	page: number;
+	pageSize: number;
+}
+
+export interface CustomerRepository {
+	create(accountId: AccountId, input: CreateCustomerInput): Promise<Customer>;
+	list(options: ListCustomersOptions): Promise<{ customers: Customer[]; total: number }>;
+	findById(accountId: AccountId, id: CustomerId): Promise<Customer | null>;
+	update(
+		accountId: AccountId,
+		id: CustomerId,
+		input: UpdateCustomerInput,
+	): Promise<Customer | null>;
+	delete(accountId: AccountId, id: CustomerId): Promise<boolean>;
 }

--- a/packages/api/src/routes/customers.ts
+++ b/packages/api/src/routes/customers.ts
@@ -1,0 +1,149 @@
+import {
+	type AccountId,
+	buildPaginationMeta,
+	type CustomerId,
+	createCustomerSchema,
+	paginationQuerySchema,
+	updateCustomerSchema,
+} from '@rivus/core';
+import type { FastifyPluginAsync } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+	customerListResponseSchema,
+	customerResponseSchema,
+	errorResponseSchema,
+	idParamsSchema,
+} from '../http-schemas';
+
+export const customerRoutes: FastifyPluginAsync = async (fastify) => {
+	const app = fastify.withTypeProvider<ZodTypeProvider>();
+	const { customers } = app.deps;
+
+	// Every customer route requires a valid JWT.
+	app.addHook('onRequest', fastify.authenticate);
+
+	app.get(
+		'/',
+		{
+			schema: {
+				tags: ['customers'],
+				summary: "List your account's customers",
+				security: [{ bearerAuth: [] }],
+				querystring: paginationQuerySchema,
+				response: { 200: customerListResponseSchema, 401: errorResponseSchema },
+			},
+		},
+		async (request) => {
+			const accountId = request.user.accountId as AccountId;
+			const { page, pageSize } = request.query;
+			const { customers: data, total } = await customers.list({ accountId, page, pageSize });
+			return { data, meta: buildPaginationMeta({ page, pageSize, total }) };
+		},
+	);
+
+	app.post(
+		'/',
+		{
+			schema: {
+				tags: ['customers'],
+				summary: 'Create a customer',
+				security: [{ bearerAuth: [] }],
+				body: createCustomerSchema,
+				response: {
+					201: customerResponseSchema,
+					400: errorResponseSchema,
+					401: errorResponseSchema,
+				},
+			},
+		},
+		async (request, reply) => {
+			const customer = await customers.create(request.user.accountId as AccountId, request.body);
+			return reply.code(201).send(customer);
+		},
+	);
+
+	app.get(
+		'/:id',
+		{
+			schema: {
+				tags: ['customers'],
+				summary: 'Fetch one of your customers',
+				security: [{ bearerAuth: [] }],
+				params: idParamsSchema,
+				response: {
+					200: customerResponseSchema,
+					404: errorResponseSchema,
+					401: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const customer = await customers.findById(
+				request.user.accountId as AccountId,
+				request.params.id as CustomerId,
+			);
+			if (!customer) {
+				throw app.httpErrors.notFound('Customer not found');
+			}
+			return customer;
+		},
+	);
+
+	app.patch(
+		'/:id',
+		{
+			schema: {
+				tags: ['customers'],
+				summary: 'Update one of your customers',
+				security: [{ bearerAuth: [] }],
+				params: idParamsSchema,
+				body: updateCustomerSchema,
+				response: {
+					200: customerResponseSchema,
+					400: errorResponseSchema,
+					404: errorResponseSchema,
+					401: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const customer = await customers.update(
+				request.user.accountId as AccountId,
+				request.params.id as CustomerId,
+				request.body,
+			);
+			if (!customer) {
+				throw app.httpErrors.notFound('Customer not found');
+			}
+			return customer;
+		},
+	);
+
+	app.delete(
+		'/:id',
+		{
+			schema: {
+				tags: ['customers'],
+				summary: 'Delete one of your customers',
+				security: [{ bearerAuth: [] }],
+				params: idParamsSchema,
+				response: {
+					204: z.null(),
+					401: errorResponseSchema,
+					404: errorResponseSchema,
+				},
+			},
+		},
+		async (request, reply) => {
+			const deleted = await customers.delete(
+				request.user.accountId as AccountId,
+				request.params.id as CustomerId,
+			);
+			if (!deleted) {
+				throw app.httpErrors.notFound('Customer not found');
+			}
+			return reply.code(204).send(null);
+		},
+	);
+};

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -4,6 +4,7 @@ import { loadConfig } from './config';
 import { checkDatabaseReady, connectMongoose, disconnectMongoose } from './db/mongoose';
 import {
 	MongoAccountRepository,
+	MongoCustomerRepository,
 	MongoFaqRepository,
 	MongoInviteRepository,
 	MongoItemRepository,
@@ -29,6 +30,7 @@ export async function start(): Promise<void> {
 		onboarding: new MongoOnboardingRepository(),
 		items: new MongoItemRepository(),
 		faqs: new MongoFaqRepository(),
+		customers: new MongoCustomerRepository(),
 		verificationCodes: new MongoVerificationCodeRepository(),
 		mailer: createMailer(config),
 		faqSimilarity: createFaqSimilarityService(config),

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -3,6 +3,7 @@ import type { FastifyReply, FastifyRequest } from 'fastify';
 import type { Config } from './config';
 import type {
 	AccountRepository,
+	CustomerRepository,
 	FaqRepository,
 	InviteRepository,
 	ItemRepository,
@@ -31,6 +32,7 @@ export interface AppDeps {
 	onboarding: OnboardingRepository;
 	items: ItemRepository;
 	faqs: FaqRepository;
+	customers: CustomerRepository;
 	/** Stores one-time sign-in codes for passwordless auth. */
 	verificationCodes: VerificationCodeRepository;
 	/** Sends transactional email (invitations and sign-in codes). */

--- a/packages/api/test/customers.test.ts
+++ b/packages/api/test/customers.test.ts
@@ -1,0 +1,243 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { authHeader, buildTestApp, signupOwner } from './helpers';
+
+describe('customers', () => {
+	let app: FastifyInstance;
+	let token: string;
+
+	beforeEach(async () => {
+		app = await buildTestApp();
+		token = (await signupOwner(app)).token;
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	async function createCustomer(name: string, extra: Record<string, unknown> = {}) {
+		return app.inject({
+			method: 'POST',
+			url: '/v1/customers',
+			headers: authHeader(token),
+			payload: { name, ...extra },
+		});
+	}
+
+	it('requires authentication', async () => {
+		const response = await app.inject({ method: 'GET', url: '/v1/customers' });
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('creates a customer with defaults', async () => {
+		const response = await createCustomer('Grace Kim');
+
+		expect(response.statusCode).toBe(201);
+		expect(response.json()).toMatchObject({
+			name: 'Grace Kim',
+			email: '',
+			phone: '',
+			area: '',
+			channel: 'phone',
+			status: 'lead',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+		expect(response.json().id).toBeTypeOf('string');
+	});
+
+	it('creates a customer with a full CRM record', async () => {
+		const response = await createCustomer('Priya Anand', {
+			email: 'Priya@Example.com',
+			phone: '(206) 555-0119',
+			area: 'Capitol Hill',
+			channel: 'email',
+			status: 'due',
+			lifetimeValue: 526_000,
+			balance: 54_000,
+			notes: 'Billing flag',
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(response.json()).toMatchObject({
+			name: 'Priya Anand',
+			email: 'priya@example.com',
+			channel: 'email',
+			status: 'due',
+			lifetimeValue: 526_000,
+			balance: 54_000,
+		});
+	});
+
+	it('rejects a create with no name (400)', async () => {
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/customers',
+			headers: authHeader(token),
+			payload: { area: 'orphan' },
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects a create with an unknown channel (400)', async () => {
+		const response = await createCustomer('Bad Channel', { channel: 'telegram' });
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects a create with an unknown status (400)', async () => {
+		const response = await createCustomer('Bad Status', { status: 'cold' });
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects a create with negative money (400)', async () => {
+		const response = await createCustomer('Bad Balance', { balance: -1 });
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects a create with a malformed email (400)', async () => {
+		const response = await createCustomer('Bad Email', { email: 'not-an-email' });
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('lists customers newest-first with pagination metadata', async () => {
+		await createCustomer('one');
+		await createCustomer('two');
+		await createCustomer('three');
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/v1/customers?page=1&pageSize=2',
+			headers: authHeader(token),
+		});
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.data).toHaveLength(2);
+		expect(body.meta).toMatchObject({
+			page: 1,
+			pageSize: 2,
+			total: 3,
+			totalPages: 2,
+			hasNextPage: true,
+			hasPreviousPage: false,
+		});
+		expect(body.data[0].name).toBe('three');
+	});
+
+	it('fetches a single customer by id', async () => {
+		const created = await createCustomer('findable');
+		const id = created.json().id;
+
+		const response = await app.inject({
+			method: 'GET',
+			url: `/v1/customers/${id}`,
+			headers: authHeader(token),
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().id).toBe(id);
+	});
+
+	it('returns 404 for an unknown id', async () => {
+		const response = await app.inject({
+			method: 'GET',
+			url: '/v1/customers/does-not-exist',
+			headers: authHeader(token),
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	it('updates a customer', async () => {
+		const created = await createCustomer('before', { status: 'lead' });
+		const id = created.json().id;
+
+		const response = await app.inject({
+			method: 'PATCH',
+			url: `/v1/customers/${id}`,
+			headers: authHeader(token),
+			payload: { status: 'paid', balance: 21_000 },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toMatchObject({ name: 'before', status: 'paid', balance: 21_000 });
+	});
+
+	it('rejects an empty update (400)', async () => {
+		const created = await createCustomer('immutable');
+		const id = created.json().id;
+
+		const response = await app.inject({
+			method: 'PATCH',
+			url: `/v1/customers/${id}`,
+			headers: authHeader(token),
+			payload: {},
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('deletes a customer, after which it is gone', async () => {
+		const created = await createCustomer('temporary');
+		const id = created.json().id;
+
+		const deleteResponse = await app.inject({
+			method: 'DELETE',
+			url: `/v1/customers/${id}`,
+			headers: authHeader(token),
+		});
+		expect(deleteResponse.statusCode).toBe(204);
+
+		const getResponse = await app.inject({
+			method: 'GET',
+			url: `/v1/customers/${id}`,
+			headers: authHeader(token),
+		});
+		expect(getResponse.statusCode).toBe(404);
+	});
+
+	it('does not leak customers across owners', async () => {
+		const created = await createCustomer('private');
+		const id = created.json().id;
+
+		const otherToken = (await signupOwner(app)).token;
+		const response = await app.inject({
+			method: 'GET',
+			url: `/v1/customers/${id}`,
+			headers: authHeader(otherToken),
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	it('does not let another owner update a customer', async () => {
+		const created = await createCustomer('private');
+		const id = created.json().id;
+		const otherToken = (await signupOwner(app)).token;
+
+		const response = await app.inject({
+			method: 'PATCH',
+			url: `/v1/customers/${id}`,
+			headers: authHeader(otherToken),
+			payload: { name: 'hijacked' },
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+
+	it('does not let another owner delete a customer', async () => {
+		const created = await createCustomer('private');
+		const id = created.json().id;
+		const otherToken = (await signupOwner(app)).token;
+
+		const response = await app.inject({
+			method: 'DELETE',
+			url: `/v1/customers/${id}`,
+			headers: authHeader(otherToken),
+		});
+
+		expect(response.statusCode).toBe(404);
+	});
+});

--- a/packages/api/test/helpers.ts
+++ b/packages/api/test/helpers.ts
@@ -28,8 +28,17 @@ const TEST_CONFIG = {
 } as NodeJS.ProcessEnv;
 
 export async function buildTestApp(overrides: Partial<AppDeps> = {}): Promise<FastifyInstance> {
-	const { users, accounts, memberships, invites, onboarding, items, faqs, verificationCodes } =
-		createInMemoryRepositories();
+	const {
+		users,
+		accounts,
+		memberships,
+		invites,
+		onboarding,
+		items,
+		faqs,
+		customers,
+		verificationCodes,
+	} = createInMemoryRepositories();
 	const app = buildApp({
 		config: loadConfig(TEST_CONFIG),
 		users,
@@ -39,6 +48,7 @@ export async function buildTestApp(overrides: Partial<AppDeps> = {}): Promise<Fa
 		onboarding,
 		items,
 		faqs,
+		customers,
 		verificationCodes,
 		// A recording mailer by default so helpers can read back the emailed code.
 		mailer: new RecordingMailer(),
@@ -60,8 +70,17 @@ export async function buildTestAppWithRepos(): Promise<{
 	repos: InMemoryRepositories;
 }> {
 	const repos = createInMemoryRepositories();
-	const { users, accounts, memberships, invites, onboarding, items, faqs, verificationCodes } =
-		repos;
+	const {
+		users,
+		accounts,
+		memberships,
+		invites,
+		onboarding,
+		items,
+		faqs,
+		customers,
+		verificationCodes,
+	} = repos;
 	const app = buildApp({
 		config: loadConfig(TEST_CONFIG),
 		users,
@@ -71,6 +90,7 @@ export async function buildTestAppWithRepos(): Promise<{
 		onboarding,
 		items,
 		faqs,
+		customers,
 		verificationCodes,
 		mailer: new RecordingMailer(),
 		faqSimilarity: new NoopFaqSimilarityService(),

--- a/packages/app/app/customers.tsx
+++ b/packages/app/app/customers.tsx
@@ -1,8 +1,27 @@
-import { ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
-import { RivusSymbol } from '@/src/brand/RivusLogo';
-import { BrandGradient } from '@/src/components/Gradient';
-import { Avatar, GradientButton, Icon, Pill, SectionLabel, Txt } from '@/src/components/ui';
-import { customerStatusStyle, customers } from '@/src/data/demo';
+import type { CustomerChannel, CustomerStatus } from '@rivus/core';
+import { type ComponentProps, useCallback, useEffect, useState } from 'react';
+import {
+	ActivityIndicator,
+	Pressable,
+	ScrollView,
+	StyleSheet,
+	useWindowDimensions,
+	View,
+} from 'react-native';
+import { ApiError, type Customer } from '@/src/api/client';
+import { initialsOf, useAuth } from '@/src/auth/AuthContext';
+import {
+	Avatar,
+	Card,
+	GradientButton,
+	Icon,
+	OutlineButton,
+	Pill,
+	SectionLabel,
+	Segmented,
+	TextField,
+	Txt,
+} from '@/src/components/ui';
 import { colors, font, radii, SIDEBAR_BREAKPOINT, SIDEBAR_WIDTH } from '@/src/theme/tokens';
 
 const COLS = {
@@ -14,25 +33,226 @@ const COLS = {
 	status: 1.1,
 };
 
-const recent = [
-	{ color: colors.brandPurple, title: 'Emailed about invoice #1051', time: 'Today, 8:47 AM' },
-	{ color: colors.brandCyan, title: 'Valve replacement completed', time: 'Jun 18' },
-	{ color: '#d3d6e0', title: 'Left a 5-star review', time: 'May 30' },
+const CHANNEL_OPTIONS: { label: string; value: CustomerChannel }[] = [
+	{ label: 'WhatsApp', value: 'whatsapp' },
+	{ label: 'Phone', value: 'phone' },
+	{ label: 'Email', value: 'email' },
+	{ label: 'SMS', value: 'sms' },
 ];
 
-const invoices = [
-	{ title: '#1051 · Valve replacement', meta: 'Due Jun 30', tag: '$540', paid: false },
-	{ title: '#1037 · Drain cleaning', meta: 'Paid May 28', tag: 'Paid', paid: true },
-	{ title: '#1022 · Faucet install', meta: 'Paid Apr 11', tag: 'Paid', paid: true },
+const STATUS_OPTIONS: { label: string; value: CustomerStatus }[] = [
+	{ label: 'Lead', value: 'lead' },
+	{ label: 'Quote', value: 'quote' },
+	{ label: 'Paid', value: 'paid' },
+	{ label: 'Due', value: 'due' },
 ];
+
+const CHANNEL_LABEL: Record<CustomerChannel, string> = {
+	whatsapp: 'WhatsApp',
+	phone: 'Phone',
+	email: 'Email',
+	sms: 'SMS',
+};
+
+const STATUS_STYLE: Record<CustomerStatus, { label: string; color: string; background: string }> = {
+	paid: { label: 'Paid up', color: colors.green, background: 'rgba(31,181,115,0.12)' },
+	due: { label: 'Balance due', color: colors.redInk, background: 'rgba(240,88,75,0.12)' },
+	quote: { label: 'Quote pending', color: colors.amberInk, background: 'rgba(240,160,32,0.14)' },
+	lead: { label: 'New lead', color: colors.brandPurple, background: 'rgba(110,30,200,0.10)' },
+};
+
+/** Format integer cents as a grouped dollar string (54000 → "$540.00"). */
+function formatMoney(cents: number): string {
+	const sign = cents < 0 ? '-' : '';
+	const abs = Math.abs(cents);
+	const dollars = String(Math.floor(abs / 100)).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+	return `${sign}$${dollars}.${String(abs % 100).padStart(2, '0')}`;
+}
+
+/** Parse a dollar text input into integer cents; returns null when invalid. */
+function dollarsToCents(text: string): number | null {
+	const trimmed = text.trim();
+	if (trimmed === '') {
+		return 0;
+	}
+	const value = Number(trimmed.replace(/[$,\s]/g, ''));
+	if (!Number.isFinite(value) || value < 0) {
+		return null;
+	}
+	return Math.round(value * 100);
+}
+
+/** Pre-fill the dollar input when editing (0 shows blank so the placeholder shows). */
+function centsToInput(cents: number): string {
+	if (cents === 0) {
+		return '';
+	}
+	return cents % 100 === 0 ? String(cents / 100) : (cents / 100).toFixed(2);
+}
 
 export default function CustomersScreen() {
+	const { session, client } = useAuth();
 	const { width } = useWindowDimensions();
 	const sidebar = width >= SIDEBAR_BREAKPOINT ? SIDEBAR_WIDTH : 0;
 	const showPanel = width >= 1040;
 	const panel = showPanel ? 340 : 0;
 	const avail = width - sidebar - panel - 48;
-	const tableWidth = Math.max(620, avail);
+	const tableWidth = Math.max(640, avail);
+
+	const [list, setList] = useState<Customer[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [selectedId, setSelectedId] = useState<string | null>(null);
+
+	const [formOpen, setFormOpen] = useState(false);
+	const [editing, setEditing] = useState<Customer | null>(null);
+	const [name, setName] = useState('');
+	const [email, setEmail] = useState('');
+	const [phone, setPhone] = useState('');
+	const [area, setArea] = useState('');
+	const [channel, setChannel] = useState<CustomerChannel>('phone');
+	const [status, setStatus] = useState<CustomerStatus>('lead');
+	const [lifetime, setLifetime] = useState('');
+	const [balance, setBalance] = useState('');
+	const [notes, setNotes] = useState('');
+	const [formError, setFormError] = useState<string | null>(null);
+	const [saving, setSaving] = useState(false);
+	const [deleting, setDeleting] = useState(false);
+
+	const load = useCallback(async () => {
+		if (!session) {
+			return;
+		}
+		setLoading(true);
+		setError(null);
+		try {
+			// The API caps pageSize at 100 and this screen has no pagination UI, so
+			// page through everything — otherwise customers past the first 100 would
+			// vanish from the list with no way to view or edit them.
+			const all: Customer[] = [];
+			let page = 1;
+			let hasNext = true;
+			while (hasNext) {
+				const { data, meta } = await client.listCustomers(session.token, { page, pageSize: 100 });
+				all.push(...data);
+				hasNext = meta.hasNextPage;
+				page += 1;
+			}
+			setList(all);
+		} catch (caught) {
+			setError(caught instanceof ApiError ? caught.message : 'Could not load your customers.');
+		} finally {
+			setLoading(false);
+		}
+	}, [client, session]);
+
+	useEffect(() => {
+		load();
+	}, [load]);
+
+	function resetForm() {
+		setName('');
+		setEmail('');
+		setPhone('');
+		setArea('');
+		setChannel('phone');
+		setStatus('lead');
+		setLifetime('');
+		setBalance('');
+		setNotes('');
+		setFormError(null);
+	}
+
+	function openCreate() {
+		setEditing(null);
+		resetForm();
+		setFormOpen(true);
+	}
+
+	function openEdit(customer: Customer) {
+		setEditing(customer);
+		setName(customer.name);
+		setEmail(customer.email);
+		setPhone(customer.phone);
+		setArea(customer.area);
+		setChannel(customer.channel);
+		setStatus(customer.status);
+		setLifetime(centsToInput(customer.lifetimeValue));
+		setBalance(centsToInput(customer.balance));
+		setNotes(customer.notes);
+		setFormError(null);
+		setSelectedId(customer.id);
+		setFormOpen(true);
+	}
+
+	function closeForm() {
+		setFormOpen(false);
+		setFormError(null);
+	}
+
+	async function onSave() {
+		if (!session || saving) {
+			return;
+		}
+		const lifetimeValue = dollarsToCents(lifetime);
+		const balanceValue = dollarsToCents(balance);
+		if (lifetimeValue === null || balanceValue === null) {
+			setFormError('Enter a valid, non-negative amount for the money fields.');
+			return;
+		}
+		setFormError(null);
+		setSaving(true);
+		try {
+			const input = {
+				name: name.trim(),
+				email: email.trim(),
+				phone: phone.trim(),
+				area: area.trim(),
+				channel,
+				status,
+				lifetimeValue,
+				balance: balanceValue,
+				notes: notes.trim(),
+			};
+			const saved = editing
+				? await client.updateCustomer(session.token, editing.id, input)
+				: await client.createCustomer(session.token, input);
+			setSelectedId(saved.id);
+			closeForm();
+			await load();
+		} catch (caught) {
+			setFormError(caught instanceof Error ? caught.message : 'Could not save the customer.');
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	async function onDelete() {
+		if (!session || !editing || deleting) {
+			return;
+		}
+		setFormError(null);
+		setDeleting(true);
+		try {
+			await client.deleteCustomer(session.token, editing.id);
+			if (selectedId === editing.id) {
+				setSelectedId(null);
+			}
+			closeForm();
+			await load();
+		} catch (caught) {
+			setFormError(caught instanceof ApiError ? caught.message : 'Could not delete the customer.');
+		} finally {
+			setDeleting(false);
+		}
+	}
+
+	if (!session) {
+		return null;
+	}
+
+	const selected = list.find((customer) => customer.id === selectedId) ?? list[0] ?? null;
+	const countLabel = `${list.length} ${list.length === 1 ? 'contact' : 'contacts'}`;
 
 	return (
 		<View style={styles.row}>
@@ -40,120 +260,265 @@ export default function CustomersScreen() {
 				<View style={styles.head}>
 					<View>
 						<Txt style={styles.title}>Customers</Txt>
-						<Txt style={styles.subtitle}>1,284 contacts · synced with QuickBooks</Txt>
+						<Txt style={styles.subtitle}>{countLabel}</Txt>
 					</View>
-					<View style={styles.headActions}>
-						<View style={styles.syncChip}>
-							<Icon name="refresh-cw" size={15} color={colors.green} />
-							<Txt style={styles.syncTxt}>QuickBooks · synced 6m ago</Txt>
-						</View>
-						<GradientButton label="Add customer" icon="plus" />
-					</View>
+					<GradientButton label="Add customer" icon="plus" onPress={openCreate} />
 				</View>
 
-				<ScrollView horizontal showsHorizontalScrollIndicator={false}>
-					<View style={[styles.table, { width: tableWidth }]}>
-						<View style={styles.tableHead}>
-							<Txt style={[styles.th, { flex: COLS.customer }]}>Customer</Txt>
-							<Txt style={[styles.th, { flex: COLS.area }]}>Area</Txt>
-							<Txt style={[styles.th, { flex: COLS.channel }]}>Channel</Txt>
-							<Txt style={[styles.th, styles.right, { flex: COLS.lifetime }]}>Lifetime</Txt>
-							<Txt style={[styles.th, styles.right, { flex: COLS.balance }]}>Balance</Txt>
-							<Txt style={[styles.th, styles.right, { flex: COLS.status }]}>Status</Txt>
+				{formOpen ? (
+					<Card style={styles.form}>
+						<View style={styles.formHead}>
+							<Txt style={styles.formTitle}>{editing ? 'Edit customer' : 'New customer'}</Txt>
+							<Pressable onPress={closeForm} accessibilityRole="button">
+								<Icon name="x" size={18} color={colors.textMuted} />
+							</Pressable>
 						</View>
-						{customers.map((c, i) => {
-							const st = customerStatusStyle[c.status];
-							return (
-								<View key={c.name} style={[styles.tr, i === customers.length - 1 && styles.trLast]}>
-									<View style={[styles.cell, styles.customerCell, { flex: COLS.customer }]}>
-										<Avatar initials={c.initials} size={36} />
-										<Txt style={styles.customerName} numberOfLines={1}>
-											{c.name}
+						<TextField
+							label="Name"
+							value={name}
+							onChangeText={setName}
+							placeholder="Grace Kim"
+							autoCapitalize="words"
+						/>
+						<View style={styles.formRow}>
+							<View style={styles.formCol}>
+								<TextField
+									label="Email"
+									value={email}
+									onChangeText={setEmail}
+									placeholder="grace@example.com"
+									autoCapitalize="none"
+									keyboardType="email-address"
+								/>
+							</View>
+							<View style={styles.formCol}>
+								<TextField
+									label="Phone"
+									value={phone}
+									onChangeText={setPhone}
+									placeholder="(206) 555-0155"
+									keyboardType="phone-pad"
+								/>
+							</View>
+						</View>
+						<TextField
+							label="Area"
+							value={area}
+							onChangeText={setArea}
+							placeholder="Fremont"
+							autoCapitalize="words"
+						/>
+						<View style={styles.fieldWrap}>
+							<Txt style={styles.fieldLabel}>Channel</Txt>
+							<Segmented options={CHANNEL_OPTIONS} value={channel} onChange={setChannel} />
+						</View>
+						<View style={styles.fieldWrap}>
+							<Txt style={styles.fieldLabel}>Status</Txt>
+							<Segmented options={STATUS_OPTIONS} value={status} onChange={setStatus} />
+						</View>
+						<View style={styles.formRow}>
+							<View style={styles.formCol}>
+								<TextField
+									label="Lifetime value ($)"
+									value={lifetime}
+									onChangeText={setLifetime}
+									placeholder="0.00"
+									keyboardType="decimal-pad"
+								/>
+							</View>
+							<View style={styles.formCol}>
+								<TextField
+									label="Balance ($)"
+									value={balance}
+									onChangeText={setBalance}
+									placeholder="0.00"
+									keyboardType="decimal-pad"
+								/>
+							</View>
+						</View>
+						<TextField
+							label="Notes"
+							value={notes}
+							onChangeText={setNotes}
+							placeholder="Repeat client · membership"
+							multiline
+							style={styles.notesInput}
+						/>
+
+						{formError ? <Txt style={styles.errorTxt}>{formError}</Txt> : null}
+
+						<View style={styles.btnRow}>
+							<GradientButton
+								label={saving ? 'Saving…' : editing ? 'Save changes' : 'Add customer'}
+								icon="check"
+								onPress={onSave}
+								style={styles.btnGrow}
+							/>
+							<OutlineButton label="Cancel" onPress={closeForm} style={styles.btnGrow} />
+						</View>
+						{editing ? (
+							<OutlineButton
+								label={deleting ? 'Deleting…' : 'Delete customer'}
+								onPress={onDelete}
+								style={styles.deleteBtn}
+							/>
+						) : null}
+					</Card>
+				) : null}
+
+				{loading ? (
+					<ActivityIndicator color={colors.brandPurple} style={styles.loading} />
+				) : error ? (
+					<Txt style={styles.errorTxt}>{error}</Txt>
+				) : list.length === 0 ? (
+					<Txt style={styles.empty}>
+						No customers yet. Add your first contact to start tracking jobs and balances.
+					</Txt>
+				) : (
+					<ScrollView horizontal showsHorizontalScrollIndicator={false}>
+						<View style={[styles.table, { width: tableWidth }]}>
+							<View style={styles.tableHead}>
+								<Txt style={[styles.th, { flex: COLS.customer }]}>Customer</Txt>
+								<Txt style={[styles.th, { flex: COLS.area }]}>Area</Txt>
+								<Txt style={[styles.th, { flex: COLS.channel }]}>Channel</Txt>
+								<Txt style={[styles.th, styles.right, { flex: COLS.lifetime }]}>Lifetime</Txt>
+								<Txt style={[styles.th, styles.right, { flex: COLS.balance }]}>Balance</Txt>
+								<Txt style={[styles.th, styles.right, { flex: COLS.status }]}>Status</Txt>
+								<View style={styles.editCol} />
+							</View>
+							{list.map((customer, index) => {
+								const st = STATUS_STYLE[customer.status];
+								const isSelected = customer.id === selected?.id;
+								return (
+									<Pressable
+										key={customer.id}
+										onPress={() => setSelectedId(customer.id)}
+										style={[
+											styles.tr,
+											index === list.length - 1 && styles.trLast,
+											isSelected && styles.trSelected,
+										]}
+									>
+										<View style={[styles.cell, styles.customerCell, { flex: COLS.customer }]}>
+											<Avatar initials={initialsOf(customer.name)} size={36} />
+											<Txt style={styles.customerName} numberOfLines={1}>
+												{customer.name}
+											</Txt>
+										</View>
+										<Txt style={[styles.td, { flex: COLS.area }]} numberOfLines={1}>
+											{customer.area || '—'}
 										</Txt>
-									</View>
-									<Txt style={[styles.td, { flex: COLS.area }]}>{c.area}</Txt>
-									<Txt style={[styles.td, { flex: COLS.channel }]}>{c.channel}</Txt>
-									<Txt style={[styles.td, styles.right, styles.tdMed, { flex: COLS.lifetime }]}>
-										{c.ltv}
-									</Txt>
-									<Txt style={[styles.td, styles.right, styles.tdBold, { flex: COLS.balance }]}>
-										{c.balance}
-									</Txt>
-									<View style={[styles.cell, styles.statusCell, { flex: COLS.status }]}>
-										<Pill label={st.label} color={st.color} background={st.background} />
-									</View>
-								</View>
-							);
-						})}
-					</View>
-				</ScrollView>
+										<Txt style={[styles.td, { flex: COLS.channel }]}>
+											{CHANNEL_LABEL[customer.channel]}
+										</Txt>
+										<Txt style={[styles.td, styles.right, styles.tdMed, { flex: COLS.lifetime }]}>
+											{formatMoney(customer.lifetimeValue)}
+										</Txt>
+										<Txt style={[styles.td, styles.right, styles.tdBold, { flex: COLS.balance }]}>
+											{formatMoney(customer.balance)}
+										</Txt>
+										<View style={[styles.cell, styles.statusCell, { flex: COLS.status }]}>
+											<Pill label={st.label} color={st.color} background={st.background} />
+										</View>
+										<Pressable
+											style={styles.editCol}
+											onPress={() => openEdit(customer)}
+											accessibilityRole="button"
+										>
+											<Icon name="edit-3" size={16} color={colors.textFaint} />
+										</Pressable>
+									</Pressable>
+								);
+							})}
+						</View>
+					</ScrollView>
+				)}
 			</ScrollView>
 
-			{showPanel ? <AccountPanel /> : null}
+			{showPanel && selected ? (
+				<AccountPanel customer={selected} onEdit={() => openEdit(selected)} />
+			) : null}
 		</View>
 	);
 }
 
-function AccountPanel() {
+function ContactRow({
+	icon,
+	label,
+	value,
+}: {
+	icon: ComponentProps<typeof Icon>['name'];
+	label: string;
+	value: string;
+}) {
+	return (
+		<View style={styles.contactRow}>
+			<Icon name={icon} size={15} color={colors.textMuted} />
+			<View style={{ flex: 1 }}>
+				<Txt style={styles.contactLabel}>{label}</Txt>
+				<Txt style={styles.contactValue}>{value}</Txt>
+			</View>
+		</View>
+	);
+}
+
+function AccountPanel({ customer, onEdit }: { customer: Customer; onEdit: () => void }) {
+	const st = STATUS_STYLE[customer.status];
+	const since = new Date(customer.createdAt).getFullYear();
 	return (
 		<ScrollView style={styles.panel} contentContainerStyle={styles.panelPad}>
 			<SectionLabel style={{ marginBottom: 14 }}>Account</SectionLabel>
 			<View style={styles.acctHead}>
-				<Avatar initials="PA" size={50} />
+				<Avatar initials={initialsOf(customer.name)} size={50} />
 				<View style={{ flex: 1 }}>
-					<Txt style={styles.acctName}>Priya Anand</Txt>
-					<Txt style={styles.acctSub}>Capitol Hill · Customer since 2020</Txt>
+					<Txt style={styles.acctName}>{customer.name}</Txt>
+					<Txt style={styles.acctSub}>
+						{customer.area ? `${customer.area} · ` : ''}Customer since {since}
+					</Txt>
 				</View>
+			</View>
+
+			<View style={styles.pillRow}>
+				<Pill label={st.label} color={st.color} background={st.background} />
 			</View>
 
 			<View style={styles.billCard}>
-				<View style={styles.qbHead}>
-					<Icon name="credit-card" size={16} color={colors.green} />
-					<Txt style={styles.qbTitle}>Billing · QuickBooks</Txt>
-				</View>
 				<View style={styles.balanceRow}>
 					<Txt style={styles.muted}>Balance due</Txt>
-					<Txt style={styles.balanceAmt}>$540.00</Txt>
+					<Txt
+						style={[
+							styles.balanceAmt,
+							{ color: customer.balance > 0 ? colors.redInk : colors.green },
+						]}
+					>
+						{formatMoney(customer.balance)}
+					</Txt>
 				</View>
-				<View style={styles.invoiceList}>
-					{invoices.map((inv) => (
-						<View key={inv.title} style={styles.invoiceRow}>
-							<View style={{ flex: 1 }}>
-								<Txt style={styles.invoiceTitle}>{inv.title}</Txt>
-								<Txt style={styles.invoiceMeta}>{inv.meta}</Txt>
-							</View>
-							<Pill
-								label={inv.tag}
-								color={inv.paid ? colors.green : colors.redInk}
-								background={inv.paid ? 'rgba(31,181,115,0.12)' : 'rgba(240,88,75,0.12)'}
-							/>
-						</View>
-					))}
+				<View style={styles.ltvRow}>
+					<Txt style={styles.muted}>Lifetime value</Txt>
+					<Txt style={styles.ltvAmt}>{formatMoney(customer.lifetimeValue)}</Txt>
 				</View>
 			</View>
 
-			<View style={styles.rivusNote}>
-				<BrandGradient style={styles.rivusNoteMark}>
-					<RivusSymbol size={16} />
-				</BrandGradient>
-				<Txt style={styles.rivusNoteTxt}>
-					Rivus answers Priya's billing &amp; account questions automatically — payment links,
-					invoice copies, and balance lookups, straight from QuickBooks.
-				</Txt>
+			<SectionLabel style={{ marginTop: 8, marginBottom: 12 }}>Contact</SectionLabel>
+			<View style={{ gap: 12 }}>
+				<ContactRow
+					icon="message-circle"
+					label="Preferred channel"
+					value={CHANNEL_LABEL[customer.channel]}
+				/>
+				{customer.email ? <ContactRow icon="mail" label="Email" value={customer.email} /> : null}
+				{customer.phone ? <ContactRow icon="phone" label="Phone" value={customer.phone} /> : null}
 			</View>
 
-			<SectionLabel style={{ marginTop: 22, marginBottom: 12 }}>Recent activity</SectionLabel>
-			<View style={{ gap: 13 }}>
-				{recent.map((r) => (
-					<View key={r.title} style={styles.activityRow}>
-						<View style={[styles.activityDot, { backgroundColor: r.color }]} />
-						<View>
-							<Txt style={styles.activityTitle}>{r.title}</Txt>
-							<Txt style={styles.invoiceMeta}>{r.time}</Txt>
-						</View>
-					</View>
-				))}
-			</View>
+			{customer.notes ? (
+				<>
+					<SectionLabel style={{ marginTop: 22, marginBottom: 10 }}>Notes</SectionLabel>
+					<Txt style={styles.notesTxt}>{customer.notes}</Txt>
+				</>
+			) : null}
+
+			<OutlineButton label="Edit customer" onPress={onEdit} style={styles.panelEdit} />
 		</ScrollView>
 	);
 }
@@ -171,19 +536,26 @@ const styles = StyleSheet.create({
 	},
 	title: { fontFamily: font.semibold, fontSize: 20 },
 	subtitle: { fontFamily: font.regular, fontSize: 13, color: colors.textMuted, marginTop: 3 },
-	headActions: { flexDirection: 'row', alignItems: 'center', gap: 10, flexWrap: 'wrap' },
-	syncChip: {
+
+	// Form
+	form: { gap: 14, marginBottom: 22 },
+	formHead: {
 		flexDirection: 'row',
 		alignItems: 'center',
-		gap: 8,
-		borderWidth: 1,
-		borderColor: colors.borderField,
-		backgroundColor: colors.surface,
-		borderRadius: 9,
-		paddingVertical: 8,
-		paddingHorizontal: 12,
+		justifyContent: 'space-between',
 	},
-	syncTxt: { fontFamily: font.regular, fontSize: 12.5, color: colors.textSub },
+	formTitle: { fontFamily: font.semibold, fontSize: 15, color: colors.text },
+	formRow: { flexDirection: 'row', gap: 12, flexWrap: 'wrap' },
+	formCol: { flexGrow: 1, flexBasis: 180 },
+	fieldWrap: { gap: 6 },
+	fieldLabel: { fontFamily: font.semibold, fontSize: 12.5, color: colors.textSub },
+	notesInput: { minHeight: 80, textAlignVertical: 'top' },
+	btnRow: { flexDirection: 'row', gap: 10, flexWrap: 'wrap' },
+	btnGrow: { flexGrow: 1, flexBasis: 140 },
+	deleteBtn: { borderColor: 'rgba(240,88,75,0.4)' },
+
+	loading: { paddingVertical: 24 },
+	empty: { fontFamily: font.regular, fontSize: 13, color: colors.textMuted, paddingVertical: 16 },
 
 	table: {
 		backgroundColor: colors.surface,
@@ -194,6 +566,7 @@ const styles = StyleSheet.create({
 	},
 	tableHead: {
 		flexDirection: 'row',
+		alignItems: 'center',
 		paddingVertical: 13,
 		paddingHorizontal: 18,
 		borderBottomWidth: 1,
@@ -217,6 +590,7 @@ const styles = StyleSheet.create({
 		borderBottomColor: colors.borderRow,
 	},
 	trLast: { borderBottomWidth: 0 },
+	trSelected: { backgroundColor: 'rgba(110,30,200,0.05)' },
 	cell: { flexDirection: 'row', alignItems: 'center' },
 	customerCell: { gap: 12 },
 	customerName: { fontFamily: font.medium, fontSize: 13.5, flex: 1 },
@@ -224,6 +598,7 @@ const styles = StyleSheet.create({
 	tdMed: { fontFamily: font.medium, color: colors.text },
 	tdBold: { fontFamily: font.semibold, color: colors.text },
 	statusCell: { justifyContent: 'flex-end' },
+	editCol: { width: 30, alignItems: 'flex-end' },
 
 	// Panel
 	panel: {
@@ -235,9 +610,10 @@ const styles = StyleSheet.create({
 		backgroundColor: colors.surfaceAlt,
 	},
 	panelPad: { paddingVertical: 24, paddingHorizontal: 22 },
-	acctHead: { flexDirection: 'row', alignItems: 'center', gap: 13, marginBottom: 18 },
+	acctHead: { flexDirection: 'row', alignItems: 'center', gap: 13, marginBottom: 14 },
 	acctName: { fontFamily: font.semibold, fontSize: 16 },
 	acctSub: { fontFamily: font.regular, fontSize: 12.5, color: colors.textMuted },
+	pillRow: { marginBottom: 14 },
 	billCard: {
 		backgroundColor: colors.surface,
 		borderWidth: 1,
@@ -245,50 +621,24 @@ const styles = StyleSheet.create({
 		borderRadius: radii.xl,
 		padding: 16,
 		marginBottom: 14,
+		gap: 12,
 	},
-	qbHead: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 13 },
-	qbTitle: { fontFamily: font.semibold, fontSize: 13 },
 	muted: { fontFamily: font.regular, fontSize: 12.5, color: colors.textMuted },
-	balanceRow: {
+	balanceRow: { flexDirection: 'row', alignItems: 'baseline', justifyContent: 'space-between' },
+	balanceAmt: { fontFamily: font.semibold, fontSize: 22 },
+	ltvRow: {
 		flexDirection: 'row',
 		alignItems: 'baseline',
 		justifyContent: 'space-between',
-		marginBottom: 14,
+		borderTopWidth: 1,
+		borderTopColor: '#f0f1f5',
+		paddingTop: 12,
 	},
-	balanceAmt: { fontFamily: font.semibold, fontSize: 22, color: colors.redInk },
-	invoiceList: { borderTopWidth: 1, borderTopColor: '#f0f1f5', paddingTop: 13, gap: 9 },
-	invoiceRow: {
-		flexDirection: 'row',
-		justifyContent: 'space-between',
-		alignItems: 'center',
-		gap: 10,
-	},
-	invoiceTitle: { fontFamily: font.medium, fontSize: 12.5 },
-	invoiceMeta: { fontFamily: font.regular, fontSize: 11, color: colors.textFaint, marginTop: 2 },
-	rivusNote: {
-		flexDirection: 'row',
-		gap: 11,
-		backgroundColor: 'rgba(110,30,200,0.05)',
-		borderWidth: 1,
-		borderColor: 'rgba(110,30,200,0.14)',
-		borderRadius: radii.xl,
-		padding: 14,
-	},
-	rivusNoteMark: {
-		width: 26,
-		height: 26,
-		borderRadius: 7,
-		alignItems: 'center',
-		justifyContent: 'center',
-	},
-	rivusNoteTxt: {
-		flex: 1,
-		fontFamily: font.regular,
-		fontSize: 12,
-		color: '#4a3b60',
-		lineHeight: 18,
-	},
-	activityRow: { flexDirection: 'row', gap: 11 },
-	activityDot: { width: 8, height: 8, borderRadius: 4, marginTop: 5 },
-	activityTitle: { fontFamily: font.regular, fontSize: 12.5 },
+	ltvAmt: { fontFamily: font.semibold, fontSize: 15, color: colors.text },
+	contactRow: { flexDirection: 'row', alignItems: 'center', gap: 11 },
+	contactLabel: { fontFamily: font.regular, fontSize: 11, color: colors.textFaint },
+	contactValue: { fontFamily: font.medium, fontSize: 13, color: colors.text, marginTop: 1 },
+	notesTxt: { fontFamily: font.regular, fontSize: 12.5, color: colors.textSub, lineHeight: 19 },
+	panelEdit: { marginTop: 22 },
+	errorTxt: { fontFamily: font.medium, fontSize: 12.5, color: colors.redInk },
 });

--- a/packages/app/app/customers.tsx
+++ b/packages/app/app/customers.tsx
@@ -75,11 +75,14 @@ function dollarsToCents(text: string): number | null {
 	if (trimmed === '') {
 		return 0;
 	}
-	const value = Number(trimmed.replace(/[$,\s]/g, ''));
-	if (!Number.isFinite(value) || value < 0) {
+	// Accept digits with optional thousands separators and up to two decimals
+	// (e.g. "1,234.56"); reject anything else so stray formatting like "$" isn't
+	// coerced to 0 and "12.999" isn't silently rounded into a different amount.
+	const cleaned = trimmed.replace(/[$,]/g, '');
+	if (!/^\d+(\.\d{1,2})?$/.test(cleaned)) {
 		return null;
 	}
-	return Math.round(value * 100);
+	return Math.round(Number(cleaned) * 100);
 }
 
 /** Pre-fill the dollar input when editing (0 shows blank so the placeholder shows). */
@@ -119,35 +122,53 @@ export default function CustomersScreen() {
 	const [saving, setSaving] = useState(false);
 	const [deleting, setDeleting] = useState(false);
 
-	const load = useCallback(async () => {
-		if (!session) {
-			return;
-		}
-		setLoading(true);
-		setError(null);
-		try {
-			// The API caps pageSize at 100 and this screen has no pagination UI, so
-			// page through everything — otherwise customers past the first 100 would
-			// vanish from the list with no way to view or edit them.
-			const all: Customer[] = [];
-			let page = 1;
-			let hasNext = true;
-			while (hasNext) {
-				const { data, meta } = await client.listCustomers(session.token, { page, pageSize: 100 });
-				all.push(...data);
-				hasNext = meta.hasNextPage;
-				page += 1;
+	const load = useCallback(
+		async (isActive: () => boolean = () => true) => {
+			if (!session) {
+				return;
 			}
-			setList(all);
-		} catch (caught) {
-			setError(caught instanceof ApiError ? caught.message : 'Could not load your customers.');
-		} finally {
-			setLoading(false);
-		}
-	}, [client, session]);
+			setLoading(true);
+			setError(null);
+			try {
+				// The API caps pageSize at 100 and this screen has no pagination UI, so
+				// page through everything — otherwise customers past the first 100 would
+				// vanish from the list with no way to view or edit them. MAX_PAGES is a
+				// backstop against an API that returns hasNextPage forever (far more than
+				// this un-virtualized list will ever render).
+				const all: Customer[] = [];
+				const MAX_PAGES = 100;
+				let page = 1;
+				let hasNext = true;
+				while (hasNext && page <= MAX_PAGES) {
+					const { data, meta } = await client.listCustomers(session.token, { page, pageSize: 100 });
+					all.push(...data);
+					hasNext = meta.hasNextPage;
+					page += 1;
+				}
+				// Ignore the result if the session/account changed mid-load (e.g. a staff
+				// company switch) so we never paint one account's customers over another's.
+				if (isActive()) {
+					setList(all);
+				}
+			} catch (caught) {
+				if (isActive()) {
+					setError(caught instanceof ApiError ? caught.message : 'Could not load your customers.');
+				}
+			} finally {
+				if (isActive()) {
+					setLoading(false);
+				}
+			}
+		},
+		[client, session],
+	);
 
 	useEffect(() => {
-		load();
+		let active = true;
+		load(() => active);
+		return () => {
+			active = false;
+		};
 	}, [load]);
 
 	function resetForm() {

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import type { AccountId, FaqId } from '@rivus/core';
+import type { AccountId, CustomerId, FaqId } from '@rivus/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError, createApiClient, ValidationError } from './client';
 
@@ -73,6 +73,25 @@ function makeFaq() {
 		answer: faker.lorem.paragraph(),
 		category: faker.helpers.arrayElement(['Pricing', 'Scheduling', '']),
 		status: 'published' as const,
+		createdAt: now,
+		updatedAt: now,
+	};
+}
+
+function makeCustomer() {
+	const now = new Date().toISOString();
+	return {
+		id: faker.string.uuid(),
+		accountId: faker.string.uuid(),
+		name: faker.person.fullName(),
+		email: faker.internet.email().toLowerCase(),
+		phone: faker.phone.number(),
+		area: faker.location.city(),
+		channel: faker.helpers.arrayElement(['whatsapp', 'phone', 'email', 'sms'] as const),
+		status: faker.helpers.arrayElement(['lead', 'quote', 'paid', 'due'] as const),
+		lifetimeValue: faker.number.int({ min: 0, max: 1_000_000 }),
+		balance: faker.number.int({ min: 0, max: 100_000 }),
+		notes: faker.lorem.sentence(),
 		createdAt: now,
 		updatedAt: now,
 	};
@@ -688,6 +707,192 @@ describe('createApiClient', () => {
 
 			const client = createApiClient(BASE, fetchMock);
 			const error = await client.deleteFaq('tok', 'missing' as never).catch((e) => e);
+			expect(error).toBeInstanceOf(ApiError);
+			expect(error.status).toBe(404);
+		});
+	});
+
+	describe('listCustomers', () => {
+		it('returns parsed customers and sends the bearer auth header', async () => {
+			const customers = [makeCustomer(), makeCustomer()];
+			const response = {
+				data: customers,
+				meta: {
+					page: 1,
+					pageSize: 20,
+					total: customers.length,
+					totalPages: 1,
+					hasNextPage: false,
+					hasPreviousPage: false,
+				},
+			};
+			fetchMock.mockResolvedValueOnce(jsonResponse(response));
+
+			const client = createApiClient(BASE, fetchMock);
+			const token = faker.string.alphanumeric(32);
+			const result = await client.listCustomers(token);
+
+			expect(result.data).toEqual(customers);
+			expect(result.meta.total).toBe(customers.length);
+
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/customers?page=1&pageSize=20`);
+			expect(init.headers).toMatchObject({ Authorization: `Bearer ${token}` });
+		});
+
+		it('forwards custom pagination query params', async () => {
+			const response = {
+				data: [],
+				meta: {
+					page: 2,
+					pageSize: 100,
+					total: 0,
+					totalPages: 0,
+					hasNextPage: false,
+					hasPreviousPage: false,
+				},
+			};
+			fetchMock.mockResolvedValueOnce(jsonResponse(response));
+
+			const client = createApiClient(BASE, fetchMock);
+			await client.listCustomers('token', { page: 2, pageSize: 100 });
+
+			const [url] = fetchMock.mock.calls[0] as [string];
+			expect(url).toBe(`${BASE}/v1/customers?page=2&pageSize=100`);
+		});
+	});
+
+	describe('createCustomer', () => {
+		it('posts a customer with the bearer token and returns it', async () => {
+			const customer = makeCustomer();
+			fetchMock.mockResolvedValueOnce(jsonResponse(customer, { status: 201 }));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.createCustomer('owner-token', {
+				name: customer.name,
+				email: customer.email,
+				channel: customer.channel,
+				status: customer.status,
+				lifetimeValue: customer.lifetimeValue,
+				balance: customer.balance,
+			});
+
+			expect(result).toEqual(customer);
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/customers`);
+			expect(init.method).toBe('POST');
+			expect(init.headers).toMatchObject({
+				Authorization: 'Bearer owner-token',
+				'Content-Type': 'application/json',
+			});
+			expect(JSON.parse(init.body as string)).toMatchObject({ name: customer.name });
+		});
+
+		it('accepts just a name, filling every other default', async () => {
+			const customer = makeCustomer();
+			fetchMock.mockResolvedValueOnce(jsonResponse(customer, { status: 201 }));
+
+			const client = createApiClient(BASE, fetchMock);
+			// Only `name` is supplied — the schema defaults the rest, so the client must
+			// not require them at the type level and must send the defaulted values.
+			await client.createCustomer('tok', { name: 'Grace Kim' });
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(JSON.parse(init.body as string)).toMatchObject({
+				name: 'Grace Kim',
+				email: '',
+				phone: '',
+				area: '',
+				channel: 'phone',
+				status: 'lead',
+				lifetimeValue: 0,
+				balance: 0,
+				notes: '',
+			});
+		});
+
+		it('rejects a customer with no name before hitting the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.createCustomer('tok', { name: '' })).rejects.toThrow(ValidationError);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('rejects a negative balance before hitting the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.createCustomer('tok', { name: 'Bad', balance: -1 })).rejects.toThrow(
+				ValidationError,
+			);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('getCustomer', () => {
+		it('fetches a customer by id and url-encodes it', async () => {
+			const customer = makeCustomer();
+			fetchMock.mockResolvedValueOnce(jsonResponse(customer));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.getCustomer('tok', 'a/b c' as CustomerId);
+
+			expect(result).toEqual(customer);
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/customers/a%2Fb%20c`);
+			expect(init.method).toBe('GET');
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer tok' });
+		});
+	});
+
+	describe('updateCustomer', () => {
+		it('PATCHes the customer with the bearer token and returns it', async () => {
+			const customer = { ...makeCustomer(), status: 'paid' as const };
+			fetchMock.mockResolvedValueOnce(jsonResponse(customer));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.updateCustomer('owner-token', customer.id as CustomerId, {
+				status: 'paid',
+				balance: 0,
+			});
+
+			expect(result.status).toBe('paid');
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/customers/${customer.id}`);
+			expect(init.method).toBe('PATCH');
+			expect(JSON.parse(init.body as string)).toEqual({ status: 'paid', balance: 0 });
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer owner-token' });
+		});
+
+		it('rejects an empty update before hitting the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.updateCustomer('tok', 'id' as CustomerId, {})).rejects.toThrow();
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('deleteCustomer', () => {
+		it('DELETEs the customer with the bearer token and resolves on 204', async () => {
+			fetchMock.mockResolvedValueOnce(jsonResponse(undefined, { status: 204 }));
+
+			const client = createApiClient(BASE, fetchMock);
+			await expect(
+				client.deleteCustomer('owner-token', 'cust-1' as CustomerId),
+			).resolves.toBeUndefined();
+
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/customers/cust-1`);
+			expect(init.method).toBe('DELETE');
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer owner-token' });
+		});
+
+		it('throws an ApiError when the customer is gone (404)', async () => {
+			fetchMock.mockResolvedValueOnce(
+				jsonResponse(
+					{ error: 'Not Found', message: 'Customer not found', statusCode: 404 },
+					{ status: 404 },
+				),
+			);
+
+			const client = createApiClient(BASE, fetchMock);
+			const error = await client.deleteCustomer('tok', 'missing' as CustomerId).catch((e) => e);
 			expect(error).toBeInstanceOf(ApiError);
 			expect(error.status).toBe(404);
 		});

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -4,7 +4,12 @@ import {
 	type AccountId,
 	acceptInviteSchema,
 	accountStatusSchema,
+	type Customer,
+	type CustomerId,
+	createCustomerSchema,
 	createFaqSchema,
+	customerChannelSchema,
+	customerStatusSchema,
 	type Faq,
 	type FaqId,
 	faqSimilarityQuerySchema,
@@ -23,10 +28,12 @@ import {
 	roleSchema,
 	signupSchema,
 	type UpdateAccountInput,
+	type UpdateCustomerInput,
 	type UpdateFaqInput,
 	type User,
 	type UserId,
 	updateAccountSchema,
+	updateCustomerSchema,
 	updateFaqSchema,
 	type VerifyCodeInput,
 	verifyCodeSchema,
@@ -43,11 +50,18 @@ export type SignupBody = z.input<typeof signupSchema>;
  */
 export type CreateFaqBody = z.input<typeof createFaqSchema>;
 
+/**
+ * createCustomer accepts the schema's *input*: every field except `name` has a
+ * schema default the API fills, so callers may pass just `{ name }`.
+ */
+export type CreateCustomerBody = z.input<typeof createCustomerSchema>;
+
 // `@rivus/core` brands its ids so a user id can't be passed where an item id is
 // expected. The wire format is a plain string; these helpers validate as strings
 // while preserving the brand in the inferred type.
 const itemId = () => z.string().min(1) as unknown as z.ZodType<ItemId>;
 const faqId = () => z.string().min(1) as unknown as z.ZodType<FaqId>;
+const customerId = () => z.string().min(1) as unknown as z.ZodType<CustomerId>;
 const accountId = () => z.string().min(1) as unknown as z.ZodType<AccountId>;
 const userId = () => z.string().min(1) as unknown as z.ZodType<UserId>;
 
@@ -246,6 +260,32 @@ export interface FaqListResponse {
 	meta: PaginationMeta;
 }
 
+const customerResponseSchema = z.object({
+	id: customerId(),
+	accountId: accountId(),
+	name: z.string(),
+	email: z.string(),
+	phone: z.string(),
+	area: z.string(),
+	channel: customerChannelSchema,
+	status: customerStatusSchema,
+	lifetimeValue: z.number().int(),
+	balance: z.number().int(),
+	notes: z.string(),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+}) satisfies z.ZodType<Customer>;
+
+const customerListResponseSchema = z.object({
+	data: z.array(customerResponseSchema),
+	meta: paginationMetaSchema,
+});
+
+export interface CustomerListResponse {
+	data: Customer[];
+	meta: PaginationMeta;
+}
+
 const faqSimilarityResponseSchema = z.object({
 	match: faqResponseSchema.nullable(),
 	reason: z.string(),
@@ -340,6 +380,16 @@ export interface RivusApiClient {
 	updateFaq(token: string, id: FaqId, input: UpdateFaqInput): Promise<Faq>;
 	/** Delete one of the account's FAQs. */
 	deleteFaq(token: string, id: FaqId): Promise<void>;
+	/** List the account's customers (CRM contacts). */
+	listCustomers(token: string, query?: Partial<PaginationQuery>): Promise<CustomerListResponse>;
+	/** Create a customer for the account. */
+	createCustomer(token: string, input: CreateCustomerBody): Promise<Customer>;
+	/** Fetch one of the account's customers. */
+	getCustomer(token: string, id: CustomerId): Promise<Customer>;
+	/** Update one of the account's customers. */
+	updateCustomer(token: string, id: CustomerId, input: UpdateCustomerInput): Promise<Customer>;
+	/** Delete one of the account's customers. */
+	deleteCustomer(token: string, id: CustomerId): Promise<void>;
 	/**
 	 * List/search every company, for the staff company switcher. Restricted to Rivus
 	 * staff server-side (a regular customer gets 403).
@@ -539,6 +589,46 @@ export function createApiClient(
 			});
 		},
 
+		async listCustomers(token: string, query?: Partial<PaginationQuery>) {
+			const { page, pageSize } = parseInput(paginationQuerySchema, query ?? {});
+			const search = new URLSearchParams({
+				page: String(page),
+				pageSize: String(pageSize),
+			});
+			return request(`/v1/customers?${search.toString()}`, customerListResponseSchema, {
+				method: 'GET',
+				headers: authHeaders(token),
+			});
+		},
+
+		async createCustomer(token: string, input: CreateCustomerBody) {
+			const payload = parseInput(createCustomerSchema, input);
+			return request('/v1/customers', customerResponseSchema, jsonInit('POST', payload, token));
+		},
+
+		getCustomer(token: string, id: CustomerId) {
+			return request(`/v1/customers/${encodeURIComponent(id)}`, customerResponseSchema, {
+				method: 'GET',
+				headers: authHeaders(token),
+			});
+		},
+
+		async updateCustomer(token: string, id: CustomerId, input: UpdateCustomerInput) {
+			const payload = parseInput(updateCustomerSchema, input);
+			return request(
+				`/v1/customers/${encodeURIComponent(id)}`,
+				customerResponseSchema,
+				jsonInit('PATCH', payload, token),
+			);
+		},
+
+		async deleteCustomer(token: string, id: CustomerId) {
+			await request(`/v1/customers/${encodeURIComponent(id)}`, noContentSchema, {
+				method: 'DELETE',
+				headers: authHeaders(token),
+			});
+		},
+
 		async listCompanies(token: string, query?: CompanyListQuery) {
 			const { page, pageSize } = parseInput(paginationQuerySchema, {
 				page: query?.page,
@@ -573,4 +663,4 @@ function safeJsonParse(raw: string): unknown {
 	}
 }
 
-export type { Account, Faq, Item, PaginationMeta, Role, User };
+export type { Account, Customer, Faq, Item, PaginationMeta, Role, User };

--- a/packages/app/src/data/demo.ts
+++ b/packages/app/src/data/demo.ts
@@ -1,8 +1,6 @@
 // Demo content for the Rivus dashboard, lifted verbatim from the Rivus.dc.html
 // design so the UI is fully populated without a backend. Pure data — no imports.
 
-import { colors } from '../theme/tokens';
-
 export type Channel = 'WhatsApp' | 'Phone' | 'Email' | 'SMS';
 
 export const channelColor: Record<Channel, string> = {
@@ -188,111 +186,6 @@ export const threads: Thread[] = [
 		],
 	},
 ];
-
-export type CustomerStatus = 'paid' | 'due' | 'quote' | 'lead';
-export type Customer = {
-	name: string;
-	initials: string;
-	area: string;
-	channel: Channel;
-	ltv: string;
-	balance: string;
-	last: string;
-	status: CustomerStatus;
-};
-
-export const customers: Customer[] = [
-	{
-		name: 'Grace Kim',
-		initials: 'GK',
-		area: 'Fremont',
-		channel: 'WhatsApp',
-		ltv: '$7,140',
-		balance: '$0.00',
-		last: 'Yesterday',
-		status: 'paid',
-	},
-	{
-		name: 'Priya Anand',
-		initials: 'PA',
-		area: 'Capitol Hill',
-		channel: 'Email',
-		ltv: '$5,260',
-		balance: '$540.00',
-		last: 'Today',
-		status: 'due',
-	},
-	{
-		name: 'Dana Whitfield',
-		initials: 'DW',
-		area: 'Ballard',
-		channel: 'WhatsApp',
-		ltv: '$3,480',
-		balance: '$0.00',
-		last: 'Today',
-		status: 'paid',
-	},
-	{
-		name: 'Robert Vance',
-		initials: 'RV',
-		area: 'Magnolia',
-		channel: 'Phone',
-		ltv: '$2,910',
-		balance: '$0.00',
-		last: '2 days ago',
-		status: 'quote',
-	},
-	{
-		name: 'Hari Patel',
-		initials: 'HP',
-		area: 'Greenwood',
-		channel: 'SMS',
-		ltv: '$1,820',
-		balance: '$210.00',
-		last: '3 days ago',
-		status: 'due',
-	},
-	{
-		name: 'Theo Marsh',
-		initials: 'TM',
-		area: 'Queen Anne',
-		channel: 'Phone',
-		ltv: '$910',
-		balance: '$0.00',
-		last: 'Today',
-		status: 'paid',
-	},
-	{
-		name: 'Maya Flores',
-		initials: 'MF',
-		area: 'Bellevue',
-		channel: 'Email',
-		ltv: '$640',
-		balance: '$0.00',
-		last: '1 week ago',
-		status: 'paid',
-	},
-	{
-		name: 'Luis Romero',
-		initials: 'LR',
-		area: 'Bellevue',
-		channel: 'SMS',
-		ltv: '—',
-		balance: '$0.00',
-		last: 'Yesterday',
-		status: 'lead',
-	},
-];
-
-export const customerStatusStyle: Record<
-	CustomerStatus,
-	{ label: string; color: string; background: string }
-> = {
-	paid: { label: 'Paid up', color: colors.green, background: 'rgba(31,181,115,0.12)' },
-	due: { label: 'Balance due', color: colors.redInk, background: 'rgba(240,88,75,0.12)' },
-	quote: { label: 'Quote pending', color: colors.amberInk, background: 'rgba(240,160,32,0.14)' },
-	lead: { label: 'New lead', color: colors.brandPurple, background: 'rgba(110,30,200,0.10)' },
-};
 
 export type Faq = { cat: string; q: string; a: string; uses: string };
 

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -4,6 +4,7 @@ import {
 	acceptInviteSchema,
 	accountBusinessSchema,
 	accountStatusSchema,
+	createCustomerSchema,
 	createFaqSchema,
 	createItemSchema,
 	inviteMemberSchema,
@@ -11,6 +12,7 @@ import {
 	paginationQuerySchema,
 	signupSchema,
 	updateAccountSchema,
+	updateCustomerSchema,
 	updateFaqSchema,
 	updateItemSchema,
 	updateMemberRoleSchema,
@@ -253,6 +255,75 @@ describe('updateFaqSchema', () => {
 
 	it('rejects an empty update', () => {
 		expect(() => updateFaqSchema.parse({})).toThrow();
+	});
+});
+
+describe('createCustomerSchema', () => {
+	it('applies defaults for every optional field', () => {
+		expect(createCustomerSchema.parse({ name: 'Grace Kim' })).toEqual({
+			name: 'Grace Kim',
+			email: '',
+			phone: '',
+			area: '',
+			channel: 'phone',
+			status: 'lead',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+	});
+
+	it('accepts and normalizes a fully specified record', () => {
+		const parsed = createCustomerSchema.parse({
+			name: 'Priya Anand',
+			email: '  Priya@Example.COM ',
+			phone: '(206) 555-0119',
+			area: 'Capitol Hill',
+			channel: 'email',
+			status: 'due',
+			lifetimeValue: 526_000,
+			balance: 54_000,
+			notes: 'Billing flag',
+		});
+		expect(parsed.email).toBe('priya@example.com');
+		expect(parsed).toMatchObject({ channel: 'email', status: 'due', balance: 54_000 });
+	});
+
+	it('rejects an unknown channel', () => {
+		expect(() => createCustomerSchema.parse({ name: 'X', channel: 'telegram' })).toThrow();
+	});
+
+	it('rejects an unknown status', () => {
+		expect(() => createCustomerSchema.parse({ name: 'X', status: 'cold' })).toThrow();
+	});
+
+	it('rejects negative money', () => {
+		expect(() => createCustomerSchema.parse({ name: 'X', balance: -1 })).toThrow();
+	});
+
+	it('rejects non-integer money', () => {
+		expect(() => createCustomerSchema.parse({ name: 'X', lifetimeValue: 1.5 })).toThrow();
+	});
+
+	it('accepts a blank email but rejects a malformed one in plain language', () => {
+		expect(createCustomerSchema.parse({ name: 'X', email: '' }).email).toBe('');
+		const result = createCustomerSchema.safeParse({ name: 'X', email: 'not-an-email' });
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe('Enter a valid email address.');
+	});
+});
+
+describe('updateCustomerSchema', () => {
+	it('accepts a partial update of one field', () => {
+		expect(updateCustomerSchema.parse({ status: 'paid' })).toEqual({ status: 'paid' });
+	});
+
+	it('rejects an empty update', () => {
+		expect(() => updateCustomerSchema.parse({})).toThrow();
+	});
+
+	it('rejects a negative balance', () => {
+		expect(() => updateCustomerSchema.parse({ balance: -5 })).toThrow();
 	});
 });
 

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -226,6 +226,76 @@ export const faqSimilarityQuerySchema = z.object({
 });
 export type FaqSimilarityQueryInput = z.infer<typeof faqSimilarityQuerySchema>;
 
+// --- Customers ----------------------------------------------------------------
+
+/**
+ * An optional email: either an empty string or a valid address. Built like
+ * {@link websiteSchema} (a plain `z.string()` refined to `'' || valid`) rather
+ * than reusing the required {@link emailSchema}, so a customer with no email on
+ * file is allowed while a non-empty value is still validated and normalized.
+ */
+export const optionalEmailSchema = z
+	.string()
+	.trim()
+	.toLowerCase()
+	.max(254, { error: 'That email address is too long.' })
+	.refine((value) => value === '' || z.email().safeParse(value).success, {
+		error: 'Enter a valid email address.',
+	});
+
+/** A money amount stored as a non-negative whole number of cents. */
+function moneyCents(label: string) {
+	return z
+		.number({ error: `${label} must be a number.` })
+		.int({ error: `${label} must be a whole number of cents.` })
+		.min(0, { error: `${label} can't be negative.` });
+}
+
+/** The preferred channel a customer is reached on. */
+export const customerChannelSchema = z.enum(['whatsapp', 'phone', 'email', 'sms'], {
+	error: 'Choose a valid contact channel.',
+});
+
+/** Where a customer sits in the sales/billing lifecycle. */
+export const customerStatusSchema = z.enum(['lead', 'quote', 'paid', 'due'], {
+	error: 'Choose a valid status.',
+});
+
+export const createCustomerSchema = z.object({
+	name: nameSchema,
+	email: optionalEmailSchema.default(''),
+	phone: phoneSchema.default(''),
+	area: optionalText('Area', 120).default(''),
+	channel: customerChannelSchema.default('phone'),
+	status: customerStatusSchema.default('lead'),
+	lifetimeValue: moneyCents('Lifetime value').default(0),
+	balance: moneyCents('Balance').default(0),
+	notes: optionalText('Notes', 2000).default(''),
+});
+export type CreateCustomerInput = z.infer<typeof createCustomerSchema>;
+
+/**
+ * Every field optional, but at least one must be present — mirrors
+ * {@link updateItemSchema}. No `.default()`s (unlike create) so a partial update
+ * only touches the fields the caller actually sent.
+ */
+export const updateCustomerSchema = z
+	.object({
+		name: nameSchema.optional(),
+		email: optionalEmailSchema.optional(),
+		phone: phoneSchema.optional(),
+		area: optionalText('Area', 120).optional(),
+		channel: customerChannelSchema.optional(),
+		status: customerStatusSchema.optional(),
+		lifetimeValue: moneyCents('Lifetime value').optional(),
+		balance: moneyCents('Balance').optional(),
+		notes: optionalText('Notes', 2000).optional(),
+	})
+	.refine((value) => Object.values(value).some((field) => field !== undefined), {
+		error: 'Provide at least one field to update.',
+	});
+export type UpdateCustomerInput = z.infer<typeof updateCustomerSchema>;
+
 /** Query string for list endpoints; coerces `?page=2&pageSize=50`. */
 export const paginationQuerySchema = z.object({
 	page: z.coerce.number().int().min(1, { error: 'Page must be 1 or greater.' }).default(1),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,6 +7,7 @@ export type Id<TBrand extends string> = string & { readonly __brand: TBrand };
 export type UserId = Id<'User'>;
 export type ItemId = Id<'Item'>;
 export type FaqId = Id<'Faq'>;
+export type CustomerId = Id<'Customer'>;
 export type AccountId = Id<'Account'>;
 export type MembershipId = Id<'Membership'>;
 export type InviteId = Id<'Invite'>;
@@ -115,6 +116,38 @@ export interface Faq {
 	/** Free-text grouping (e.g. "Pricing", "Scheduling"); empty when uncategorized. */
 	category: string;
 	status: FaqStatus;
+	createdAt: IsoDateString;
+	updatedAt: IsoDateString;
+}
+
+/** The preferred channel a customer is reached on. */
+export type CustomerChannel = 'whatsapp' | 'phone' | 'email' | 'sms';
+
+/**
+ * Where a customer sits in the sales/billing lifecycle: a fresh `lead`, a
+ * `quote` awaiting approval, `paid` up, or with a balance `due`.
+ */
+export type CustomerStatus = 'lead' | 'quote' | 'paid' | 'due';
+
+/** A CRM contact owned by an account; all members share the account's customers. */
+export interface Customer {
+	id: CustomerId;
+	accountId: AccountId;
+	name: string;
+	/** Empty string when not provided. */
+	email: string;
+	/** Empty string when not provided. */
+	phone: string;
+	/** Service area / neighborhood; empty string when not provided. */
+	area: string;
+	channel: CustomerChannel;
+	status: CustomerStatus;
+	/** Lifetime value in integer cents. */
+	lifetimeValue: number;
+	/** Outstanding balance in integer cents. */
+	balance: number;
+	/** Free-text notes; empty string when none. */
+	notes: string;
 	createdAt: IsoDateString;
 	updatedAt: IsoDateString;
 }

--- a/packages/docs/site/openapi.json
+++ b/packages/docs/site/openapi.json
@@ -1647,6 +1647,76 @@
         }
       }
     },
+    "/v1/faqs/similar": {
+      "post": {
+        "summary": "Check whether a similar FAQ already exists (AI-assisted)",
+        "tags": [
+          "faqs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 300
+                  },
+                  "answer": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 4000
+                  }
+                },
+                "required": [
+                  "question"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FaqSimilarity"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/faqs/{id}": {
       "get": {
         "summary": "Fetch one of your FAQs",
@@ -1803,6 +1873,419 @@
         "summary": "Delete one of your FAQs",
         "tags": [
           "faqs"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/customers/": {
+      "get": {
+        "summary": "List your account's customers",
+        "tags": [
+          "customers"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a customer",
+        "tags": [
+          "customers"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "email": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 254
+                  },
+                  "phone": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 40
+                  },
+                  "area": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 120
+                  },
+                  "channel": {
+                    "default": "phone",
+                    "type": "string",
+                    "enum": [
+                      "whatsapp",
+                      "phone",
+                      "email",
+                      "sms"
+                    ]
+                  },
+                  "status": {
+                    "default": "lead",
+                    "type": "string",
+                    "enum": [
+                      "lead",
+                      "quote",
+                      "paid",
+                      "due"
+                    ]
+                  },
+                  "lifetimeValue": {
+                    "default": 0,
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "balance": {
+                    "default": 0,
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "notes": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 2000
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/customers/{id}": {
+      "get": {
+        "summary": "Fetch one of your customers",
+        "tags": [
+          "customers"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update one of your customers",
+        "tags": [
+          "customers"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "email": {
+                    "type": "string",
+                    "maxLength": 254
+                  },
+                  "phone": {
+                    "type": "string",
+                    "maxLength": 40
+                  },
+                  "area": {
+                    "type": "string",
+                    "maxLength": 120
+                  },
+                  "channel": {
+                    "type": "string",
+                    "enum": [
+                      "whatsapp",
+                      "phone",
+                      "email",
+                      "sms"
+                    ]
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "lead",
+                      "quote",
+                      "paid",
+                      "due"
+                    ]
+                  },
+                  "lifetimeValue": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "balance": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "notes": {
+                    "type": "string",
+                    "maxLength": 2000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete one of your customers",
+        "tags": [
+          "customers"
         ],
         "parameters": [
           {


### PR DESCRIPTION
## Summary

The Customers screen already existed in the app but rendered **hardcoded demo data** with no backend. This PR makes `customers` a real, persisted, account-scoped entity end-to-end, mirroring the existing `items`/`faqs` pattern exactly, and rewires the screen to the live API.

A **Customer** is a full CRM record: `name`, `email`, `phone`, `area`, preferred `channel` (whatsapp/phone/email/sms), lifecycle `status` (lead/quote/paid/due), `lifetimeValue` + `balance` (stored as **integer cents**), and `notes`.

## What changed

**`@rivus/core`**
- `Customer` type + `CustomerChannel`/`CustomerStatus` enums
- `optionalEmailSchema`, an integer-cents money schema, and `createCustomerSchema`/`updateCustomerSchema`
- Schema tests keeping the package at **100% coverage**

**`@rivus/api`**
- `customer.model.ts` Mongoose model
- `CustomerRepository` with in-memory (tests) and Mongo (prod) implementations
- `/v1/customers` CRUD routes (list + create + get + update + delete) with response schemas
- DI wiring (`AppDeps`, `app.ts`, `server.ts`, `openapi.ts`, test helpers)
- `customers.test.ts` covering defaults, validation (bad channel/status, negative money, empty update), pagination, and **cross-account isolation**

**`@rivus/app`**
- Typed client methods `listCustomers`/`createCustomer`/`getCustomer`/`updateCustomer`/`deleteCustomer`, with fetch-mocked tests for the coverage gate
- Rewired **Customers** screen: API-driven list (pages through all results), a row-selected **live detail panel** (real contact/status/balance/notes — the mock QuickBooks invoices/activity are removed), a full add/edit/delete inline form, and an engine-safe currency formatter
- Removed the now-unused customer demo data from `src/data/demo.ts` (kept `Channel`/`channelColor`/`threads`, still used by Inbox)

## Testing

- `pnpm lint && pnpm type-check && pnpm test` all green (433 tests across the monorepo)
- Coverage verified per package: core **100%**, app `client.ts` ~**100%**, api **95.6%/88.9%** — all above thresholds
- The API CRUD path is exercised end-to-end through the real Fastify pipeline via `app.inject`

## Notes

- Money is integer cents everywhere; the only float math is the form's dollar↔cents conversion (`Math.round(dollars * 100)`).
- `channel`/`status` are stored lowercase; the UI maps them to display labels.
- The Mongoose model and Mongo repository are coverage-excluded (consistent with `items`), so no Mongo integration tests were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AecJBW6oASzQkH2XmFVYMG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AecJBW6oASzQkH2XmFVYMG)_