### PR TITLE
docs: add Rivus design system and require it for all UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,6 @@
 .env.*
 !.env.example
 .dev.vars
+
+# Design-system source archive (visual reference only; DESIGN_SYSTEM.md is the spec)
+*.mhtml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,27 @@ Before committing, the three gates that CI runs must pass locally:
   `src`). Apps bundle it: tsdown `deps.alwaysBundle`, Next `transpilePackages`,
   Metro/esbuild inline it. There is no build-order dependency on it.
 
+## Design system
+
+**[`DESIGN_SYSTEM.md`](./DESIGN_SYSTEM.md) is the single source of truth for all
+user-facing visual design.** Always follow it when building or changing any UI —
+the marketing site (`website`), the app (`app`), the docs (`docs`), and any other
+visible surface (emails, screenshots, marketing artifacts).
+
+- Use the documented **tokens** (color, typography, radius) instead of inventing
+  new hex values, font sizes, or one-off styles. The typeface is **Montserrat**
+  (weights 400/500/600).
+- Reserve the **signature gradient** (`linear-gradient(135deg, #1ebefa, #6e1ec8)`)
+  for Rivus-the-agent (primary buttons, AI status, active nav) — never as a page
+  or card background.
+- Reuse the documented **components** (`BriefingBanner`, `RivusPill`,
+  `StatusBadge`, `MetricCard`, `Avatar`, primary/secondary buttons) and match
+  their props.
+- If you need a value or component the system doesn't cover, **add it to
+  `DESIGN_SYSTEM.md` first**, then implement it — don't hard-code a new literal.
+- The original interactive reference is `Rivus-Design-System.mhtml` (open in a
+  browser); `DESIGN_SYSTEM.md` is the canonical, editable spec.
+
 ## Adding a dependency (mind the supply-chain gate)
 
 `pnpm-workspace.yaml` enforces `minimumReleaseAge: 10080` (strict): pnpm refuses
@@ -73,13 +94,14 @@ Tests are an inventory of failure modes, not a coverage ritual.
   (`memory.ts`, `mongo.ts`), and the route. Regenerate the OpenAPI doc with
   `pnpm --filter @rivus/api openapi`.
 - **website** — `type-check` runs `next typegen` first; `next-env.d.ts` is
-  generated, not committed.
+  generated, not committed. All UI follows [`DESIGN_SYSTEM.md`](./DESIGN_SYSTEM.md).
 - **docs** — `scripts/sync-openapi.mjs` copies the API spec into the site on
   build. `githubPath` is gated on `GITHUB_TOKEN` so builds stay green offline.
 - **worker** — Handler logic is pure and injectable; `src/index.ts` is the only
   Workers-runtime adapter. Build validates with `wrangler deploy --dry-run`.
 - **app** — The API client (`src/api`) is RN-free so it is unit-tested under
-  Node. Native builds need Expo tooling/devices and are not run in CI.
+  Node. Native builds need Expo tooling/devices and are not run in CI. All UI
+  follows [`DESIGN_SYSTEM.md`](./DESIGN_SYSTEM.md).
 
 ## Commits & CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,5 +16,7 @@ essentials:
 - `@rivus/core` is imported as source; apps bundle it.
 - Keep tests hermetic (the API uses in-memory repositories; the worker and app
   mock `fetch`). Don't lower coverage thresholds to pass.
+- All user-facing UI must follow **[DESIGN_SYSTEM.md](./DESIGN_SYSTEM.md)** — use
+  its tokens and components, never ad-hoc styles.
 
 Use Conventional Commit messages.

--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -1,0 +1,176 @@
+# Rivus Design System
+
+The reusable visual language behind the Rivus business-management agent — tokens,
+type, and components shared across every screen.
+
+> **v1 · Living document.** This is the single source of truth for Rivus' visual
+> design. Every user-facing surface (`@rivus/website`, `@rivus/app`,
+> `@rivus/docs`, and any marketing/email/UI artifact) must use these tokens and
+> components rather than inventing new colors, type sizes, or one-off styles. The
+> original interactive reference is preserved alongside this file as
+> [`Rivus-Design-System.mhtml`](./Rivus-Design-System.mhtml) — open it in a
+> browser to see the live components.
+
+When a value you need is missing here, add it to this document (and the shared
+theme) instead of hard-coding a new literal in a component.
+
+---
+
+## Color
+
+### Brand
+
+| Token         | Value                          | Notes                                  |
+| ------------- | ------------------------------ | -------------------------------------- |
+| Rivus gradient | `#1ebefa → #6e1ec8`           | The signature element (see Gradient)   |
+| Sky           | `#1ebefa`                      | Gradient start                         |
+| Violet        | `#6e1ec8`                      | Gradient end / accent                  |
+| Ink           | `#101019`                      | Darkest brand neutral                  |
+
+### Surfaces
+
+| Token          | Value      | Use                                         |
+| -------------- | ---------- | ------------------------------------------- |
+| App background | `#f6f7fb`  | Default page background                     |
+| Card           | `#ffffff`  | Cards, sheets, raised surfaces              |
+| Briefing dark  | `#13131f`  | Dark "briefing" surfaces (gradient base)    |
+| Hairline       | `#e9eaf0`  | 1px borders, dividers, separators           |
+
+### Status
+
+| Token   | Value      | Use                          |
+| ------- | ---------- | ---------------------------- |
+| Success | `#1fb573`  | Paid, positive, online       |
+| Warning | `#f0a020`  | Pending, attention           |
+| Danger  | `#f0584b`  | Overdue, errors, destructive |
+| Accent  | `#6e1ec8`  | Quotes, highlights (violet)  |
+
+### Text
+
+| Token    | Value      | Use                                   |
+| -------- | ---------- | ------------------------------------- |
+| Primary  | `#16161f`  | Default body and headings             |
+| Sub      | `#8a8b99`  | Secondary text                        |
+| Muted    | `#9a9bb0`  | Tertiary / supporting text            |
+| Disabled | `#b6b8c4`  | Disabled controls and placeholder     |
+
+---
+
+## Typography · Montserrat
+
+The single typeface is **Montserrat** (`font-family: Montserrat, sans-serif`).
+Weights in use: **400 / 500 / 600**.
+
+| Style   | Size     | Weight | Letter-spacing | Example use                          |
+| ------- | -------- | ------ | -------------- | ------------------------------------ |
+| Display | `30px`   | 600    | `-0.02em`      | "Good morning, Marcus"               |
+| Heading | `20px`   | 600    | —              | Section titles ("Schedule")          |
+| Subhead | `15px`   | 600    | —              | "Today's schedule"                   |
+| Body    | `13.5px` | 400    | —              | Paragraph / default copy             |
+| Label   | `12px`   | 600    | `0.06em`       | Uppercase labels ("CONVERSATIONS")   |
+| Caption | `11.5px` | 500    | —              | Supporting captions                  |
+
+Uppercase eyebrows/labels use wider tracking (`0.06em`–`0.1em`). Large display
+text uses tight tracking (`-0.02em`).
+
+---
+
+## Signature gradient
+
+```css
+linear-gradient(135deg, #1ebefa, #6e1ec8)
+```
+
+The **one** signature element. Reserve it for Rivus-the-agent: primary buttons,
+the symbol tile, AI status, active nav. **Never** use it as a page or card
+background.
+
+Supporting gradients:
+
+- **Briefing dark surface:** `linear-gradient(120deg, #13131f, #1b1530)` — dark
+  banners (e.g. the "while you were away" briefing).
+- **Soft accent tint:** `linear-gradient(135deg, rgba(30,190,250,0.12), rgba(110,30,200,0.12))`
+  — subtle brand-tinted fills behind icons/checks.
+
+---
+
+## Radius
+
+| Token            | Value      | Use                  |
+| ---------------- | ---------- | -------------------- |
+| Controls         | `8px`      | Small controls       |
+| Buttons / inputs | `10–11px`  | Buttons, inputs      |
+| Cards            | `14px`     | Cards, sheets        |
+| Pills            | `999px`    | Pills, avatars, dots |
+
+---
+
+## Elevation & focus
+
+- Cards sit on `#f6f7fb` with a `1px` `#e9eaf0` hairline; keep shadows subtle.
+- Status focus glow (success): `box-shadow: 0 0 0 3px rgba(31,181,115,0.18)`.
+
+---
+
+## Components
+
+These are the shared, reusable building blocks. Match their structure and props
+when implementing per platform.
+
+### BriefingBanner
+
+The agent's "while you were away" summary. Dark briefing surface.
+
+- **Props:** `eyebrow` · `message` · `ctaLabel`
+- Example: _"While you were away — Rivus handled 38 conversations, booked 6 jobs,
+  and answered 19 questions overnight. Two items need a human eye."_
+
+### RivusPill
+
+AI status pill for the agent's state.
+
+- **Props:** `label` · `variant(dot | check)`
+- Examples: "Rivus is online" (dot), "Rivus is handling" (dot),
+  "Rivus auto-scheduled 6 jobs" (check)
+
+### StatusBadge
+
+Compact status label for business records.
+
+- **Props:** `label` · `tone(paid | due | quote | lead | neutral)`
+- Examples: "Paid up" (paid), "Balance due" (due), "Quote pending" (quote),
+  "New lead" (lead), "Reminder sent" (neutral)
+
+### MetricCard
+
+A single dashboard metric.
+
+- **Props:** `label` · `value` · `delta` · `tone(positive | neutral)` · `sub`
+- Examples:
+  - "Conversations today" · `38` · `+12%` · "34 handled by Rivus"
+  - "Jobs booked" · `6` · "today" · "$4,200 pipeline value"
+  - "Avg. response time" · `12s` · "Was 4h before Rivus"
+  - "Open invoices" · `$8,140` · "5 invoices · QuickBooks"
+
+### Avatar
+
+- **Props:** `initials` · `size`
+- Circular (`999px`), shows 2-letter initials (e.g. "MT", "PA").
+
+### Buttons
+
+- **Primary:** uses the signature gradient at `11px` radius.
+- **Secondary:** white with a `1px` hairline (`#e9eaf0`) border.
+- Both stay **inline** — there is no shared button design component; build per
+  platform using these recipes.
+
+---
+
+## Using this system
+
+- **Reach for tokens, not literals.** Use the color/type/radius tokens above; do
+  not introduce new hex values or font sizes ad hoc.
+- **One gradient, one job.** The signature gradient marks Rivus-the-agent only.
+- **Montserrat everywhere.** All text is Montserrat in weights 400/500/600.
+- **Reuse components.** Prefer the components above; if a screen needs something
+  new, add it here first so every surface stays consistent.

--- a/Rivus-Design-System.mhtml
+++ b/Rivus-Design-System.mhtml
@@ -1,0 +1,9982 @@
+From: <Saved by Blink>
+Snapshot-Content-Location: https://claude.ai/design/p/15b5e0f9-5329-43e0-8d6a-0aed95d8ce1a?file=Rivus+Design+System+%28standalone%29.html
+Subject: Rivus Business Management Agent
+Date: Fri, 26 Jun 2026 15:14:30 -0700
+MIME-Version: 1.0
+Content-Type: multipart/related;
+	type="text/html";
+	boundary="----MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----"
+
+
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/html
+Content-ID: <frame-D688105FDDEA9EA937284CAF4CC5C4FB@mhtml.blink>
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://claude.ai/design/p/15b5e0f9-5329-43e0-8d6a-0aed95d8ce1a?file=Rivus+Design+System+%28standalone%29.html
+
+<!DOCTYPE html><html lang=3D"en" data-theme=3D"light"><head><meta http-equi=
+v=3D"Content-Type" content=3D"text/html; charset=3DUTF-8">
+   =20
+    <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=
+=3D1.0">
+    <title>Rivus Business Management Agent</title>
+    <link rel=3D"icon" type=3D"image/png" href=3D"https://claude.ai/design/=
+favicon.png">
+   =20
+   =20
+    <link rel=3D"modulepreload" crossorigin=3D"" href=3D"https://claude.ai/=
+design/assets/v1/rolldown-runtime-CMxvf4Kt.js">
+    <link rel=3D"modulepreload" crossorigin=3D"" href=3D"https://claude.ai/=
+design/assets/v1/preload-helper-7XptfjGJ.js">
+    <link rel=3D"modulepreload" crossorigin=3D"" href=3D"https://claude.ai/=
+design/assets/v1/react-BthIFXYf.js">
+    <link rel=3D"modulepreload" crossorigin=3D"" href=3D"https://claude.ai/=
+design/assets/v1/client-lite-D9N8kEta.js">
+    <link rel=3D"modulepreload" crossorigin=3D"" href=3D"https://claude.ai/=
+design/assets/v1/useOrg-L52xR1Er.js">
+    <link rel=3D"modulepreload" crossorigin=3D"" href=3D"https://claude.ai/=
+design/assets/v1/cn-BvRk9kiK.js">
+    <link rel=3D"modulepreload" crossorigin=3D"" href=3D"https://claude.ai/=
+design/assets/v1/cn-qYiRd2Uw.js">
+    <link rel=3D"modulepreload" crossorigin=3D"" href=3D"https://claude.ai/=
+design/assets/v1/jsx-runtime-DDrWIXeu.js">
+    <link rel=3D"modulepreload" crossorigin=3D"" href=3D"https://claude.ai/=
+design/assets/v1/Button-2Qw1S5Jt.js">
+    <link rel=3D"stylesheet" crossorigin=3D"" href=3D"https://claude.ai/des=
+ign/assets/v1/index-D0EsnHXb.css">
+  <link rel=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"low" href=
+=3D"https://claude.ai/design/assets/v1/AttachmentChips-B3IgIMUS.js"><link r=
+el=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"low" href=3D"https:/=
+/claude.ai/design/assets/v1/Button-DdEhBt1J.js"><link rel=3D"modulepreload"=
+ crossorigin=3D"" fetchpriority=3D"low" href=3D"https://claude.ai/design/as=
+sets/v1/Dialog-YsXmgOAc.js"><link rel=3D"modulepreload" crossorigin=3D"" fe=
+tchpriority=3D"low" href=3D"https://claude.ai/design/assets/v1/LimitUpsellO=
+ptionCard-CjB24Up6.js"><link rel=3D"modulepreload" crossorigin=3D"" fetchpr=
+iority=3D"low" href=3D"https://claude.ai/design/assets/v1/ProjectPage-CfEc6=
+3MB.js"><link rel=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"low" =
+href=3D"https://claude.ai/design/assets/v1/SpinnerCursorContext-FnwGR7gg.js=
+"><link rel=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"low" href=
+=3D"https://claude.ai/design/assets/v1/browser-BV-Pd9QF.js"><link rel=3D"mo=
+dulepreload" crossorigin=3D"" fetchpriority=3D"low" href=3D"https://claude.=
+ai/design/assets/v1/client-BLr9pfHO.js"><link rel=3D"modulepreload" crossor=
+igin=3D"" fetchpriority=3D"low" href=3D"https://claude.ai/design/assets/v1/=
+client-event-bus-CUOhmLFi.js"><link rel=3D"modulepreload" crossorigin=3D"" =
+fetchpriority=3D"low" href=3D"https://claude.ai/design/assets/v1/connectrpc=
+-C_tuT162.js"><link rel=3D"modulepreload" crossorigin=3D"" fetchpriority=3D=
+"low" href=3D"https://claude.ai/design/assets/v1/ds-contract-t_Kqu8SX.js"><=
+link rel=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"low" href=3D"h=
+ttps://claude.ai/design/assets/v1/ds-manifest-guards-CDOctgob.js"><link rel=
+=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"low" href=3D"https://c=
+laude.ai/design/assets/v1/esm-BBwE_gJ0.js"><link rel=3D"modulepreload" cros=
+sorigin=3D"" fetchpriority=3D"low" href=3D"https://claude.ai/design/assets/=
+v1/format-By-mtEsV.js"><link rel=3D"modulepreload" crossorigin=3D"" fetchpr=
+iority=3D"low" href=3D"https://claude.ai/design/assets/v1/glyph-BHo4ckbs.js=
+"><link rel=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"low" href=
+=3D"https://claude.ai/design/assets/v1/home-analytics-DdqZUuge.js"><link re=
+l=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"low" href=3D"https://=
+claude.ai/design/assets/v1/host-BwlQdwMG.js"><link rel=3D"modulepreload" cr=
+ossorigin=3D"" fetchpriority=3D"low" href=3D"https://claude.ai/design/asset=
+s/v1/path-B8831-h-.js"><link rel=3D"modulepreload" crossorigin=3D"" fetchpr=
+iority=3D"low" href=3D"https://claude.ai/design/assets/v1/platform-WOoNmsjC=
+.js"><link rel=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"low" hre=
+f=3D"https://claude.ai/design/assets/v1/presenterChannel-CJwPOshM.js"><link=
+ rel=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"low" href=3D"https=
+://claude.ai/design/assets/v1/shared-BtICgni1.js"><link rel=3D"modulepreloa=
+d" crossorigin=3D"" fetchpriority=3D"low" href=3D"https://claude.ai/design/=
+assets/v1/spark-kp41wht5.js"><link rel=3D"modulepreload" crossorigin=3D"" f=
+etchpriority=3D"low" href=3D"https://claude.ai/design/assets/v1/useEditInte=
+raction-MCRTOCPJ.js"><link rel=3D"modulepreload" crossorigin=3D"" fetchprio=
+rity=3D"low" href=3D"https://claude.ai/design/assets/v1/useModelSelection-Y=
+qDeo_KA.js"><link rel=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"l=
+ow" href=3D"https://claude.ai/design/assets/v1/useMutation-Q-oqcePo.js"><li=
+nk rel=3D"modulepreload" crossorigin=3D"" fetchpriority=3D"low" href=3D"htt=
+ps://claude.ai/design/assets/v1/useQuery-COlHTvS5.js"><link rel=3D"modulepr=
+eload" crossorigin=3D"" fetchpriority=3D"low" href=3D"https://claude.ai/des=
+ign/assets/v1/viewer-handle-DFClos0R.js"><link rel=3D"preload" as=3D"style"=
+ crossorigin=3D"" fetchpriority=3D"low" href=3D"https://claude.ai/design/as=
+sets/v1/Button-C3hHoRdu.css"><link rel=3D"preload" as=3D"style" crossorigin=
+=3D"" fetchpriority=3D"low" href=3D"https://claude.ai/design/assets/v1/Proj=
+ectPage-BnhONUSu.css"><link rel=3D"preload" as=3D"style" crossorigin=3D"" f=
+etchpriority=3D"low" href=3D"https://claude.ai/design/assets/v1/format-D66g=
+dL5p.css"><link rel=3D"preload" as=3D"style" crossorigin=3D"" fetchpriority=
+=3D"low" href=3D"https://claude.ai/design/assets/v1/home-analytics-DVN_Gu5T=
+.css"><link rel=3D"modulepreload" as=3D"script" crossorigin=3D"" href=3D"ht=
+tps://claude.ai/design/assets/v1/DesignSpotlight-D_go2ybL.js"><link rel=3D"=
+stylesheet" crossorigin=3D"" href=3D"https://claude.ai/design/assets/v1/But=
+ton-C3hHoRdu.css"><link rel=3D"modulepreload" as=3D"script" crossorigin=3D"=
+" href=3D"https://claude.ai/design/assets/v1/Switch-DE5PUpc9.js"><link rel=
+=3D"modulepreload" as=3D"script" crossorigin=3D"" href=3D"https://claude.ai=
+/design/assets/v1/useLabelableId-DBXfMR_T.js"><link rel=3D"modulepreload" a=
+s=3D"script" crossorigin=3D"" href=3D"https://claude.ai/design/assets/v1/ho=
+oks-DrzLFjHM.js"><link rel=3D"modulepreload" as=3D"script" crossorigin=3D""=
+ href=3D"https://claude.ai/design/assets/v1/AnimatePresence-CdFTYeUp.js"><l=
+ink rel=3D"modulepreload" as=3D"script" crossorigin=3D"" href=3D"https://cl=
+aude.ai/design/assets/v1/schemas-DgQq6Z5S.js"><link rel=3D"modulepreload" a=
+s=3D"script" crossorigin=3D"" href=3D"https://claude.ai/design/assets/v1/De=
+signChatTooltip-BvGpk4uZ.js"><link rel=3D"stylesheet" crossorigin=3D"" href=
+=3D"https://claude.ai/design/assets/v1/home-analytics-DVN_Gu5T.css"><link r=
+el=3D"stylesheet" crossorigin=3D"" href=3D"https://claude.ai/design/assets/=
+v1/format-D66gdL5p.css"><link rel=3D"stylesheet" crossorigin=3D"" href=3D"h=
+ttps://claude.ai/design/assets/v1/ProjectPage-BnhONUSu.css"><link rel=3D"mo=
+dulepreload" as=3D"script" crossorigin=3D"" href=3D"https://claude.ai/desig=
+n/assets/v1/gb-setters-D3zOkUXB.js"><link rel=3D"modulepreload" as=3D"scrip=
+t" crossorigin=3D"" href=3D"https://claude.ai/design/assets/v1/datadog-rum-=
+B5WH0SNY.js"><link rel=3D"modulepreload" as=3D"script" crossorigin=3D"" hre=
+f=3D"https://claude.ai/design/assets/v1/OnboardingModal-TfTmEqkJ.js"><link =
+rel=3D"modulepreload" as=3D"script" crossorigin=3D"" href=3D"https://claude=
+.ai/design/assets/v1/index-DmMQpmvL.js"><link rel=3D"modulepreload" as=3D"s=
+cript" crossorigin=3D"" href=3D"https://claude.ai/design/assets/v1/data-Dai=
+Jg8Bw.js"><link rel=3D"modulepreload" as=3D"script" crossorigin=3D"" href=
+=3D"https://claude.ai/design/assets/v1/UserSettingsPanel-SmbFm9E8.js"><link=
+ rel=3D"modulepreload" as=3D"script" crossorigin=3D"" href=3D"https://claud=
+e.ai/design/assets/v1/useReferral-CZPjkqtW.js"><link rel=3D"modulepreload" =
+as=3D"script" crossorigin=3D"" href=3D"https://claude.ai/design/assets/v1/C=
+onnectorsPanel-DOPYkB3c.js"><link rel=3D"modulepreload" as=3D"script" cross=
+origin=3D"" href=3D"https://claude.ai/design/assets/v1/DsBrowseModal-mzUv6F=
+Xz.js"><link rel=3D"modulepreload" as=3D"script" crossorigin=3D"" href=3D"h=
+ttps://claude.ai/design/assets/v1/HandoffModal-D_qZWJ_v.js"><meta name=3D"o=
+melette-user-email" content=3D"me@jaredwray.com"></head>
+  <body>
+    <div id=3D"root"><div class=3D"h-dvh flex flex-col"><div class=3D"flex-=
+1 min-h-0"><div class=3D"h-full flex flex-col bg-transparent"><div class=3D=
+"flex-1 flex flex-col overflow-hidden"><div class=3D"relative flex flex-col=
+ h-full bg-transparent"><div class=3D"relative flex flex-col h-full bg-om-b=
+g-app"><div class=3D"flex-1 flex min-h-0" style=3D"padding: 8px; gap: 8px;"=
+><div style=3D"position: absolute; pointer-events: none;"><div class=3D"abs=
+olute inset-0 bg-[radial-gradient(ellipse_120%_90%_at_40%_30%,#1a1a1a_0%,#0=
+d0d0d_50%,#000_100%)] invisible"><div class=3D"origin-top-left" style=3D"tr=
+ansform: translate(0px, 0px) scale(0.166667);"><iframe src=3D"cid:frame-40B=
+ECF81F0084B3424C7A0802889AFC9@mhtml.blink" width=3D"924" height=3D"540" all=
+ow=3D"camera; microphone; geolocation" sandbox=3D"allow-scripts allow-forms=
+ allow-popups allow-same-origin" style=3D"border-width: medium; border-styl=
+e: none; border-color: currentcolor; border-image: initial; pointer-events:=
+ none; display: block; background: transparent; color-scheme: normal;"></if=
+rame></div></div><div class=3D"absolute inset-0 bg-[radial-gradient(ellipse=
+_120%_90%_at_40%_30%,#1a1a1a_0%,#0d0d0d_50%,#000_100%)] invisible"><div cla=
+ss=3D"origin-top-left" style=3D"transform: translate(0px, 0px) scale(0.1666=
+67);"><iframe src=3D"cid:frame-95B80C3396D04C3E818D04B557599D4F@mhtml.blink=
+" width=3D"924" height=3D"540" allow=3D"camera; microphone; geolocation" sa=
+ndbox=3D"allow-scripts allow-forms allow-popups allow-same-origin" style=3D=
+"border-width: medium; border-style: none; border-color: currentcolor; bord=
+er-image: initial; pointer-events: none; display: block; background: transp=
+arent; color-scheme: normal;"></iframe></div></div></div><div class=3D"shri=
+nk-0 opacity-100 visible overflow-visible" style=3D"width: 301px; margin-ri=
+ght: 0px; transition: width 0.28s cubic-bezier(0.4, 0, 0.2, 1), margin-righ=
+t 0.28s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.18s, visibility linear;"><d=
+iv class=3D"h-full flex flex-col min-h-0" style=3D"width: 301px; transition=
+: width 0.28s cubic-bezier(0.4, 0, 0.2, 1);"><div class=3D"flex items-cente=
+r gap-1.5 py-2 shrink-0 [-webkit-app-region:drag] [&amp;_:is(button,a,input=
+)]:[-webkit-app-region:no-drag]"><div class=3D"inline-flex"><a class=3D"rou=
+nded-[7px] inline-flex items-center justify-center self-center shrink-0 tex=
+t-om-accent-primary bg-om-bg-elevated cursor-default no-underline shadow-[0=
+_1px_2px_rgba(20,20,19,0.08),0_0_0_1px_var(--om-border-subtle)] transition-=
+[box-shadow,transform] duration-[120ms] hover:shadow-[0_2px_5px_rgba(20,20,=
+19,0.12),0_0_0_1px_var(--om-border-default)] hover:-translate-y-px active:t=
+ranslate-y-px w-[26px] h-[26px] ml-1.5" href=3D"https://claude.ai/design/" =
+aria-label=3D"Back to projects"><svg width=3D"16" height=3D"16" viewBox=3D"=
+0 0 20 21" fill=3D"none" aria-hidden=3D"true"><path d=3D"M9.99902 0C15.5258=
+ 0.000170936 19.999 4.50643 19.999 10.0547C19.999 11.7656 19.5863 12.9976 1=
+8.7861 13.8203C17.9924 14.6362 16.9465 14.9138 15.9854 15.0078C15.05 15.099=
+3 14.0097 15.0262 13.2549 15.0186C12.8524 15.0145 12.5177 15.0267 12.2441 1=
+5.0703C11.9682 15.1144 11.8143 15.1813 11.7305 15.2432C11.4745 15.4322 11.3=
+353 15.7121 11.2656 16.1602C11.2303 16.3875 11.2168 16.6362 11.209 16.9131C=
+11.2017 17.1715 11.1986 17.4893 11.1807 17.7705C11.1469 18.2975 11.0495 19.=
+0865 10.4199 19.5908C9.7846 20.0996 8.88652 20.1057 7.85449 19.877C7.36399 =
+19.7682 6.88652 19.6232 6.42578 19.4453C2.66989 17.9949 0.000187748 14.3414=
+ 0 10.0547C0 4.50643 4.47223 0.000171048 9.99902 0ZM9.99902 1.60547C5.36781=
+ 1.60564 1.60547 5.38391 1.60547 10.0547C1.60566 13.6582 3.84823 16.7296 7.=
+00391 17.9482C7.39027 18.0974 7.79085 18.2184 8.20215 18.3096C9.1375 18.516=
+9 9.384 18.3633 9.41602 18.3379C9.4524 18.3087 9.54558 18.1915 9.5791 17.66=
+8C9.5947 17.4239 9.59473 17.1786 9.60352 16.8672C9.61179 16.5742 9.62831 16=
+.2435 9.67969 15.9131C9.78359 15.2455 10.0474 14.4906 10.7764 13.9521C11.14=
+79 13.6778 11.5842 13.5493 11.9912 13.4844C12.4007 13.4191 12.8434 13.4088 =
+13.2705 13.4131C14.1753 13.4222 15.0071 13.4905 15.8291 13.4102C16.6257 13.=
+3322 17.2249 13.1235 17.6357 12.7012C18.0401 12.2855 18.3935 11.5261 18.393=
+6 10.0547C18.3936 5.38391 14.6302 1.60564 9.99902 1.60547ZM5.11621 9.86719C=
+5.86386 9.91468 6.45486 10.5348 6.45508 11.2939C6.45506 12.0838 5.81519 12.=
+7245 5.02539 12.7246C4.28481 12.7246 3.67573 12.1617 3.60254 11.4404L3.5947=
+3 11.2939L3.60156 11.1533C3.66942 10.4596 4.23282 9.91186 4.93359 9.86719H5=
+.11621ZM14.9814 7.19141C15.729 7.23889 16.3199 7.85919 16.3203 8.61816C16.3=
+203 9.40801 15.6804 10.0487 14.8906 10.0488C14.1501 10.0487 13.5409 9.48586=
+ 13.4678 8.76465L13.46 8.61816L13.4668 8.47754C13.5348 7.78403 14.0983 7.23=
+618 14.7988 7.19141H14.9814ZM6.4541 4.93457C7.20161 4.9822 7.79275 5.60231 =
+7.79297 6.36133C7.79288 7.151 7.15291 7.7917 6.36328 7.79199C5.62274 7.7919=
+9 5.01369 7.22903 4.94043 6.50781L4.93262 6.36133L4.93945 6.2207C5.00731 5.=
+52698 5.5707 4.97922 6.27148 4.93457H6.4541ZM11.3867 3.59668C12.1343 3.6441=
+9 12.7253 4.26436 12.7256 5.02344C12.7256 5.81326 12.0857 6.45393 11.2959 6=
+.4541C10.5553 6.4541 9.94622 5.89123 9.87305 5.16992L9.86523 5.02344L9.8720=
+7 4.88281C9.93996 4.18912 10.5033 3.64133 11.2041 3.59668H11.3867Z" fill=3D=
+"currentColor"></path></svg></a></div><div class=3D"flex-1 min-w-0 flex ite=
+ms-center [-webkit-app-region:no-drag]"><span class=3D"box-border text-[13p=
+x] font-[450] text-om-text-primary tracking-[-0.1px] leading-5 rounded-[4px=
+] px-1.5 py-0.5 border border-transparent max-w-[320px] absolute invisible =
+whitespace-pre pointer-events-none">Rivus Business Management Agent</span><=
+span class=3D"box-border text-[13px] font-[450] text-om-text-primary tracki=
+ng-[-0.1px] leading-5 rounded-[4px] px-1.5 py-0.5 border border-transparent=
+ max-w-[320px] truncate cursor-text hover:bg-om-bg-hover" title=3D"Rivus Bu=
+siness Management Agent" data-testid=3D"project-title">Rivus Business Manag=
+ement Agent</span><button title=3D"Project menu" aria-label=3D"Project menu=
+" class=3D"shrink-0 w-5 h-5 flex items-center justify-center p-0 rounded-[4=
+px] text-om-text-tertiary cursor-default outline-none hover:bg-om-bg-hover =
+hover:text-om-text-secondary bg-transparent"><i class=3D"ai-CaretDownSmall =
+leading-none not-italic w-[1em] h-[1em] inline-flex items-center justify-ce=
+nter shrink-0" style=3D"font-size: 12px; transform: translateY(1.5px);"></i=
+></button></div><div class=3D"inline-flex"><button class=3D"flex cursor-def=
+ault select-none items-center justify-center rounded p-0 text-om-text-terti=
+ary no-underline outline-none bg-transparent hover:bg-om-bg-hover hover:tex=
+t-om-text-secondary active:brightness-[.8] disabled:cursor-not-allowed disa=
+bled:opacity-30" aria-label=3D"Hide sidebar" style=3D"width: 25px; height: =
+25px;"><i class=3D"ai-Sidebar leading-none not-italic w-[1em] h-[1em] inlin=
+e-flex items-center justify-center shrink-0" style=3D"font-size: 14px; -web=
+kit-text-stroke: 0.04em currentcolor;"></i></button></div><div style=3D"dis=
+play: inline-flex; align-self: center; padding-right: 6px;"><button class=
+=3D"flex cursor-default select-none items-center justify-center rounded p-0=
+ text-om-text-tertiary no-underline outline-none bg-transparent hover:bg-om=
+-bg-hover hover:text-om-text-secondary active:brightness-[.8] disabled:curs=
+or-not-allowed disabled:opacity-30" title=3D"Chat history" aria-label=3D"Ch=
+at history" data-testid=3D"nav-chat-history" style=3D"width: 25px; height: =
+25px;"><i class=3D"ai-Chats leading-none not-italic w-[1em] h-[1em] inline-=
+flex items-center justify-center shrink-0" style=3D"font-size: 14px; -webki=
+t-text-stroke: 0.04em currentcolor;"></i></button></div></div><div class=3D=
+"flex-1 min-h-0 flex flex-col"><div class=3D"flex-1 min-h-0 flex flex-col">=
+<div style=3D"display: flex; flex-direction: column; flex: 1 1 0%; min-heig=
+ht: 0px;"><div class=3D"flex flex-col h-full relative"><div class=3D"flex-1=
+ h-0 flex flex-col bg-transparent" style=3D"--chat-floor: var(--om-bg-app);=
+ --chat-pad-l: 8px; --chat-pad-r: 0px;"><div class=3D"flex-1 relative overf=
+low-hidden [contain:strict] before:content-[''] before:absolute before:top-=
+0 before:left-0 before:right-0 before:h-5 before:bg-[linear-gradient(to_bot=
+tom,var(--chat-floor)_2%,transparent_100%)] before:pointer-events-none befo=
+re:z-[1]"><div data-testid=3D"chat-messages" data-chat-id=3D"f5cae5a5-abf5-=
+4b37-89a2-dfaa3b2446b4" class=3D"om-chat-messages h-full pt-3.5 pr-[var(--c=
+hat-pad-r)] pb-[38px] pl-[var(--chat-pad-l)] overflow-auto relative"><div s=
+tyle=3D"position: relative; height: 5043px;"><div data-index=3D"2" style=3D=
+"position: absolute; top: 0px; left: 0px; width: 100%; transform: translate=
+Y(1719px);"><div class=3D"mb-3.5 flex flex-col items-end"><div class=3D"sel=
+ect-text [overflow-wrap:break-word] break-words min-w-0 py-2 px-3 max-w-[85=
+%] w-fit text-left" style=3D"background: var(--om-bg-surface); border: 0.5p=
+x solid var(--om-border-default); border-radius: 8px; box-shadow: rgba(0, 0=
+, 0, 0.04) 0px 1px 2px;"><span style=3D"font-size: 13px; color: var(--om-te=
+xt-primary); line-height: 1.6; white-space: pre-wrap;">b</span></div></div>=
+</div><div data-index=3D"3" style=3D"position: absolute; top: 0px; left: 0p=
+x; width: 100%; transform: translateY(1771px);"><div class=3D"om-assistant-=
+group"><div class=3D"mb-3.5"><div class=3D"select-text [overflow-wrap:break=
+-word] break-words min-w-0"><div class=3D"om-md-content"><div><p>Building o=
+ption (b): the 5 reusable component DCs, the reference page that imports th=
+em, and a <code>CLAUDE.md</code> to persist the system.</p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow=
+-[0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-cente=
+r h-6 select-none px-2.5 cursor-default"><i class=3D"ai-Checklist leading-n=
+one not-italic w-[1em] h-[1em] inline-flex items-center justify-center shri=
+nk-0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrin=
+k: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 o=
+verflow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace=
+-nowrap">Updated todos</span></div></div></div><div class=3D"om-md-content"=
+><div><p>I'll write all five component DCs in parallel.</p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow=
+-[0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-cente=
+r h-6 select-none px-2.5 cursor-pointer"><i class=3D"ai-Lightning leading-n=
+one not-italic w-[1em] h-[1em] inline-flex items-center justify-center shri=
+nk-0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrin=
+k: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 o=
+verflow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace=
+-nowrap">Designing =C3=975</span><i class=3D"ai-CaretDown leading-none not-=
+italic w-[1em] h-[1em] inline-flex items-center justify-center text-om-text=
+-tertiary shrink-0 transition-transform duration-150 rotate-0" style=3D"fon=
+t-size: 12px;"></i></div></div><div class=3D"my-2 rounded-lg overflow-hidde=
+n bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow-[0=
+_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-center h=
+-6 select-none px-2.5 cursor-default"><i class=3D"ai-Checklist leading-none=
+ not-italic w-[1em] h-[1em] inline-flex items-center justify-center shrink-=
+0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrink: =
+0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 over=
+flow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace-no=
+wrap">Updated todos</span></div></div></div><div class=3D"om-md-content"><d=
+iv><p>Now the reference page that documents tokens and showcases the live c=
+omponents.</p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow=
+-[0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-cente=
+r h-6 select-none px-2.5 cursor-pointer"><i class=3D"ai-Lightning leading-n=
+one not-italic w-[1em] h-[1em] inline-flex items-center justify-center shri=
+nk-0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrin=
+k: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 o=
+verflow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace=
+-nowrap">Designing</span><i class=3D"ai-CaretDown leading-none not-italic w=
+-[1em] h-[1em] inline-flex items-center justify-center text-om-text-tertiar=
+y shrink-0 transition-transform duration-150 rotate-0" style=3D"font-size: =
+12px;"></i></div></div></div><div class=3D"om-md-content"><div><p>Now the C=
+LAUDE.md to persist the system across future conversations.</p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow=
+-[0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-cente=
+r h-6 select-none px-2.5 cursor-pointer"><i class=3D"ai-Lightning leading-n=
+one not-italic w-[1em] h-[1em] inline-flex items-center justify-center shri=
+nk-0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrin=
+k: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 o=
+verflow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace=
+-nowrap">Writing</span><i class=3D"ai-CaretDown leading-none not-italic w-[=
+1em] h-[1em] inline-flex items-center justify-center text-om-text-tertiary =
+shrink-0 transition-transform duration-150 rotate-0" style=3D"font-size: 12=
+px;"></i></div></div><div class=3D"my-2 rounded-lg overflow-hidden bg-om-bg=
+-panel border-[0.5px] border-[var(--om-border-default)] shadow-[0_1px_2px_r=
+gba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-center h-6 select-=
+none px-2.5 cursor-pointer"><i class=3D"ai-Checklist leading-none not-itali=
+c w-[1em] h-[1em] inline-flex items-center justify-center shrink-0" style=
+=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrink: 0; margi=
+n-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 overflow-hid=
+den tabular-nums text-om-text-secondary text-ellipsis whitespace-nowrap">Up=
+dated todos</span><i class=3D"ai-CaretDown leading-none not-italic w-[1em] =
+h-[1em] inline-flex items-center justify-center text-om-text-tertiary shrin=
+k-0 transition-transform duration-150 rotate-180" style=3D"font-size: 12px;=
+"></i></div><div class=3D"border-t-[0.5px] border-[var(--om-border-default)=
+] py-2 px-2.5 bg-om-bg-panel"><div style=3D"display: flex; flex-direction: =
+column; gap: 2px;"><div style=3D"display: flex; align-items: center; gap: 6=
+px; font-size: 12px; font-weight: 400; padding: 4px 0px; color: var(--om-te=
+xt-disabled); text-decoration: line-through;"><span style=3D"width: 11px; h=
+eight: 11px; border-radius: 3px; flex-shrink: 0; border: 1.5px solid rgb(12=
+0, 140, 93); background: rgb(120, 140, 93); display: flex; align-items: cen=
+ter; justify-content: center; font-size: 7px; color: white; line-height: 1;=
+">=E2=9C=93</span>Rivus Design System reference page</div><div style=3D"dis=
+play: flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 40=
+0; padding: 4px 0px; color: var(--om-text-disabled); text-decoration: line-=
+through;"><span style=3D"width: 11px; height: 11px; border-radius: 3px; fle=
+x-shrink: 0; border: 1.5px solid rgb(120, 140, 93); background: rgb(120, 14=
+0, 93); display: flex; align-items: center; justify-content: center; font-s=
+ize: 7px; color: white; line-height: 1;">=E2=9C=93</span>CLAUDE.md with tok=
+en rules</div></div></div></div><div class=3D"my-2 rounded-lg overflow-hidd=
+en bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow-[=
+0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-center =
+h-6 select-none px-2.5 cursor-pointer"><i class=3D"ai-Lightning leading-non=
+e not-italic w-[1em] h-[1em] inline-flex items-center justify-center shrink=
+-0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrink:=
+ 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 ove=
+rflow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace-n=
+owrap">Finishing up</span><i class=3D"ai-CaretDown leading-none not-italic =
+w-[1em] h-[1em] inline-flex items-center justify-center text-om-text-tertia=
+ry shrink-0 transition-transform duration-150 rotate-0" style=3D"font-size:=
+ 12px;"></i></div></div></div><div class=3D"om-md-content"><div><p>Done. Bu=
+ilt option (b) =E2=80=94 the Rivus design system is now three reusable arti=
+facts:</p>
+<p><strong><code>Rivus Design System.dc.html</code></strong> =E2=80=94 the =
+canonical reference page: color tokens (brand/surface/status/text), the Mon=
+tserrat type scale, the signature gradient, radius scale, and live previews=
+ of every component with its prop list and button recipes.</p>
+<p><strong>5 component DCs</strong> =E2=80=94 <code>RivusPill</code>, <code=
+>MetricCard</code>, <code>StatusBadge</code>, <code>Avatar</code>, <code>Br=
+iefingBanner</code>, each with editor props/tweaks. Mount in any new screen=
+ via <code>&lt;dc-import name=3D"MetricCard" value=3D"38" ... hint-size=3D"=
+=E2=80=A6"&gt;</code>.</p>
+<p><strong><code>CLAUDE.md</code></strong> =E2=80=94 persists the tokens, c=
+omponent list, and conventions so every future build in this project stays =
+on-system automatically.</p>
+<p>Next time you want a new Rivus screen, I'll pull from these instead of r=
+e-deriving the styling. Want me to retrofit the existing <code>Rivus.dc.htm=
+l</code> to consume these components, or leave it as-is?</p>
+</div></div></div></div><div data-msgfb=3D"true" class=3D"mt-0.5 flex flex-=
+wrap items-center gap-0.5 transition-opacity duration-[120ms] pointer-event=
+s-auto opacity-100 focus-within:pointer-events-auto focus-within:opacity-10=
+0 om-no-hover:pointer-events-auto om-no-hover:opacity-100 om-coarse:pointer=
+-events-auto om-coarse:opacity-100 [&amp;_button:focus-visible]:outline-2 [=
+&amp;_button:focus-visible]:outline-om-accent-primary [&amp;_button:focus-v=
+isible]:-outline-offset-2"><button class=3D"flex cursor-default select-none=
+ items-center justify-center rounded-md p-0 text-om-text-secondary outline-=
+none disabled:cursor-not-allowed disabled:opacity-30 bg-transparent hover:b=
+g-om-bg-hover active:bg-om-bg-active border border-transparent" title=3D"Go=
+od response" aria-pressed=3D"false" style=3D"width: 24px; height: 24px;"><i=
+ class=3D"ai-ThumbsUp leading-none not-italic w-[1em] h-[1em] inline-flex i=
+tems-center justify-center shrink-0" style=3D"font-size: 14px;"></i></butto=
+n><button class=3D"flex cursor-default select-none items-center justify-cen=
+ter rounded-md p-0 text-om-text-secondary outline-none disabled:cursor-not-=
+allowed disabled:opacity-30 bg-transparent hover:bg-om-bg-hover active:bg-o=
+m-bg-active border border-transparent" title=3D"Bad response" aria-pressed=
+=3D"false" style=3D"width: 24px; height: 24px;"><i class=3D"ai-ThumbsDown l=
+eading-none not-italic w-[1em] h-[1em] inline-flex items-center justify-cen=
+ter shrink-0" style=3D"font-size: 14px;"></i></button><span title=3D"Create=
+d 7 files" class=3D"min-w-0 flex-1 overflow-hidden text-ellipsis whitespace=
+-nowrap text-[11px] font-medium text-om-text-tertiary [&amp;:not(:first-chi=
+ld)]:ml-2 no-underline">Created 7 files</span><span aria-live=3D"polite" cl=
+ass=3D"[&amp;:not(:empty)]:w-full [&amp;&gt;a]:ml-0"></span></div></div></d=
+iv><div data-index=3D"4" style=3D"position: absolute; top: 0px; left: 0px; =
+width: 100%; transform: translateY(2797px);"><div class=3D"mb-3.5 flex flex=
+-col items-end"><div class=3D"select-text [overflow-wrap:break-word] break-=
+words min-w-0 py-2 px-3 max-w-[85%] w-fit text-left" style=3D"background: v=
+ar(--om-bg-surface); border: 0.5px solid var(--om-border-default); border-r=
+adius: 8px; box-shadow: rgba(0, 0, 0, 0.04) 0px 1px 2px;"><span style=3D"fo=
+nt-size: 13px; color: var(--om-text-primary); line-height: 1.6; white-space=
+: pre-wrap;">how do I add this to the repo so claude knows what to use?</sp=
+an></div></div></div><div data-index=3D"5" style=3D"position: absolute; top=
+: 0px; left: 0px; width: 100%; transform: translateY(2871px);"><div class=
+=3D"om-assistant-group"><div class=3D"mb-3.5"><div class=3D"select-text [ov=
+erflow-wrap:break-word] break-words min-w-0"><div class=3D"my-1.5"></div><d=
+iv class=3D"om-md-content"><div><p>Two layers =E2=80=94 one's already done,=
+ the other depends on where "the repo" lives.</p>
+<p><strong>1. Within this project =E2=80=94 already handled.</strong> The <=
+code>CLAUDE.md</code> I wrote at the project root is the mechanism. It's au=
+to-loaded as instructions at the start of <em>every</em> conversation here,=
+ so Claude reads the tokens, the 5 component names, and the conventions bef=
+ore touching any Rivus screen =E2=80=94 no need to re-attach or remind. Tha=
+t file <em>is</em> "telling Claude what to use." Keep it at the root and ke=
+ep it current as the system grows.</p>
+<p><strong>2. Into an actual external git repo.</strong> If by "the repo" y=
+ou mean your own GitHub/git project (not this workspace), you need to get t=
+hese files into it:</p>
+<ul>
+<li>The files to carry over: <code>CLAUDE.md</code>, <code>Rivus Design Sys=
+tem.dc.html</code>, the 5 component DCs (<code>RivusPill</code>/<code>Metri=
+cCard</code>/<code>StatusBadge</code>/<code>Avatar</code>/<code>BriefingBan=
+ner</code>.dc.html), <code>support.js</code>, and the <code>assets/</code> =
+folder.</li>
+<li><code>CLAUDE.md</code> is the convention Claude Code (and this tool) bo=
+th read automatically from a repo root, so committing it there means Claude=
+ knows the system anywhere that repo is opened.</li>
+</ul>
+<p>I can do the handoff for you a couple of ways:</p>
+<ul>
+<li><strong>Connect GitHub</strong> and I'll push these files straight into=
+ a repo/branch.</li>
+<li><strong>Download a bundle</strong> of the design-system files to commit=
+ yourself.</li>
+<li><strong>Handoff to Claude Code</strong> package, if you're moving this =
+into a dev workflow.</li>
+</ul>
+<p>Which do you want? If it's GitHub, say the word and I'll start the conne=
+ct flow.</p>
+</div></div></div></div><div data-msgfb=3D"true" class=3D"mt-0.5 flex flex-=
+wrap items-center gap-0.5 transition-opacity duration-[120ms] pointer-event=
+s-none opacity-0 focus-within:pointer-events-auto focus-within:opacity-100 =
+om-no-hover:pointer-events-auto om-no-hover:opacity-100 om-coarse:pointer-e=
+vents-auto om-coarse:opacity-100 [&amp;_button:focus-visible]:outline-2 [&a=
+mp;_button:focus-visible]:outline-om-accent-primary [&amp;_button:focus-vis=
+ible]:-outline-offset-2"><button class=3D"flex cursor-default select-none i=
+tems-center justify-center rounded-md p-0 text-om-text-secondary outline-no=
+ne disabled:cursor-not-allowed disabled:opacity-30 bg-transparent hover:bg-=
+om-bg-hover active:bg-om-bg-active border border-transparent" title=3D"Good=
+ response" aria-pressed=3D"false" style=3D"width: 24px; height: 24px;"><i c=
+lass=3D"ai-ThumbsUp leading-none not-italic w-[1em] h-[1em] inline-flex ite=
+ms-center justify-center shrink-0" style=3D"font-size: 14px;"></i></button>=
+<button class=3D"flex cursor-default select-none items-center justify-cente=
+r rounded-md p-0 text-om-text-secondary outline-none disabled:cursor-not-al=
+lowed disabled:opacity-30 bg-transparent hover:bg-om-bg-hover active:bg-om-=
+bg-active border border-transparent" title=3D"Bad response" aria-pressed=3D=
+"false" style=3D"width: 24px; height: 24px;"><i class=3D"ai-ThumbsDown lead=
+ing-none not-italic w-[1em] h-[1em] inline-flex items-center justify-center=
+ shrink-0" style=3D"font-size: 14px;"></i></button><span aria-live=3D"polit=
+e" class=3D""></span></div></div></div><div data-index=3D"6" style=3D"posit=
+ion: absolute; top: 0px; left: 0px; width: 100%; transform: translateY(3729=
+px);"><div class=3D"mb-3.5 flex flex-col items-end"><div class=3D"select-te=
+xt [overflow-wrap:break-word] break-words min-w-0 py-2 px-3 max-w-[85%] w-f=
+it text-left" style=3D"background: var(--om-bg-surface); border: 0.5px soli=
+d var(--om-border-default); border-radius: 8px; box-shadow: rgba(0, 0, 0, 0=
+.04) 0px 1px 2px;"><span style=3D"font-size: 13px; color: var(--om-text-pri=
+mary); line-height: 1.6; white-space: pre-wrap;">Save as standalone HTML: R=
+ivus Design System.dc.html</span><div class=3D"flex flex-wrap items-start g=
+ap-1.5 mt-2"><div class=3D"group inline-flex items-center font-medium borde=
+r rounded-lg shadow-[0_1px_2px_rgba(0,0,0,0.04)] min-w-0 shrink gap-1 py-0.=
+5 px-1.5 text-[10px] bg-om-bg-panel border-om-border-default text-om-text-s=
+econdary" title=3D"Export the current design as a single self-contained HTM=
+L file that works completely offline =E2=80=94 no external dependencies.
+
+## How it works
+
+There is a deterministic bundler (super_inline_html tool) that can inline r=
+esources referenced directly in HTML attributes =E2=80=94 img src/srcset, s=
+ource src/srcset, video/audio/track src, video poster, SVG `&lt;image href&=
+gt;`/`&lt;use href&gt;`, link href (stylesheets, favicons), script src, CSS=
+ url() and @import, inline style attributes. However, it CANNOT discover re=
+sources that are only referenced as strings in JavaScript or JSX code =E2=
+=80=94 for example:
+- An image src set in React: `&lt;img src=3D{&quot;./hero.png&quot;} /&gt;`
+- A background URL in a styled-component: `background: url('./pattern.svg')=
+`
+- A dynamically imported script
+
+Your job is to prepare the HTML file so the bundler c=E2=80=A6"><span class=
+=3D"truncate">Save as standalone HTML</span></div></div></div></div></div><=
+div data-index=3D"7" style=3D"position: absolute; top: 0px; left: 0px; widt=
+h: 100%; transform: translateY(3828px);"><div class=3D"om-assistant-group">=
+<div class=3D"mb-3.5"><div class=3D"select-text [overflow-wrap:break-word] =
+break-words min-w-0"><div class=3D"om-md-content"><div><p>I'll prepare the =
+standalone export. First let me look at the file structure to understand wh=
+at needs bundling.</p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow=
+-[0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-cente=
+r h-6 select-none px-2.5 cursor-pointer"><i class=3D"ai-Lightning leading-n=
+one not-italic w-[1em] h-[1em] inline-flex items-center justify-center shri=
+nk-0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrin=
+k: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 o=
+verflow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace=
+-nowrap">Reading</span><i class=3D"ai-CaretDown leading-none not-italic w-[=
+1em] h-[1em] inline-flex items-center justify-center text-om-text-tertiary =
+shrink-0 transition-transform duration-150 rotate-0" style=3D"font-size: 12=
+px;"></i></div></div></div><div class=3D"om-md-content"><div><p>Let me add =
+the required thumbnail template, then bundle.</p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow=
+-[0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-cente=
+r h-6 select-none px-2.5 cursor-pointer"><i class=3D"ai-Lightning leading-n=
+one not-italic w-[1em] h-[1em] inline-flex items-center justify-center shri=
+nk-0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrin=
+k: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 o=
+verflow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace=
+-nowrap">Editing, Generating HTML</span><i class=3D"ai-CaretDown leading-no=
+ne not-italic w-[1em] h-[1em] inline-flex items-center justify-center text-=
+om-text-tertiary shrink-0 transition-transform duration-150 rotate-0" style=
+=3D"font-size: 12px;"></i></div></div><div class=3D"my-2 rounded-lg overflo=
+w-hidden bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] sh=
+adow-[0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-c=
+enter h-6 select-none px-2.5 cursor-pointer"><i class=3D"ai-File leading-no=
+ne not-italic w-[1em] h-[1em] inline-flex items-center justify-center shrin=
+k-0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrink=
+: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 ov=
+erflow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace-=
+nowrap">Rivus Design System (standalone).html</span><i class=3D"ai-ArrowOut=
+Square leading-none not-italic w-[1em] h-[1em] inline-flex items-center jus=
+tify-center text-om-text-tertiary shrink-0 transition-transform duration-15=
+0 rotate-0" style=3D"font-size: 12px;"></i></div></div></div><div class=3D"=
+om-md-content"><div><p>This is a bundle-correctness check (dc-import childr=
+en are fetched at runtime), so I do need to verify it visually.</p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow=
+-[0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-cente=
+r h-6 select-none px-2.5 cursor-pointer"><i class=3D"ai-File leading-none n=
+ot-italic w-[1em] h-[1em] inline-flex items-center justify-center shrink-0"=
+ style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrink: 0;=
+ margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 overfl=
+ow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace-nowr=
+ap">Rivus Design System (standalone).html</span><i class=3D"ai-ArrowOutSqua=
+re leading-none not-italic w-[1em] h-[1em] inline-flex items-center justify=
+-center text-om-text-tertiary shrink-0 transition-transform duration-150 ro=
+tate-0" style=3D"font-size: 12px;"></i></div></div></div><div class=3D"om-m=
+d-content"><div><p>Header and tokens render. Let me verify the dc-import co=
+mponents rendered (the runtime-fetched children are the risk).</p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow=
+-[0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-cente=
+r h-6 select-none px-2.5 cursor-pointer"><i class=3D"ai-Lightning leading-n=
+one not-italic w-[1em] h-[1em] inline-flex items-center justify-center shri=
+nk-0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrin=
+k: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 o=
+verflow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace=
+-nowrap">Screenshot =C3=972</span><i class=3D"ai-CaretDown leading-none not=
+-italic w-[1em] h-[1em] inline-flex items-center justify-center text-om-tex=
+t-tertiary shrink-0 transition-transform duration-150 rotate-0" style=3D"fo=
+nt-size: 12px;"></i></div></div></div><div class=3D"om-md-content"><div><p>=
+The dc-import children bundled and render. Let me confirm the middle sectio=
+n (briefing banner + its inlined symbol SVG) and check for errors.</p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow=
+-[0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-cente=
+r h-6 select-none px-2.5 cursor-pointer"><i class=3D"ai-Lightning leading-n=
+one not-italic w-[1em] h-[1em] inline-flex items-center justify-center shri=
+nk-0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrin=
+k: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 o=
+verflow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace=
+-nowrap">Screenshot, Reading logs</span><i class=3D"ai-CaretDown leading-no=
+ne not-italic w-[1em] h-[1em] inline-flex items-center justify-center text-=
+om-text-tertiary shrink-0 transition-transform duration-150 rotate-0" style=
+=3D"font-size: 12px;"></i></div></div></div><div class=3D"om-md-content"><d=
+iv><p>Everything bundled cleanly =E2=80=94 components, the inlined Rivus sy=
+mbol/wordmark SVGs, fonts, no console errors. Here's the standalone file:</=
+p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-[#2C2C2A] shadow-[0_2px_8px_rgba(0,0,0,0.18),0_1px_3px_rgba(0,0,0,0=
+.12)] transition-all duration-150 hover:bg-[#3A3A38]"><div class=3D"flex mi=
+n-h-6 gap-2 items-center h-6 select-none px-3 cursor-pointer"><i class=3D"a=
+i-Download leading-none not-italic w-[1em] h-[1em] inline-flex items-center=
+ justify-center shrink-0" style=3D"font-size: 14px; color: rgb(250, 249, 24=
+5); flex-shrink: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-m=
+edium flex-1 overflow-hidden tabular-nums text-[#FAF9F5] text-ellipsis whit=
+espace-nowrap">Download Rivus Design System =E2=80=94 standalone HTML</span=
+></div></div></div><div class=3D"om-md-content"><div><p>Single self-contain=
+ed file =E2=80=94 opens offline anywhere, no dependencies. Components, bran=
+d SVGs, and fonts are all inlined.</p>
+</div></div></div></div><div data-msgfb=3D"true" class=3D"mt-0.5 flex flex-=
+wrap items-center gap-0.5 transition-opacity duration-[120ms] pointer-event=
+s-auto opacity-100 focus-within:pointer-events-auto focus-within:opacity-10=
+0 om-no-hover:pointer-events-auto om-no-hover:opacity-100 om-coarse:pointer=
+-events-auto om-coarse:opacity-100 [&amp;_button:focus-visible]:outline-2 [=
+&amp;_button:focus-visible]:outline-om-accent-primary [&amp;_button:focus-v=
+isible]:-outline-offset-2"><button class=3D"flex cursor-default select-none=
+ items-center justify-center rounded-md p-0 text-om-text-secondary outline-=
+none disabled:cursor-not-allowed disabled:opacity-30 bg-transparent hover:b=
+g-om-bg-hover active:bg-om-bg-active border border-transparent" title=3D"Go=
+od response" aria-pressed=3D"false" style=3D"width: 24px; height: 24px;"><i=
+ class=3D"ai-ThumbsUp leading-none not-italic w-[1em] h-[1em] inline-flex i=
+tems-center justify-center shrink-0" style=3D"font-size: 14px;"></i></butto=
+n><button class=3D"flex cursor-default select-none items-center justify-cen=
+ter rounded-md p-0 text-om-text-secondary outline-none disabled:cursor-not-=
+allowed disabled:opacity-30 bg-transparent hover:bg-om-bg-hover active:bg-o=
+m-bg-active border border-transparent" title=3D"Bad response" aria-pressed=
+=3D"false" style=3D"width: 24px; height: 24px;"><i class=3D"ai-ThumbsDown l=
+eading-none not-italic w-[1em] h-[1em] inline-flex items-center justify-cen=
+ter shrink-0" style=3D"font-size: 14px;"></i></button><span title=3D"Edited=
+ 2 files" class=3D"min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-=
+nowrap text-[11px] font-medium text-om-text-tertiary [&amp;:not(:first-chil=
+d)]:ml-2 no-underline">Edited 2 files</span><span aria-live=3D"polite" clas=
+s=3D"[&amp;:not(:empty)]:w-full [&amp;&gt;a]:ml-0"></span></div></div></div=
+><div data-index=3D"8" style=3D"position: absolute; top: 0px; left: 0px; wi=
+dth: 100%; transform: translateY(4618px);"><div class=3D"mb-3.5 flex flex-c=
+ol items-end"><div class=3D"select-text [overflow-wrap:break-word] break-wo=
+rds min-w-0 py-2 px-3 max-w-[85%] w-fit text-left" style=3D"background: var=
+(--om-bg-surface); border: 0.5px solid var(--om-border-default); border-rad=
+ius: 8px; box-shadow: rgba(0, 0, 0, 0.04) 0px 1px 2px;"><span style=3D"font=
+-size: 13px; color: var(--om-text-primary); line-height: 1.6; white-space: =
+pre-wrap;">Save as standalone HTML: Rivus Design System.dc.html</span><div =
+class=3D"flex flex-wrap items-start gap-1.5 mt-2"><div class=3D"group inlin=
+e-flex items-center font-medium border rounded-lg shadow-[0_1px_2px_rgba(0,=
+0,0,0.04)] min-w-0 shrink gap-1 py-0.5 px-1.5 text-[10px] bg-om-bg-panel bo=
+rder-om-border-default text-om-text-secondary" title=3D"Export the current =
+design as a single self-contained HTML file that works completely offline =
+=E2=80=94 no external dependencies.
+
+## How it works
+
+There is a deterministic bundler (super_inline_html tool) that can inline r=
+esources referenced directly in HTML attributes =E2=80=94 img src/srcset, s=
+ource src/srcset, video/audio/track src, video poster, SVG `&lt;image href&=
+gt;`/`&lt;use href&gt;`, link href (stylesheets, favicons), script src, CSS=
+ url() and @import, inline style attributes. However, it CANNOT discover re=
+sources that are only referenced as strings in JavaScript or JSX code =E2=
+=80=94 for example:
+- An image src set in React: `&lt;img src=3D{&quot;./hero.png&quot;} /&gt;`
+- A background URL in a styled-component: `background: url('./pattern.svg')=
+`
+- A dynamically imported script
+
+Your job is to prepare the HTML file so the bundler c=E2=80=A6"><span class=
+=3D"truncate">Save as standalone HTML</span></div></div></div></div></div><=
+div data-index=3D"9" style=3D"position: absolute; top: 0px; left: 0px; widt=
+h: 100%; transform: translateY(4717px);"><div class=3D"om-assistant-group">=
+<div class=3D"mb-3.5"><div class=3D"select-text [overflow-wrap:break-word] =
+break-words min-w-0"><div class=3D"om-md-content"><div><p>The source alread=
+y has the thumbnail and no code-referenced resources, and the bundle was ju=
+st generated cleanly last turn. Re-running to refresh, then presenting.</p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow=
+-[0_1px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-cente=
+r h-6 select-none px-2.5 cursor-pointer"><i class=3D"ai-Lightning leading-n=
+one not-italic w-[1em] h-[1em] inline-flex items-center justify-center shri=
+nk-0" style=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrin=
+k: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 o=
+verflow-hidden tabular-nums text-om-text-secondary text-ellipsis whitespace=
+-nowrap">Generating HTML</span><i class=3D"ai-CaretDown leading-none not-it=
+alic w-[1em] h-[1em] inline-flex items-center justify-center text-om-text-t=
+ertiary shrink-0 transition-transform duration-150 rotate-0" style=3D"font-=
+size: 12px;"></i></div></div><div class=3D"my-2 rounded-lg overflow-hidden =
+bg-om-bg-panel border-[0.5px] border-[var(--om-border-default)] shadow-[0_1=
+px_2px_rgba(0,0,0,0.04)]"><div class=3D"flex min-h-6 gap-2 items-center h-6=
+ select-none px-2.5 cursor-pointer"><i class=3D"ai-File leading-none not-it=
+alic w-[1em] h-[1em] inline-flex items-center justify-center shrink-0" styl=
+e=3D"font-size: 14px; color: var(--om-text-secondary); flex-shrink: 0; marg=
+in-top: 0px;"></i><span class=3D"text-[11px] font-medium flex-1 overflow-hi=
+dden tabular-nums text-om-text-secondary text-ellipsis whitespace-nowrap">R=
+ivus Design System (standalone).html</span><i class=3D"ai-ArrowOutSquare le=
+ading-none not-italic w-[1em] h-[1em] inline-flex items-center justify-cent=
+er text-om-text-tertiary shrink-0 transition-transform duration-150 rotate-=
+0" style=3D"font-size: 12px;"></i></div></div></div><div class=3D"om-md-con=
+tent"><div><p>Bundle is unchanged from last turn's verified-clean export. P=
+resenting for download.</p>
+</div></div><div class=3D"my-1.5"><div class=3D"my-2 rounded-lg overflow-hi=
+dden bg-[#2C2C2A] shadow-[0_2px_8px_rgba(0,0,0,0.18),0_1px_3px_rgba(0,0,0,0=
+.12)] transition-all duration-150 hover:bg-[#3A3A38]"><div class=3D"flex mi=
+n-h-6 gap-2 items-center h-6 select-none px-3 cursor-pointer"><i class=3D"a=
+i-Download leading-none not-italic w-[1em] h-[1em] inline-flex items-center=
+ justify-center shrink-0" style=3D"font-size: 14px; color: rgb(250, 249, 24=
+5); flex-shrink: 0; margin-top: 0px;"></i><span class=3D"text-[11px] font-m=
+edium flex-1 overflow-hidden tabular-nums text-[#FAF9F5] text-ellipsis whit=
+espace-nowrap">Download Rivus Design System =E2=80=94 standalone HTML</span=
+></div></div></div><div class=3D"om-md-content"><div><p>Single self-contain=
+ed file =E2=80=94 works offline, all components, brand SVGs, and fonts inli=
+ned.</p>
+</div></div></div></div><div data-msgfb=3D"true" class=3D"mt-0.5 flex flex-=
+wrap items-center gap-0.5 transition-opacity duration-[120ms] pointer-event=
+s-auto opacity-100 focus-within:pointer-events-auto focus-within:opacity-10=
+0 om-no-hover:pointer-events-auto om-no-hover:opacity-100 om-coarse:pointer=
+-events-auto om-coarse:opacity-100 [&amp;_button:focus-visible]:outline-2 [=
+&amp;_button:focus-visible]:outline-om-accent-primary [&amp;_button:focus-v=
+isible]:-outline-offset-2"><button class=3D"flex cursor-default select-none=
+ items-center justify-center rounded-md p-0 text-om-text-secondary outline-=
+none disabled:cursor-not-allowed disabled:opacity-30 bg-transparent hover:b=
+g-om-bg-hover active:bg-om-bg-active border border-transparent" title=3D"Go=
+od response" aria-pressed=3D"false" style=3D"width: 24px; height: 24px;"><i=
+ class=3D"ai-ThumbsUp leading-none not-italic w-[1em] h-[1em] inline-flex i=
+tems-center justify-center shrink-0" style=3D"font-size: 14px;"></i></butto=
+n><button class=3D"flex cursor-default select-none items-center justify-cen=
+ter rounded-md p-0 text-om-text-secondary outline-none disabled:cursor-not-=
+allowed disabled:opacity-30 bg-transparent hover:bg-om-bg-hover active:bg-o=
+m-bg-active border border-transparent" title=3D"Bad response" aria-pressed=
+=3D"false" style=3D"width: 24px; height: 24px;"><i class=3D"ai-ThumbsDown l=
+eading-none not-italic w-[1em] h-[1em] inline-flex items-center justify-cen=
+ter shrink-0" style=3D"font-size: 14px;"></i></button><span title=3D"Edited=
+ Rivus Design System (standalone).html" class=3D"min-w-0 flex-1 overflow-hi=
+dden text-ellipsis whitespace-nowrap text-[11px] font-medium text-om-text-t=
+ertiary [&amp;:not(:first-child)]:ml-2 no-underline">Edited Rivus Design Sy=
+stem (standalone).html</span><div class=3D"ml-auto inline-flex"><button typ=
+e=3D"button" aria-label=3D"Undo this turn=E2=80=99s file changes" class=3D"=
+cursor-default whitespace-nowrap bg-transparent px-1.5 py-1 text-[11px] fon=
+t-medium text-om-text-tertiary enabled:hover:text-om-accent-primary-hover d=
+isabled:pointer-events-none disabled:text-om-text-disabled focus-visible:ro=
+unded-[2px] focus-visible:outline-2 focus-visible:-outline-offset-2 focus-v=
+isible:outline-om-accent-primary">Undo</button></div><span aria-live=3D"pol=
+ite" class=3D"[&amp;:not(:empty)]:w-full [&amp;&gt;a]:ml-0"></span></div></=
+div></div></div></div></div><div class=3D"p-0 pt-0 [contain:layout_style]">=
+<div class=3D"bg-om-bg-surface border border-om-border-default shadow-om-sm=
+ relative z-10 rounded-[14px] p-3"><div style=3D"position: relative; margin=
+-bottom: 6px;"><div class=3D"om-rich-input" style=3D"--om-ri-min-rows: 3; -=
+-om-ri-max-rows: 8;"><div contenteditable=3D"true" role=3D"textbox" aria-mu=
+ltiline=3D"true" aria-label=3D"Describe what you want to create..." data-te=
+stid=3D"chat-composer-input" translate=3D"no" class=3D"ProseMirror"><p data=
+-placeholder=3D"Describe what you want to create..." class=3D"is-empty"><br=
+ class=3D"ProseMirror-trailingBreak"></p></div></div></div><div class=3D"fl=
+ex items-center justify-between [container-type:inline-size]"><div class=3D=
+"flex gap-1.5 items-center"><div style=3D"display: inline-flex;"><button cl=
+ass=3D"flex cursor-default select-none items-center justify-center rounded-=
+md p-0 text-om-text-secondary outline-none disabled:cursor-not-allowed disa=
+bled:opacity-30 bg-om-bg-surface hover:bg-om-bg-hover active:bg-om-bg-activ=
+e border border-om-border-default shadow-om-xs" title=3D"Add to chat" data-=
+testid=3D"composer-import-button" style=3D"width: 28px; height: 28px;"><i c=
+lass=3D"ai-Add leading-none not-italic w-[1em] h-[1em] inline-flex items-ce=
+nter justify-center shrink-0" style=3D"font-size: 14px;"></i></button></div=
+><button class=3D"flex cursor-default select-none items-center justify-cent=
+er rounded-md p-0 text-om-text-secondary outline-none disabled:cursor-not-a=
+llowed disabled:opacity-30 bg-om-bg-surface hover:bg-om-bg-hover active:bg-=
+om-bg-active border border-om-border-default shadow-om-xs" title=3D"Start v=
+oice input (=E2=8C=98G tap or hold)" data-testid=3D"live-voice-mic-button" =
+style=3D"width: 28px; height: 28px;"><i class=3D"ai-Voice leading-none not-=
+italic w-[1em] h-[1em] inline-flex items-center justify-center shrink-0" st=
+yle=3D"font-size: 14px;"></i></button></div><div class=3D"flex gap-1.5 item=
+s-center min-w-0"><div data-testid=3D"model-selector-button" class=3D"om-mo=
+del-picker-trigger"><button class=3D"relative inline-flex min-w-0 shrink cu=
+rsor-default select-none items-center justify-center overflow-hidden text-e=
+llipsis whitespace-nowrap border border-transparent font-medium outline-non=
+e disabled:cursor-not-allowed disabled:opacity-50 px-2 py-1 text-[11px] gap=
+-1 rounded-md bg-transparent hover:bg-om-bg-hover active:bg-om-bg-active te=
+xt-om-text-secondary" title=3D"Change model" style=3D"height: 28px;"><span =
+class=3D"inline-flex items-center gap-[inherit]"><span class=3D"min-w-0 ove=
+rflow-hidden text-ellipsis">Opus 4.8</span><span class=3D"shrink-0 text-om-=
+text-secondary opacity-50">High</span><i class=3D"ai-CaretDown leading-none=
+ not-italic w-[1em] h-[1em] inline-flex items-center justify-center shrink-=
+0" style=3D"font-size: 11px;"></i></span></button><button class=3D"flex cur=
+sor-default select-none items-center justify-center rounded-md p-0 text-om-=
+text-secondary outline-none disabled:cursor-not-allowed disabled:opacity-30=
+ bg-transparent hover:bg-om-bg-hover active:bg-om-bg-active border border-t=
+ransparent" title=3D"Change model" style=3D"width: 28px; height: 28px;"><i =
+class=3D"ai-Settings leading-none not-italic w-[1em] h-[1em] inline-flex it=
+ems-center justify-center shrink-0" style=3D"font-size: 14px;"></i></button=
+></div><button disabled=3D"" class=3D"relative inline-flex min-w-0 shrink c=
+ursor-default select-none items-center justify-center overflow-hidden text-=
+ellipsis whitespace-nowrap border font-medium outline-none disabled:cursor-=
+not-allowed disabled:opacity-50 px-3 py-1.5 text-xs gap-[5px] rounded-lg bg=
+-om-accent-primary hover:bg-om-accent-primary-hover active:bg-om-accent-pri=
+mary-active text-om-text-inverse border-[rgba(0,0,0,0.15)] shadow-[0_1px_3p=
+x_rgba(180,90,30,0.35),0_2px_6px_rgba(180,90,30,0.2),inset_0_1px_0_rgba(255=
+,255,255,0.15)]" title=3D"Send (Enter)" data-testid=3D"chat-send-button"><s=
+pan class=3D"inline-flex items-center gap-[inherit]"><i class=3D"ai-PaperPl=
+ane leading-none not-italic w-[1em] h-[1em] inline-flex items-center justif=
+y-center shrink-0" style=3D"font-size: 12px;"></i>Send</span></button></div=
+></div></div><div class=3D"cds-root text-primary contents" data-density=3D"=
+compact" data-mode=3D"light" data-platform=3D"web" data-font=3D"anthropic" =
+style=3D"font-size: var(--cds-font-size-body);"></div></div></div></div></d=
+iv></div></div></div></div><div class=3D"flex-1 min-w-0 flex flex-col bg-om=
+-bg-surface border border-om-border-card rounded-[14px] shadow-om-card over=
+flow-hidden relative z-[1]"><div class=3D"flex items-center gap-1.5 p-[7px_=
+10px] shrink-0 border-b border-om-border-subtle bg-om-bg-surface [-webkit-a=
+pp-region:drag] [&amp;_:is(button,a,input)]:[-webkit-app-region:no-drag]"><=
+div class=3D"flex items-center gap-1.5 shrink-0 overflow-hidden opacity-0 i=
+nvisible" style=3D"max-width: 0px; margin-right: -6px; transition: max-widt=
+h 0.28s cubic-bezier(0.4, 0, 0.2, 1), margin-right 0.28s cubic-bezier(0.4, =
+0, 0.2, 1), opacity 0.18s, visibility linear 0.28s;"><div class=3D"inline-f=
+lex"><a href=3D"https://claude.ai/design/" aria-label=3D"Back to projects" =
+class=3D"inline-flex items-center justify-center shrink-0 rounded-[4px] tex=
+t-om-accent-primary no-underline cursor-default hover:bg-om-bg-hover" style=
+=3D"width: 25px; height: 25px;"><svg width=3D"14" height=3D"14" viewBox=3D"=
+0 0 20 21" fill=3D"none" aria-hidden=3D"true"><path d=3D"M9.99902 0C15.5258=
+ 0.000170936 19.999 4.50643 19.999 10.0547C19.999 11.7656 19.5863 12.9976 1=
+8.7861 13.8203C17.9924 14.6362 16.9465 14.9138 15.9854 15.0078C15.05 15.099=
+3 14.0097 15.0262 13.2549 15.0186C12.8524 15.0145 12.5177 15.0267 12.2441 1=
+5.0703C11.9682 15.1144 11.8143 15.1813 11.7305 15.2432C11.4745 15.4322 11.3=
+353 15.7121 11.2656 16.1602C11.2303 16.3875 11.2168 16.6362 11.209 16.9131C=
+11.2017 17.1715 11.1986 17.4893 11.1807 17.7705C11.1469 18.2975 11.0495 19.=
+0865 10.4199 19.5908C9.7846 20.0996 8.88652 20.1057 7.85449 19.877C7.36399 =
+19.7682 6.88652 19.6232 6.42578 19.4453C2.66989 17.9949 0.000187748 14.3414=
+ 0 10.0547C0 4.50643 4.47223 0.000171048 9.99902 0ZM9.99902 1.60547C5.36781=
+ 1.60564 1.60547 5.38391 1.60547 10.0547C1.60566 13.6582 3.84823 16.7296 7.=
+00391 17.9482C7.39027 18.0974 7.79085 18.2184 8.20215 18.3096C9.1375 18.516=
+9 9.384 18.3633 9.41602 18.3379C9.4524 18.3087 9.54558 18.1915 9.5791 17.66=
+8C9.5947 17.4239 9.59473 17.1786 9.60352 16.8672C9.61179 16.5742 9.62831 16=
+.2435 9.67969 15.9131C9.78359 15.2455 10.0474 14.4906 10.7764 13.9521C11.14=
+79 13.6778 11.5842 13.5493 11.9912 13.4844C12.4007 13.4191 12.8434 13.4088 =
+13.2705 13.4131C14.1753 13.4222 15.0071 13.4905 15.8291 13.4102C16.6257 13.=
+3322 17.2249 13.1235 17.6357 12.7012C18.0401 12.2855 18.3935 11.5261 18.393=
+6 10.0547C18.3936 5.38391 14.6302 1.60564 9.99902 1.60547ZM5.11621 9.86719C=
+5.86386 9.91468 6.45486 10.5348 6.45508 11.2939C6.45506 12.0838 5.81519 12.=
+7245 5.02539 12.7246C4.28481 12.7246 3.67573 12.1617 3.60254 11.4404L3.5947=
+3 11.2939L3.60156 11.1533C3.66942 10.4596 4.23282 9.91186 4.93359 9.86719H5=
+.11621ZM14.9814 7.19141C15.729 7.23889 16.3199 7.85919 16.3203 8.61816C16.3=
+203 9.40801 15.6804 10.0487 14.8906 10.0488C14.1501 10.0487 13.5409 9.48586=
+ 13.4678 8.76465L13.46 8.61816L13.4668 8.47754C13.5348 7.78403 14.0983 7.23=
+618 14.7988 7.19141H14.9814ZM6.4541 4.93457C7.20161 4.9822 7.79275 5.60231 =
+7.79297 6.36133C7.79288 7.151 7.15291 7.7917 6.36328 7.79199C5.62274 7.7919=
+9 5.01369 7.22903 4.94043 6.50781L4.93262 6.36133L4.93945 6.2207C5.00731 5.=
+52698 5.5707 4.97922 6.27148 4.93457H6.4541ZM11.3867 3.59668C12.1343 3.6441=
+9 12.7253 4.26436 12.7256 5.02344C12.7256 5.81326 12.0857 6.45393 11.2959 6=
+.4541C10.5553 6.4541 9.94622 5.89123 9.87305 5.16992L9.86523 5.02344L9.8720=
+7 4.88281C9.93996 4.18912 10.5033 3.64133 11.2041 3.59668H11.3867Z" fill=3D=
+"currentColor"></path></svg></a></div><div class=3D"inline-flex"><button cl=
+ass=3D"flex cursor-default select-none items-center justify-center rounded =
+p-0 text-om-text-tertiary no-underline outline-none bg-transparent hover:bg=
+-om-bg-hover hover:text-om-text-secondary active:brightness-[.8] disabled:c=
+ursor-not-allowed disabled:opacity-30" aria-label=3D"Show sidebar" style=3D=
+"width: 25px; height: 25px;"><i class=3D"ai-Sidebar leading-none not-italic=
+ w-[1em] h-[1em] inline-flex items-center justify-center shrink-0" style=3D=
+"font-size: 14px; -webkit-text-stroke: 0.04em currentcolor;"></i></button><=
+/div></div><div id=3D"viewer-actions-leading" class=3D"inline-flex items-ce=
+nter gap-1.5 empty:hidden"><div class=3D"inline-flex"><button class=3D"flex=
+ cursor-default select-none items-center justify-center rounded p-0 text-om=
+-text-tertiary no-underline outline-none bg-transparent hover:bg-om-bg-hove=
+r hover:text-om-text-secondary active:brightness-[.8] disabled:cursor-not-a=
+llowed disabled:opacity-30" aria-label=3D"Reload" data-testid=3D"reload" st=
+yle=3D"width: 25px; height: 25px;"><i class=3D"ai-Reload leading-none not-i=
+talic w-[1em] h-[1em] inline-flex items-center justify-center shrink-0" sty=
+le=3D"font-size: 14px; -webkit-text-stroke: 0.04em currentcolor;"></i></but=
+ton></div></div><div class=3D"inline-flex min-w-0 [&amp;&gt;div]:min-w-0 [&=
+amp;&gt;div&gt;button]:border-transparent [&amp;&gt;div&gt;button]:shadow-n=
+one [&amp;&gt;div&gt;button]:shrink [&amp;&gt;div&gt;button]:min-w-0 [&amp;=
+&gt;div&gt;button]:max-w-none"><div class=3D"inline-flex min-w-0"><button c=
+lass=3D"inline-flex items-center gap-[7px] h-[29px] max-w-[260px] pr-[9px] =
+pl-2.5 rounded-[7px] border text-om-text-primary text-xs font-medium leadin=
+g-none cursor-default shrink-0 transition-colors duration-[120ms] hover:bor=
+der-om-border-strong border-om-border-default bg-om-bg-surface shadow-om-xs=
+ hover:bg-om-bg-hover" type=3D"button" data-testid=3D"files-switcher-trigge=
+r" aria-expanded=3D"false" aria-haspopup=3D"menu"><span class=3D"inline-fle=
+x flex-col gap-0 min-w-0 text-left [&amp;&gt;.om-lockup-name]:leading-[1.1]=
+ [&amp;&gt;.om-lockup-name]:py-px"><span class=3D"om-lockup-name max-w-[160=
+px] truncate font-[550] leading-[1.5] pb-px">Rivus Design System (standalon=
+e)</span><span class=3D"text-[10px] font-[450] leading-none py-px text-om-t=
+ext-tertiary truncate">16 pages</span></span><span class=3D"inline-flex tex=
+t-om-text-tertiary ml-px transition-transform duration-150"><i class=3D"ai-=
+CaretDown leading-none not-italic w-[1em] h-[1em] inline-flex items-center =
+justify-center shrink-0" style=3D"font-size: 9px;"></i></span></button></di=
+v></div><div class=3D"flex-1 min-w-0"></div><div class=3D"inline-flex"><but=
+ton class=3D"relative inline-flex min-w-0 shrink cursor-default select-none=
+ items-center justify-center overflow-hidden text-ellipsis whitespace-nowra=
+p border border-transparent font-medium outline-none disabled:cursor-not-al=
+lowed disabled:opacity-50 px-2 py-1 text-[11px] gap-1 rounded-md bg-transpa=
+rent hover:bg-om-bg-hover active:bg-om-bg-active text-om-text-secondary" ar=
+ia-label=3D"Mark up" aria-keyshortcuts=3D"M" data-testid=3D"mode-chat-about=
+"><span class=3D"inline-flex items-center gap-[inherit]">Mark up</span></bu=
+tton></div><div class=3D"inline-flex"><button class=3D"relative inline-flex=
+ min-w-0 shrink cursor-default select-none items-center justify-center over=
+flow-hidden text-ellipsis whitespace-nowrap border border-transparent font-=
+medium outline-none disabled:cursor-not-allowed disabled:opacity-50 px-2 py=
+-1 text-[11px] gap-1 rounded-md bg-transparent hover:bg-om-bg-hover active:=
+bg-om-bg-active text-om-text-secondary" aria-label=3D"Comments" aria-keysho=
+rtcuts=3D"C" data-testid=3D"mode-comment"><span class=3D"inline-flex items-=
+center gap-[inherit]">Comments</span></button></div><div class=3D"inline-fl=
+ex"><button class=3D"relative inline-flex min-w-0 shrink cursor-default sel=
+ect-none items-center justify-center overflow-hidden text-ellipsis whitespa=
+ce-nowrap border border-transparent font-medium outline-none disabled:curso=
+r-not-allowed disabled:opacity-50 px-2 py-1 text-[11px] gap-1 rounded-md bg=
+-transparent hover:bg-om-bg-hover active:bg-om-bg-active text-om-text-secon=
+dary" aria-label=3D"Edit" aria-keyshortcuts=3D"E" data-testid=3D"mode-edit"=
+><span class=3D"inline-flex items-center gap-[inherit]">Edit</span></button=
+></div><div id=3D"viewer-actions-before-modes" class=3D"inline-flex items-c=
+enter gap-1.5 empty:hidden"><div style=3D"position: relative; display: inli=
+ne-flex;"><div class=3D"inline-flex"><button class=3D"relative inline-flex =
+min-w-0 shrink cursor-default select-none items-center justify-center overf=
+low-hidden text-ellipsis whitespace-nowrap border border-transparent font-m=
+edium outline-none disabled:cursor-not-allowed disabled:opacity-50 px-2 py-=
+1 text-[11px] gap-1 rounded-md bg-transparent hover:bg-om-bg-hover active:b=
+g-om-bg-active text-om-text-secondary" aria-keyshortcuts=3D"T" data-testid=
+=3D"request-tweaks-trigger"><span class=3D"inline-flex items-center gap-[in=
+herit]"><i class=3D"ai-Add leading-none not-italic w-[1em] h-[1em] inline-f=
+lex items-center justify-center shrink-0" style=3D"font-size: 11px;"></i>Tw=
+eaks</span></button></div></div></div><div id=3D"viewer-actions-trailing" c=
+lass=3D"inline-flex items-center gap-1.5 empty:hidden"><div style=3D"displa=
+y: inline-flex;"><div class=3D"inline-flex"><button class=3D"relative inlin=
+e-flex min-w-0 shrink cursor-default select-none items-center justify-cente=
+r overflow-hidden text-ellipsis whitespace-nowrap border border-transparent=
+ font-medium outline-none disabled:cursor-not-allowed disabled:opacity-50 p=
+x-2 py-1 text-[11px] gap-1 rounded-md bg-transparent hover:bg-om-bg-hover a=
+ctive:bg-om-bg-active text-om-text-secondary"><span class=3D"inline-flex it=
+ems-center gap-[inherit]"><span class=3D"inline-grid [&amp;&gt;*]:[grid-are=
+a:1/1]" style=3D"text-align: center;"><span class=3D"invisible select-none =
+pointer-events-none" aria-hidden=3D"true">888%</span><span>100%</span></spa=
+n></span></button></div></div></div><div id=3D"toolbar-present-slot" class=
+=3D"inline-flex items-center gap-1.5 empty:hidden"><div style=3D"display: i=
+nline-flex;"><button class=3D"relative inline-flex min-w-0 shrink cursor-de=
+fault select-none items-center justify-center overflow-hidden text-ellipsis=
+ whitespace-nowrap border border-transparent font-medium outline-none disab=
+led:cursor-not-allowed disabled:opacity-50 px-2 py-1 text-[11px] gap-1 roun=
+ded-md bg-transparent hover:bg-om-bg-hover active:bg-om-bg-active text-om-t=
+ext-secondary" title=3D"Present"><span class=3D"inline-flex items-center ga=
+p-[inherit]">Present<i class=3D"ai-CaretDown leading-none not-italic w-[1em=
+] h-[1em] inline-flex items-center justify-center shrink-0" style=3D"font-s=
+ize: 11px;"></i></span></button></div></div><div><button class=3D"relative =
+inline-flex min-w-0 shrink cursor-default select-none items-center justify-=
+center overflow-hidden text-ellipsis whitespace-nowrap border font-medium o=
+utline-none disabled:cursor-not-allowed disabled:opacity-50 px-2 py-1 text-=
+[11px] gap-1 rounded-md bg-om-accent-black hover:bg-om-accent-black-hover a=
+ctive:bg-om-accent-black-active text-om-text-inverse border-transparent sha=
+dow-om-sm"><span class=3D"inline-flex items-center gap-[inherit]">Share</sp=
+an></button></div><div class=3D"cds-root text-primary contents" data-densit=
+y=3D"compact" data-mode=3D"light" data-platform=3D"web" data-font=3D"anthro=
+pic" style=3D"font-size: var(--cds-font-size-body);"><button type=3D"button=
+" aria-label=3D"Account menu" title=3D"me@jaredwray.com" class=3D"appearanc=
+e-none outline-none bg-transparent p-0 m-0 inline-flex cursor-pointer round=
+ed-full focus-visible:shadow-[0_0_0_2px_var(--om-bg-selected)]" tabindex=3D=
+"0" aria-haspopup=3D"menu" id=3D"base-ui-_r_4_" aria-expanded=3D"false"><sp=
+an data-cds=3D"Avatar" class=3D"inline-flex shrink-0 select-none items-cent=
+er justify-center overflow-hidden rounded-full font-sans font-medium size-[=
+var(--cds-avatar-sm)] text-[9px] bg-fill-control text-primary" role=3D"img"=
+ aria-label=3D"Jared">J</span></button></div></div><div class=3D"flex-1 min=
+-h-0 flex flex-col overflow-hidden relative"><div class=3D"flex-1 flex flex=
+-col min-h-0 min-w-0"><div style=3D"display: contents;"><div class=3D"flex =
+h-full flex-col bg-om-bg-surface"><div class=3D"flex-1 flex flex-col min-h-=
+0 relative"><div class=3D"flex-1 min-h-0 flex flex-col"><div style=3D"displ=
+ay: flex; flex: 1 1 0%; min-height: 0px; overflow: hidden;"><div class=3D"r=
+elative flex-1 basis-0 overflow-hidden [overscroll-behavior:contain] bg-om-=
+bg-surface"><div style=3D"width: 100%; height: 100%; overflow: hidden;"><if=
+rame data-testid=3D"html-viewer-iframe" src=3D"cid:frame-5E4D2A899281B05ED9=
+2A00AB84008AD6@mhtml.blink" allow=3D"camera; microphone; geolocation" sandb=
+ox=3D"allow-scripts allow-forms allow-popups allow-modals allow-downloads a=
+llow-same-origin" style=3D"width: 100%; height: 100%; border-width: medium;=
+ border-style: none; border-color: currentcolor; border-image: initial; bac=
+kground: transparent; color-scheme: normal; opacity: 1; transition: opacity=
+ 120ms ease-out; transform: scale(1); transform-origin: left top;"></iframe=
+></div></div></div></div></div></div></div></div></div></div></div></div></=
+div></div></div></div></div><div class=3D"fixed bottom-5 left-1/2 -translat=
+e-x-1/2 z-om-toast flex flex-col items-center gap-2 pointer-events-none"></=
+div></div>
+  <iframe height=3D"1" width=3D"1" style=3D"position: absolute; top: 0px; l=
+eft: 0px; border-width: medium; border-style: none; border-color: currentco=
+lor; border-image: initial; visibility: hidden;"></iframe>
+
+</body></html>
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://claude.ai/design/assets/v1/ProjectPage-BnhONUSu.css
+
+@charset "utf-8";
+
+@keyframes om-share-skeleton-pulse {=20
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
+.om-share-skeleton { animation: 1.4s ease-in-out 0s infinite normal none ru=
+nning om-share-skeleton-pulse; }
+
+@media (prefers-reduced-motion: reduce) {
+  .om-share-skeleton { animation: auto ease 0s 1 normal none running none; =
+}
+}
+
+@keyframes om-followup-slide-in {=20
+  0% { opacity: 0; transform: translateY(8px); }
+  100% { opacity: 1; transform: translateY(0px); }
+}
+
+.om-followup-slide-in { animation: 0.2s cubic-bezier(0.4, 0, 0.2, 1) 0s 1 n=
+ormal none running om-followup-slide-in; }
+
+@keyframes om-spinner-slide-in {=20
+  0% { opacity: 0; transform: translateY(100%); }
+  100% { opacity: 1; transform: translateY(0px); }
+}
+
+@keyframes om-spinner-slide-out {=20
+  0% { opacity: 1; transform: translateY(0px); }
+  100% { opacity: 0; transform: translateY(-100%); }
+}
+
+.om-spinner-slide-in { animation: 0.28s ease 0s 1 normal forwards running o=
+m-spinner-slide-in; }
+
+.om-spinner-slide-out { animation: 0.28s ease 0s 1 normal forwards running =
+om-spinner-slide-out; }
+
+.om-chat-drag-over::after { content: "Drop files to attach"; border: 2px da=
+shed var(--om-accent-primary); color: var(--om-accent-primary); z-index: 10=
+0; pointer-events: none; background: rgba(217, 119, 87, 0.067); border-radi=
+us: 8px; justify-content: center; align-items: center; font-size: 14px; fon=
+t-weight: 500; display: flex; position: absolute; inset: 0px; }
+
+.om-chat-messages::-webkit-scrollbar { width: 8px; }
+
+.om-chat-messages::-webkit-scrollbar-track { background: 0px 0px; margin: 2=
+px; }
+
+.om-chat-messages::-webkit-scrollbar-thumb { background: padding-box conten=
+t-box; border: 2px solid rgba(0, 0, 0, 0); border-radius: 4px; }
+
+.om-chat-messages:hover::-webkit-scrollbar-thumb { background-image: ; back=
+ground-position-x: ; background-position-y: ; background-size: ; background=
+-repeat: ; background-attachment: ; background-origin: ; background-color: =
+; background-clip: content-box; border: 2px solid rgba(0, 0, 0, 0); }
+
+.om-chat-messages::-webkit-scrollbar-thumb:hover { background-image: ; back=
+ground-position-x: ; background-position-y: ; background-size: ; background=
+-repeat: ; background-attachment: ; background-origin: ; background-color: =
+; background-clip: content-box; border: 2px solid rgba(0, 0, 0, 0); }
+
+.om-assistant-group:hover [data-msgfb], .om-assistant-group:focus-within [d=
+ata-msgfb] { opacity: 1; pointer-events: auto; }
+
+.om-assistant-group:has([data-msgfb]) { margin-bottom: 14px; }
+
+.om-assistant-group:has([data-msgfb]) > :nth-last-child(2) { margin-bottom:=
+ 0px; }
+
+.om-md-content { color: var(--om-text-prose); overflow-wrap: break-word; wo=
+rd-break: break-word; font-family: "Anthropic Serif", Georgia, serif; font-=
+size: 13px; line-height: 1.65; }
+
+.om-md-content p { margin: 0px 0px 0.75em; }
+
+.om-md-content p:last-child { margin-bottom: 0px; }
+
+.om-md-content code { background: var(--om-bg-muted); word-break: break-all=
+; border-radius: 4px; padding: 2px 5px; font-family: "SF Mono", Monaco, Men=
+lo, monospace; font-size: 12px; }
+
+.om-md-content pre { background: var(--om-bg-muted); border: 1px solid var(=
+--om-border-subtle); border-radius: 8px; margin: 0.75em 0px; padding: 12px;=
+ overflow-x: auto; }
+
+.om-md-content pre code { word-break: normal; background: 0px 0px; padding:=
+ 0px; }
+
+.om-md-content strong, .om-md-content b { color: var(--om-text-primary); fo=
+nt-weight: 600; }
+
+.om-md-content em, .om-md-content i { font-style: italic; }
+
+.om-md-content h1, .om-md-content h2, .om-md-content h3, .om-md-content h4 =
+{ color: var(--om-text-primary); margin: 1em 0px 0.5em; font-weight: 600; }
+
+.om-md-content h1:first-child, .om-md-content h2:first-child, .om-md-conten=
+t h3:first-child, .om-md-content h4:first-child { margin-top: 0px; }
+
+.om-md-content h1 { font-size: 18px; }
+
+.om-md-content h2 { font-size: 16px; }
+
+.om-md-content h3 { font-size: 14px; }
+
+.om-md-content h4 { font-size: 13px; }
+
+.om-md-content ul, .om-md-content ol { margin: 0.5em 0px; padding-left: 1.5=
+em; }
+
+.om-md-content li { margin: 0.25em 0px; }
+
+.om-md-content a { color: var(--om-accent-primary); text-decoration: none; =
+}
+
+.om-md-content a:hover { text-decoration: underline; }
+
+.om-md-content blockquote { border-left: 3px solid var(--om-border-default)=
+; color: var(--om-text-tertiary); margin: 0.75em 0px; padding-left: 12px; }
+
+.om-md-content hr { border-top: 1px solid var(--om-border-default); margin:=
+ 1em 0px; }
+
+@keyframes om-thumb-shimmer {=20
+  0% { background-position: -200px 0px; }
+  100% { background-position: 200px 0px; }
+}
+
+.om-attachment-thumb { border: 1px solid var(--om-border-default); backgrou=
+nd-image: ; background-position-x: ; background-position-y: ; background-re=
+peat: ; background-attachment: ; background-origin: ; background-clip: ; ba=
+ckground-color: ; background-size: 400px 100%; border-radius: 8px; height: =
+64px; animation: 1.4s linear 0s infinite normal none running om-thumb-shimm=
+er; overflow: hidden; box-shadow: rgba(0, 0, 0, 0.04) 0px 1px 2px; }
+
+.om-attachment-thumb img { object-fit: cover; min-width: 40px; max-width: 1=
+28px; height: 100%; display: block; }
+
+@keyframes om-comment-slide-in {=20
+  0% { opacity: 0; transform: translateY(-6px); }
+  100% { opacity: 1; transform: translateY(0px); }
+}
+
+.om-comment-slide-in { animation: 0.28s cubic-bezier(0.4, 0, 0.2, 1) 0s 1 n=
+ormal none running om-comment-slide-in; }
+
+@keyframes om-skeleton-pulse {=20
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
+.om-skeleton-pulse { animation: 1.4s ease-in-out 0s infinite normal none ru=
+nning om-skeleton-pulse; }
+
+@media (prefers-reduced-motion: reduce) {
+  .om-skeleton-pulse { animation: auto ease 0s 1 normal none running none; =
+}
+}
+
+@keyframes om-cursor-blink {=20
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+.om-cursor-blink { animation: 0.8s step-end 0s infinite normal none running=
+ om-cursor-blink; }
+
+@keyframes om-ds-shimmer {=20
+  0% { background-position: 200% 0px; }
+  100% { background-position: -200% 0px; }
+}
+
+.om-ds-progress-indeterminate > div { background-image: ; background-positi=
+on-x: ; background-position-y: ; background-repeat: ; background-attachment=
+: ; background-origin: ; background-clip: ; background-color: ; background-=
+size: 200% 100%; animation: 1.2s linear 0s infinite normal none running om-=
+ds-shimmer; width: 100% !important; }
+
+.om-ds-progress-slow > div { animation-duration: 3.5s; }
+
+.om-ds-card-placeholder { background-image: ; background-position-x: ; back=
+ground-position-y: ; background-repeat: ; background-attachment: ; backgrou=
+nd-origin: ; background-clip: ; background-color: ; background-size: 200% 1=
+00%; animation: 1.6s linear 0s infinite normal none running om-ds-shimmer; =
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .om-ds-card-placeholder { background: var(--om-bg-surface); animation: au=
+to ease 0s 1 normal none running none; }
+}
+
+.om-ds-feedback-box.om-ds-feedback-box textarea { border: 1px solid var(--o=
+m-border-default); background: var(--om-bg-surface); box-sizing: border-box=
+; border-radius: 5px; padding: 5px 8px; }
+
+@container (width <=3D 1007px) {
+  nav.om-ds-outline-aside { display: none; }
+}
+
+.om-dc-color-input::-webkit-color-swatch-wrapper { padding: 0px; }
+
+.om-dc-color-input::-webkit-color-swatch { border: 0px; border-radius: 5px;=
+ }
+
+.om-dc-select { background-image: url("data:image/svg+xml;utf8,<svg xmlns=
+=3D'http://www.w3.org/2000/svg' width=3D'10' height=3D'6' viewBox=3D'0 0 10=
+ 6'><path fill=3D'rgba(0,0,0,.5)' d=3D'M0 0h10L5 6z'/></svg>"); }
+
+.om-dc-slider::-webkit-slider-thumb { appearance: none; background: var(--o=
+m-bg-elevated); border: .5px solid var(--om-border-default); border-radius:=
+ 50%; width: 14px; height: 14px; box-shadow: rgba(0, 0, 0, 0.2) 0px 1px 3px=
+; }
+
+.om-dc-num input[type=3D"number"] { }
+
+.om-dc-num input[type=3D"number"]::-webkit-inner-spin-button { appearance: =
+none; margin: 0px; }
+
+.om-dc-num input[type=3D"number"]::-webkit-outer-spin-button { appearance: =
+none; margin: 0px; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://claude.ai/design/assets/v1/format-D66gdL5p.css
+
+@charset "utf-8";
+
+@keyframes om-thumb-shimmer {=20
+  0% { background-position: -200px 0px; }
+  100% { background-position: 200px 0px; }
+}
+
+.om-thumb-shimmer { background-image: ; background-position-x: ; background=
+-position-y: ; background-repeat: ; background-attachment: ; background-ori=
+gin: ; background-clip: ; background-color: ; background-size: 400px 100%; =
+animation: 1.4s linear 0s infinite normal none running om-thumb-shimmer; }
+
+.om-thumb-remove > button, .om-thumb-remove > button:hover { color: rgb(255=
+, 255, 255); }
+
+.om-model-picker-trigger { min-width: 0px; display: inline-flex; }
+
+.om-model-picker-trigger > :first-child > span { min-width: 0px; }
+
+.om-model-picker-trigger > :first-child > span > :last-child { flex-shrink:=
+ 0; }
+
+.om-model-picker-trigger > :last-child { display: none; }
+
+@container (width <=3D 220px) {
+  .om-model-picker-trigger > :first-child { display: none; }
+  .om-model-picker-trigger > :last-child { display: inline-flex; }
+}
+
+@keyframes om-chips-fade {=20
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+.om-chips-dropdown { animation: 0.1s ease 0s 1 normal none running om-chips=
+-fade; }
+
+.om-chips-scroll { scrollbar-width: thin; }
+
+.om-chips-scroll::-webkit-scrollbar { width: 6px; }
+
+.om-chips-scroll::-webkit-scrollbar-thumb { background: var(--cds-border); =
+border-radius: 3px; }
+
+.om-chip-shelf { transition: grid-template-rows .18s var(--cds-ease-out,eas=
+e-out); }
+
+@media (prefers-reduced-motion: reduce) {
+  .om-chip-shelf { transition: none; }
+}
+
+@keyframes om-voice-pulse {=20
+  0%, 100% { opacity: 0.9; transform: scale(1); }
+  50% { opacity: 0.6; transform: scale(1.15); }
+}
+
+.om-voice-pulse { animation: 1.4s ease-in-out 0s infinite normal none runni=
+ng om-voice-pulse; }
+
+@keyframes om-tpl-shimmer {=20
+  0% { background-position: -200px 0px; }
+  100% { background-position: 200px 0px; }
+}
+
+.om-tpl-shimmer { background-image: ; background-position-x: ; background-p=
+osition-y: ; background-repeat: ; background-attachment: ; background-origi=
+n: ; background-clip: ; background-color: ; background-size: 400px 100%; an=
+imation: 1.4s linear 0s infinite normal none running om-tpl-shimmer; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://claude.ai/design/assets/v1/home-analytics-DVN_Gu5T.css
+
+@charset "utf-8";
+
+.om-form-list-card > * + * { border-top: 1px solid var(--om-border-subtle);=
+ }
+
+.om-form-list-card > * + [data-indented-divider] { border-top-color: rgba(0=
+, 0, 0, 0); position: relative; }
+
+.om-form-list-card > * + [data-indented-divider]::before { content: ""; bac=
+kground: var(--om-border-subtle); height: 1px; position: absolute; top: -1p=
+x; left: 20px; right: 0px; }
+
+.om-form-list-card-tinted > * + * { border-top-color: rgba(217, 119, 87, 0.=
+2); }
+
+.om-rich-input { width: 100%; max-height: calc(var(--om-ri-max-rows) * 1lh)=
+; color: var(--om-text-primary); cursor: text; font-size: 14px; line-height=
+: 1.5; overflow-y: auto; }
+
+@media (width <=3D 700px) {
+  .om-rich-input { font-size: 16px; }
+}
+
+.om-rich-input .ProseMirror { min-height: calc(var(--om-ri-min-rows) * 1lh)=
+; white-space: pre-wrap; overflow-wrap: break-word; word-break: break-word;=
+ outline: none; }
+
+.om-rich-input .ProseMirror p { margin: 0px; }
+
+.om-rich-input .ProseMirror a { color: var(--om-accent-blue); cursor: text;=
+ font-weight: 500; text-decoration: none; }
+
+.om-rich-input .ProseMirror a:hover { color: var(--om-accent-blue-hover); }
+
+.om-rich-input .ProseMirror p.is-empty::before { content: attr(data-placeho=
+lder); color: var(--om-text-tertiary); pointer-events: none; float: left; h=
+eight: 0px; }
+
+.om-tabs-scroll::-webkit-scrollbar { height: 3px; }
+
+.om-tabs-scroll::-webkit-scrollbar-track { background: 0px 0px; }
+
+.om-tabs-scroll::-webkit-scrollbar-thumb { background: rgba(0, 0, 0, 0.15);=
+ border-radius: 3px; }
+
+.om-tabs-scroll::-webkit-scrollbar-thumb:hover { background: rgba(0, 0, 0, =
+0.25); }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://claude.ai/design/assets/v1/Button-C3hHoRdu.css
+
+@charset "utf-8";
+
+@font-face { font-family: Anthropicons-Variable; src: url("/design/assets/v=
+1/anthropicons-variable-DICoRAgs.woff2") format("woff2-variations"); font-w=
+eight: 400 700; font-display: block; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://claude.ai/design/assets/v1/index-D0EsnHXb.css
+
+@charset "utf-8";
+
+:root { --lightningcss-light: initial; --lightningcss-dark: ; color-scheme:=
+ light; --om-bg-app: #faf9f5; --om-bg-panel: #f8f7f3; --om-bg-surface: #fff=
+; --om-bg-elevated: #fff; --om-bg-hover: #0f0c080a; --om-bg-active: #e8e6dc=
+; --om-bg-selected: #e3dacc; --om-bg-muted: #f0eee6; --om-bg-stripe: #0f0c0=
+805; --om-bg-tint-design-system: #f6e3e3; --om-bg-tint-template: #e4e2f1; -=
+-om-bg-primary-tab-bar: #e8e6dc; --om-bg-secondary-tab-bar: #f6f5f0af; --om=
+-bg-error-tint: #a632440d; --om-bg-intro-splash: #e1dacd; --om-bg-scrim: #0=
+f0c0866; --om-border-subtle: #0f0c0814; --om-border-card: #0f0c081f; --om-b=
+order-default: #0f0c081a; --om-border-strong: #0f0c0838; --om-border-focus:=
+ #0f0c085c; --om-border-modal: #0000001a; --om-text-primary: #0f0c08eb; --o=
+m-text-prose: #0f0c08cc; --om-text-secondary: #0f0c08a3; --om-text-tertiary=
+: #0f0c0899; --om-text-disabled: #0f0c0852; --om-text-design-system-badge: =
+#c67878; --om-text-inverse: #faf9f5; --om-text-link: #6a9bcc; --om-accent-p=
+rimary: #d97757; --om-accent-primary-bg: #d977571f; --om-accent-primary-tin=
+t: #d977570a; --om-accent-primary-dash: #d9775780; --om-accent-primary-tail=
+: #d977572e; --om-accent-primary-hover: #c46a4d; --om-accent-primary-active=
+: #b05e43; --om-accent-secondary: #6a9bcc; --om-accent-secondary-hover: #5a=
+8bbb; --om-accent-secondary-active: #4e7caa; --om-accent-success: #558a42; =
+--om-accent-warning: #c9a82d; --om-accent-error: #a63244; --om-accent-pro: =
+#473aa6; --om-accent-pro-bg: #e7e4fb; --om-accent-blue: #2a78d6; --om-accen=
+t-blue-bg: #2a78d61a; --om-accent-blue-hover: #2569bf; --om-accent-review: =
+#3987e5; --om-accent-verifier: #8b6ac8; --om-accent-verifier-soft: #b7a3dc;=
+ --om-accent-black: #191915; --om-accent-black-hover: #2b2b26; --om-accent-=
+black-active: #0f0c08; --om-scrollbar-thumb: #00000026; --om-scrollbar-thum=
+b-hover: #00000040; --om-shadow-xs: 0 1px 2px #1414130a; --om-shadow-sm: 0 =
+1px 3px #1414130f; --om-shadow-md: 0 4px 6px #1414130f; --om-shadow-diffuse=
+: 0 4px 20px #1414130a; --om-shadow-lg: 0 10px 15px #14141314; --om-shadow-=
+inset: inset 0 1px 2px #1414130f; --om-shadow-modal: 0 24px 48px #0f0c0829,=
+ 0 8px 16px #0f0c0814; --om-shadow-card: 0 18px 44px #1414131a, 0 3px 10px =
+#1414130d; --om-presenter-bg: #1a1a1a; --om-presenter-text: #e8e8e8; --om-p=
+resenter-border: #333; --om-presenter-divider: #2a2a2a; --om-presenter-divi=
+der-hover: #3a3a3a; --om-presenter-slide-bg: #000; --om-presenter-slide-hov=
+er-border: #555; --om-presenter-control-bg: #2a2a2a; --om-presenter-control=
+-hover: #333; --om-presenter-control-active: #3a3a3a; --om-presenter-contro=
+l-border: #444; --om-presenter-muted: #999; --om-presenter-label: #888; --o=
+m-presenter-placeholder: #555; --om-presenter-toggle-track: #3a3a3a; --om-z=
+-modal: 2000; --om-z-modal-top: 3000; --om-z-popover: 3500; --om-z-panel-ov=
+erlay: 4000; --om-z-toast: 10000; }
+
+:root[data-theme=3D"dark"] { --lightningcss-light: ; --lightningcss-dark: i=
+nitial; color-scheme: dark; --om-bg-app: #1c1b19; --om-bg-panel: #222220; -=
+-om-bg-surface: #2a2927; --om-bg-elevated: #2a2927; --om-bg-hover: #faf9f50=
+d; --om-bg-active: #35332c; --om-bg-selected: #3c392f; --om-bg-muted: #2e2c=
+26; --om-bg-stripe: #faf9f505; --om-bg-tint-design-system: #3a2a2a; --om-bg=
+-tint-template: #2a2838; --om-bg-primary-tab-bar: #35332c; --om-bg-secondar=
+y-tab-bar: #222220af; --om-bg-error-tint: #c45a6a1f; --om-bg-intro-splash: =
+#2e2a22; --om-bg-scrim: #0009; --om-border-subtle: #faf9f51a; --om-border-c=
+ard: #faf9f524; --om-border-default: #faf9f51f; --om-border-strong: #faf9f5=
+3d; --om-border-focus: #faf9f566; --om-border-modal: #faf9f51f; --om-text-p=
+rimary: #faf9f5eb; --om-text-prose: #faf9f5cc; --om-text-secondary: #faf9f5=
+a3; --om-text-tertiary: #faf9f599; --om-text-disabled: #faf9f552; --om-text=
+-design-system-badge: #d89a9a; --om-text-inverse: #1c1b19; --om-text-link: =
+#7eaeda; --om-accent-primary: #e08968; --om-accent-primary-bg: #e0896829; -=
+-om-accent-primary-tint: #e089680f; --om-accent-primary-dash: #e0896880; --=
+om-accent-primary-tail: #e0896833; --om-accent-primary-hover: #e89b7e; --om=
+-accent-primary-active: #efad94; --om-accent-secondary: #7eaeda; --om-accen=
+t-secondary-hover: #91bce2; --om-accent-secondary-active: #a4c9e9; --om-acc=
+ent-success: #6fa859; --om-accent-warning: #dabe4a; --om-accent-error: #c45=
+a6a; --om-accent-pro: #9a8fe0; --om-accent-pro-bg: #2c2847; --om-accent-blu=
+e: #4d90e0; --om-accent-blue-bg: #4d90e024; --om-accent-blue-hover: #62a0e8=
+; --om-accent-review: #5a9bec; --om-accent-verifier: #a68dd8; --om-accent-v=
+erifier-soft: #8572b0; --om-accent-black: #f0eee6; --om-accent-black-hover:=
+ #e4e2d9; --om-accent-black-active: #d8d5cb; --om-scrollbar-thumb: #faf9f52=
+6; --om-scrollbar-thumb-hover: #faf9f540; --om-shadow-xs: 0 1px 2px #000000=
+3d; --om-shadow-sm: 0 1px 3px #00000047; --om-shadow-md: 0 4px 6px #0000004=
+7; --om-shadow-diffuse: 0 4px 20px #0000003d; --om-shadow-lg: 0 10px 15px #=
+00000052; --om-shadow-inset: inset 0 1px 2px #00000047; --om-shadow-modal: =
+0 24px 48px #0000007a, 0 8px 16px #00000052; --om-shadow-card: 0 18px 44px =
+#0006, 0 3px 10px #0000003d; }
+
+*, ::before, ::after { box-sizing: border-box; border-style: solid; border-=
+width: 0px; }
+
+button, input, select, textarea { font-family: inherit; }
+
+.cds-root :where(h1, h2, h3, h4, h5, h6) { font-size: inherit; font-weight:=
+ inherit; margin: 0px; }
+
+.cds-root :where(p) { margin: 0px; }
+
+html { overscroll-behavior-x: none; }
+
+iframe { color-scheme: normal; }
+
+html, body { -webkit-font-smoothing: antialiased; background: var(--om-bg-a=
+pp); color: var(--om-text-primary); margin: 0px; padding: 0px; font-family:=
+ -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", A=
+rial, sans-serif; }
+
+a { color: inherit; text-decoration: none; }
+
+.om-scrollbar { scrollbar-width: thin; scrollbar-color: var(--om-scrollbar-=
+thumb) transparent; }
+
+.om-scrollbar::-webkit-scrollbar { width: 6px; height: 6px; }
+
+.om-scrollbar::-webkit-scrollbar-track { background: 0px 0px; }
+
+.om-scrollbar::-webkit-scrollbar-thumb { background: var(--om-scrollbar-thu=
+mb); border-radius: 3px; }
+
+.om-scrollbar::-webkit-scrollbar-thumb:hover { background: var(--om-scrollb=
+ar-thumb-hover); }
+
+@font-face { font-family: "Anthropic Serif"; src: url("/design/assets/v1/An=
+thropicSerif-Roman-rest-C34tvrfH.woff2") format("woff2"); font-weight: 300 =
+500; font-style: normal; font-display: swap; unicode-range: U+100-130, U+13=
+2-151, U+154-17F, U+1CD-1DC, U+1E2-1E3, U+1E6-1E7, U+1EA-1EB, U+1F4-1F5, U+=
+1F8-1F9, U+1FC-1FF, U+218-21B, U+226-227, U+22E-22F, U+232-233, U+237, U+24=
+5, U+259, U+28C, U+2B0, U+2B2-2B3, U+2B7-2B8, U+2C7, U+2CD, U+2D8-2D9, U+2D=
+B, U+2DD, U+2E1-2E3, U+300-303, U+306-307, U+30A-30C, U+30F, U+311-313, U+3=
+23, U+326-328, U+331, U+1D37, U+1D39, U+1D43, U+1D47-1D49, U+1D4D, U+1D4F-1=
+D50, U+1D52, U+1D56-1D58, U+1D5B, U+1D9C, U+1DA0, U+1DBB, U+1E02-1E03, U+1E=
+0A-1E0B, U+1E1E-1E21, U+1E24-1E25, U+1E30-1E37, U+1E3A-1E3B, U+1E3E-1E43, U=
++1E46-1E47, U+1E54-1E57, U+1E60-1E63, U+1E6A-1E6B, U+1E80-1E85, U+1E8C-1E8F=
+, U+1E9E, U+1EA0-1EA1, U+1EB8-1EB9, U+1ECA-1ECD, U+1EE4-1EE5, U+1EF2-1EF3, =
+U+2070-2071, U+2075-208E, U+2153-215F, U+2190, U+2192, U+2196-2199, U+2202,=
+ U+2219, U+2248, U+2260-2261, U+2264-2265, U+2329-232A, U+25E6, U+2E18, U+2=
+E3A-2E3B, U+E001-E00C, U+E00F, U+E011-E016, U+E021, U+E024, U+E02A, U+E031-=
+E032, U+E101-E10E, U+E111-E116, U+E11A-E11E, U+E135-E136, U+FB01-FB02; }
+
+@font-face { font-family: "Anthropic Serif"; src: url("/design/assets/v1/An=
+thropicSerif-Roman-latin-Dg0rHfL0.woff2") format("woff2"); font-weight: 300=
+ 500; font-style: normal; font-display: swap; unicode-range: U+0-FF, U+131,=
+ U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, U+2000-206=
+F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD; =
+}
+
+@font-face { font-family: "Anthropic Serif"; src: url("/design/assets/v1/An=
+thropicSerif-Italic-rest-DJfGW6Uq.woff2") format("woff2"); font-weight: 300=
+ 500; font-style: italic; font-display: swap; unicode-range: U+100-130, U+1=
+32-151, U+154-17F, U+1CD-1DC, U+1E2-1E3, U+1E6-1E7, U+1EA-1EB, U+1F4-1F5, U=
++1F8-1F9, U+1FC-1FF, U+218-21B, U+226-227, U+22E-22F, U+232-233, U+237, U+2=
+45, U+259, U+28C, U+2B0, U+2B2-2B3, U+2B7-2B8, U+2C7, U+2CD, U+2D8-2D9, U+2=
+DB, U+2DD, U+2E1-2E3, U+300-303, U+306-307, U+30A-30C, U+30F, U+311-313, U+=
+323, U+326-328, U+331, U+1D43, U+1D47-1D49, U+1D4D, U+1D4F-1D50, U+1D52, U+=
+1D56-1D58, U+1D5B, U+1D9C, U+1DA0, U+1DBB, U+1E02-1E03, U+1E0A-1E0B, U+1E1E=
+-1E21, U+1E24-1E25, U+1E30-1E37, U+1E3A-1E3B, U+1E3E-1E43, U+1E46-1E47, U+1=
+E54-1E57, U+1E60-1E63, U+1E6A-1E6B, U+1E80-1E85, U+1E8C-1E8F, U+1E9E, U+1EA=
+0-1EA1, U+1EB8-1EB9, U+1ECA-1ECD, U+1EE4-1EE5, U+1EF2-1EF3, U+2071, U+207F,=
+ U+2202, U+2219, U+2248, U+2260-2261, U+2264-2265, U+2329-232A, U+25E6, U+2=
+E18, U+2E3A-2E3B, U+E001-E00C, U+E00F, U+E011-E016, U+E02A, U+E031-E032, U+=
+E11A-E11E, U+E135-E136, U+FB01-FB02; }
+
+@font-face { font-family: "Anthropic Serif"; src: url("/design/assets/v1/An=
+thropicSerif-Italic-latin-CkQ4KvUU.woff2") format("woff2"); font-weight: 30=
+0 500; font-style: italic; font-display: swap; unicode-range: U+0-FF, U+131=
+, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, U+2000-20=
+6F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;=
+ }
+
+@font-face { font-family: "Anthropic Sans"; src: url("/design/assets/v1/Ant=
+hropicSans-Roman-Web-Ch5JsymX.woff2") format("woff2"); font-weight: 300 800=
+; font-style: normal; font-display: swap; }
+
+@font-face { font-family: anthropicons; src: url("/design/assets/v1/anthrop=
+icons-CsGjKSEn.woff2?eb198a5f1dc03d5d801e95db845b7148") format("woff2"), ur=
+l("/design/assets/v1/anthropicons-BHjwL-_A.woff?eb198a5f1dc03d5d801e95db845=
+b7148") format("woff"); }
+
+i[class^=3D"ai-"]::before, i[class*=3D" ai-"]::before { font-variant: norma=
+l; text-transform: none; -webkit-font-smoothing: antialiased; font-style: n=
+ormal; line-height: 1; font-family: anthropicons !important; font-weight: 4=
+00 !important; }
+
+.ai-XSmall::before { content: "=EF=84=81"; }
+
+.ai-X::before { content: "=EF=84=82"; }
+
+.ai-Wrench::before { content: "=EF=84=83"; }
+
+.ai-Workspace::before { content: "=EF=84=84"; }
+
+.ai-Warning::before { content: "=EF=84=85"; }
+
+.ai-Voice::before { content: "=EF=84=86"; }
+
+.ai-Verified::before { content: "=EF=84=87"; }
+
+.ai-Users::before { content: "=EF=84=88"; }
+
+.ai-UserCircle::before { content: "=EF=84=89"; }
+
+.ai-User::before { content: "=EF=84=8A"; }
+
+.ai-Upload::before { content: "=EF=84=8B"; }
+
+.ai-Trust::before { content: "=EF=84=8C"; }
+
+.ai-Trash::before { content: "=EF=84=8D"; }
+
+.ai-Tool::before { content: "=EF=84=8E"; }
+
+.ai-Token::before { content: "=EF=84=8F"; }
+
+.ai-Timer::before { content: "=EF=84=90"; }
+
+.ai-ThumbsUp::before { content: "=EF=84=91"; }
+
+.ai-ThumbsDown::before { content: "=EF=84=92"; }
+
+.ai-TextUnderlineSelected::before { content: "=EF=84=93"; }
+
+.ai-TextUnderline::before { content: "=EF=84=94"; }
+
+.ai-TextItalicsSelected::before { content: "=EF=84=95"; }
+
+.ai-TextItalics::before { content: "=EF=84=96"; }
+
+.ai-TextBoldSelected::before { content: "=EF=84=97"; }
+
+.ai-TextBold::before { content: "=EF=84=98"; }
+
+.ai-TextAa::before { content: "=EF=84=99"; }
+
+.ai-TemperatureSimple::before { content: "=EF=84=9A"; }
+
+.ai-Temperature::before { content: "=EF=84=9B"; }
+
+.ai-Team::before { content: "=EF=84=9C"; }
+
+.ai-Tasks::before { content: "=EF=84=9D"; }
+
+.ai-Sun::before { content: "=EF=84=9E"; }
+
+.ai-Styles::before { content: "=EF=84=9F"; }
+
+.ai-StopSmall::before { content: "=EF=84=A0"; }
+
+.ai-StopCircle::before { content: "=EF=84=A1"; }
+
+.ai-Stop::before { content: "=EF=84=A2"; }
+
+.ai-StarFilled::before { content: "=EF=84=A3"; }
+
+.ai-Star::before { content: "=EF=84=A4"; }
+
+.ai-Spreadsheet::before { content: "=EF=84=A5"; }
+
+.ai-Sort::before { content: "=EF=84=A6"; }
+
+.ai-Slides::before { content: "=EF=84=A7"; }
+
+.ai-Signpost::before { content: "=EF=84=A8"; }
+
+.ai-SidebarOpen::before { content: "=EF=84=A9"; }
+
+.ai-SidebarClose::before { content: "=EF=84=AA"; }
+
+.ai-Sidebar::before { content: "=EF=84=AB"; }
+
+.ai-Share::before { content: "=EF=84=AC"; }
+
+.ai-Settings::before { content: "=EF=84=AD"; }
+
+.ai-Search::before { content: "=EF=84=AE"; }
+
+.ai-Screenshare::before { content: "=EF=84=AF"; }
+
+.ai-Research::before { content: "=EF=84=B0"; }
+
+.ai-Reload::before { content: "=EF=84=B1"; }
+
+.ai-PullRequestDraft::before { content: "=EF=84=B2"; }
+
+.ai-PullRequestClosed::before { content: "=EF=84=B3"; }
+
+.ai-Prompt::before { content: "=EF=84=B4"; }
+
+.ai-ProjectsX::before { content: "=EF=84=B5"; }
+
+.ai-Projects::before { content: "=EF=84=B6"; }
+
+.ai-Prohibit::before { content: "=EF=84=B7"; }
+
+.ai-Pro::before { content: "=EF=84=B8"; }
+
+.ai-PlaySmall::before { content: "=EF=84=B9"; }
+
+.ai-PlayCircleFilled::before { content: "=EF=84=BA"; }
+
+.ai-PlayCircle::before { content: "=EF=84=BB"; }
+
+.ai-Play::before { content: "=EF=84=BC"; }
+
+.ai-PaperPlane::before { content: "=EF=84=BD"; }
+
+.ai-Owl::before { content: "=EF=84=BE"; }
+
+.ai-Organization::before { content: "=EF=84=BF"; }
+
+.ai-Notification::before { content: "=EF=85=80"; }
+
+.ai-Moon::before { content: "=EF=85=81"; }
+
+.ai-MinusSmall::before { content: "=EF=85=82"; }
+
+.ai-Minus::before { content: "=EF=85=83"; }
+
+.ai-Memory::before { content: "=EF=85=84"; }
+
+.ai-MapPin::before { content: "=EF=85=85"; }
+
+.ai-Mailbox::before { content: "=EF=85=86"; }
+
+.ai-Logout::before { content: "=EF=85=87"; }
+
+.ai-LockOpen::before { content: "=EF=85=88"; }
+
+.ai-Lock::before { content: "=EF=85=89"; }
+
+.ai-ListNumbered::before { content: "=EF=85=8A"; }
+
+.ai-ListBullet::before { content: "=EF=85=8B"; }
+
+.ai-ListAdd::before { content: "=EF=85=8C"; }
+
+.ai-LinkSimple::before { content: "=EF=85=8D"; }
+
+.ai-Link::before { content: "=EF=85=8E"; }
+
+.ai-Lightning::before { content: "=EF=85=8F"; }
+
+.ai-Lightbulb::before { content: "=EF=85=90"; }
+
+.ai-Library::before { content: "=EF=85=91"; }
+
+.ai-Knowledge::before { content: "=EF=85=92"; }
+
+.ai-Keyboard::before { content: "=EF=85=93"; }
+
+.ai-Key::before { content: "=EF=85=94"; }
+
+.ai-Info::before { content: "=EF=85=95"; }
+
+.ai-Indent::before { content: "=EF=85=96"; }
+
+.ai-Image::before { content: "=EF=85=97"; }
+
+.ai-Home::before { content: "=EF=85=98"; }
+
+.ai-Help::before { content: "=EF=85=99"; }
+
+.ai-Hand::before { content: "=EF=85=9A"; }
+
+.ai-GraduationCap::before { content: "=EF=85=9B"; }
+
+.ai-Globe::before { content: "=EF=85=9C"; }
+
+.ai-GhostFilled::before { content: "=EF=85=9D"; }
+
+.ai-Ghost::before { content: "=EF=85=9E"; }
+
+.ai-FolderPlus::before { content: "=EF=85=9F"; }
+
+.ai-Folder::before { content: "=EF=85=A0"; }
+
+.ai-Filter::before { content: "=EF=85=A1"; }
+
+.ai-Files::before { content: "=EF=85=A2"; }
+
+.ai-File::before { content: "=EF=85=A3"; }
+
+.ai-Feedback::before { content: "=EF=85=A4"; }
+
+.ai-EyeSlash::before { content: "=EF=85=A5"; }
+
+.ai-Eye::before { content: "=EF=85=A6"; }
+
+.ai-ExtendedThinking::before { content: "=EF=85=A7"; }
+
+.ai-Experimental::before { content: "=EF=85=A8"; }
+
+.ai-Expand::before { content: "=EF=85=A9"; }
+
+.ai-Evals::before { content: "=EF=85=AA"; }
+
+.ai-Edit::before { content: "=EF=85=AB"; }
+
+.ai-Download::before { content: "=EF=85=AC"; }
+
+.ai-DotsVerticalSmall::before { content: "=EF=85=AD"; }
+
+.ai-DotsVertical::before { content: "=EF=85=AE"; }
+
+.ai-DotsHorizontalSmall::before { content: "=EF=85=AF"; }
+
+.ai-DotsHorizontal::before { content: "=EF=85=B0"; }
+
+.ai-Database::before { content: "=EF=85=B1"; }
+
+.ai-CreditCard::before { content: "=EF=85=B2"; }
+
+.ai-Copy::before { content: "=EF=85=B3"; }
+
+.ai-Connectors::before { content: "=EF=85=B4"; }
+
+.ai-Computer::before { content: "=EF=85=B5"; }
+
+.ai-CommandLine::before { content: "=EF=85=B6"; }
+
+.ai-Collapse::before { content: "=EF=85=B7"; }
+
+.ai-CoffeeCup::before { content: "=EF=85=B8"; }
+
+.ai-CodeBrackets::before { content: "=EF=85=B9"; }
+
+.ai-CodeBlock::before { content: "=EF=85=BA"; }
+
+.ai-Code::before { content: "=EF=85=BB"; }
+
+.ai-Cloud::before { content: "=EF=85=BC"; }
+
+.ai-Clock::before { content: "=EF=85=BD"; }
+
+.ai-Clipboard::before { content: "=EF=85=BE"; }
+
+.ai-Claudification::before { content: "=EF=85=BF"; }
+
+.ai-Checklist::before { content: "=EF=86=80"; }
+
+.ai-CheckDouble::before { content: "=EF=86=81"; }
+
+.ai-CheckCircleFilled::before { content: "=EF=86=82"; }
+
+.ai-CheckCircle::before { content: "=EF=86=83"; }
+
+.ai-Check::before { content: "=EF=86=84"; }
+
+.ai-Chats::before { content: "=EF=86=85"; }
+
+.ai-ChatAddFilled::before { content: "=EF=86=86"; }
+
+.ai-ChatAdd::before { content: "=EF=86=87"; }
+
+.ai-Chat::before { content: "=EF=86=88"; }
+
+.ai-Chart::before { content: "=EF=86=89"; }
+
+.ai-CaretUpSmall::before { content: "=EF=86=8A"; }
+
+.ai-CaretUpDown::before { content: "=EF=86=8B"; }
+
+.ai-CaretUp::before { content: "=EF=86=8C"; }
+
+.ai-CaretRightSmall::before { content: "=EF=86=8D"; }
+
+.ai-CaretRight::before { content: "=EF=86=8E"; }
+
+.ai-CaretLeftSmall::before { content: "=EF=86=8F"; }
+
+.ai-CaretLeft::before { content: "=EF=86=90"; }
+
+.ai-CaretDownUp::before { content: "=EF=86=91"; }
+
+.ai-CaretDownSmall::before { content: "=EF=86=92"; }
+
+.ai-CaretDown::before { content: "=EF=86=93"; }
+
+.ai-Capacity::before { content: "=EF=86=94"; }
+
+.ai-Camera::before { content: "=EF=86=95"; }
+
+.ai-Cache::before { content: "=EF=86=96"; }
+
+.ai-Branch::before { content: "=EF=86=97"; }
+
+.ai-BookText::before { content: "=EF=86=98"; }
+
+.ai-Book::before { content: "=EF=86=99"; }
+
+.ai-Batch::before { content: "=EF=86=9A"; }
+
+.ai-Attachment::before { content: "=EF=86=9B"; }
+
+.ai-Artifacts::before { content: "=EF=86=9C"; }
+
+.ai-ArtifactFile::before { content: "=EF=86=9D"; }
+
+.ai-ArrowsOut::before { content: "=EF=86=9E"; }
+
+.ai-ArrowUpSmall::before { content: "=EF=86=9F"; }
+
+.ai-ArrowUpRightSmall::before { content: "=EF=86=A0"; }
+
+.ai-ArrowUpRight::before { content: "=EF=86=A1"; }
+
+.ai-ArrowUpCircle::before { content: "=EF=86=A2"; }
+
+.ai-ArrowUp::before { content: "=EF=86=A3"; }
+
+.ai-ArrowRightSmall::before { content: "=EF=86=A4"; }
+
+.ai-ArrowRightCircle::before { content: "=EF=86=A5"; }
+
+.ai-ArrowRight::before { content: "=EF=86=A6"; }
+
+.ai-ArrowOutSquare::before { content: "=EF=86=A7"; }
+
+.ai-ArrowLeftSmall::before { content: "=EF=86=A8"; }
+
+.ai-ArrowLeftCircle::before { content: "=EF=86=A9"; }
+
+.ai-ArrowLeft::before { content: "=EF=86=AA"; }
+
+.ai-ArrowInSquare::before { content: "=EF=86=AB"; }
+
+.ai-ArrowDownSmall::before { content: "=EF=86=AC"; }
+
+.ai-ArrowDownCircle::before { content: "=EF=86=AD"; }
+
+.ai-ArrowDown::before { content: "=EF=86=AE"; }
+
+.ai-Archive::before { content: "=EF=86=AF"; }
+
+.ai-Ant::before { content: "=EF=86=B0"; }
+
+.ai-Agent::before { content: "=EF=86=B1"; }
+
+.ai-AddSmall::before { content: "=EF=86=B2"; }
+
+.ai-AddBold::before { content: "=EF=86=B3"; }
+
+.ai-Add::before { content: "=EF=86=B4"; }
+
+.ai-Activity::before { content: "=EF=86=B5"; }
+
+.ai-Interactive::before { content: "=EF=86=B6"; }
+
+.cds-root { -webkit-font-smoothing: antialiased; }
+
+.cds-root[data-font] { font-family: var(--cds-font-sans); }
+
+.cds-root .cds-btn-squish { transform-origin: 50% center; transition: trans=
+form .45s var(--cds-btn-spring); }
+
+.cds-root .group\/btn:active:not([disabled]) .cds-btn-squish { transition: =
+transform 60ms ease-out; transform: scale(0.975); }
+
+.cds-root.cds-root.cds-root .cds-reset:focus, .cds-root.cds-root.cds-root .=
+cds-reset:focus-visible { outline: none; }
+
+:where(.cds-root) input.cds-input::-webkit-search-cancel-button { appearanc=
+e: none; display: none; }
+
+:where(.cds-root) input.cds-input::-webkit-search-decoration { appearance: =
+none; display: none; }
+
+:where(.cds-root) textarea.cds-input::-webkit-resizer { background: url("da=
+ta:image/svg+xml,%3Csvg xmlns=3D'http://www.w3.org/2000/svg' viewBox=3D'0 0=
+ 16 16'%3E%3Cpath d=3D'M4.5 11.5 11.5 4.5M8.5 11.5 11.5 8.5' stroke=3D'%238=
+98781' stroke-width=3D'1.5' stroke-linecap=3D'round' fill=3D'none'/%3E%3C/s=
+vg%3E") 0px 0px / 100% 100% no-repeat; }
+
+@keyframes cds-dot-pulse {=20
+  0%, 5% { background: var(--cds-alpha-3); animation-timing-function: cubic=
+-bezier(0.165, 0.84, 0.44, 1); }
+  15%, 25% { background: var(--cds-alpha-7); animation-timing-function: cub=
+ic-bezier(0.165, 0.84, 0.44, 1); }
+  65%, 100% { background: var(--cds-alpha-3); }
+}
+
+.cds-root .cds-dot { background: var(--cds-alpha-3); border-radius: 9999px;=
+ width: 3px; height: 3px; animation: 1.8s linear 0s infinite normal none ru=
+nning cds-dot-pulse; }
+
+.cds-root .cds-dot:nth-child(2) { animation-delay: 0.2s; }
+
+.cds-root .cds-dot:nth-child(3) { animation-delay: 0.4s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .cds-root .cds-dot { animation: auto ease 0s 1 normal none running none; =
+}
+}
+
+@keyframes cds-shimmer {=20
+  0% { transform: translate(-100%); }
+  100% { transform: translate(100%); }
+}
+
+@keyframes cds-shimmer-text-shine {=20
+  0% { background-position: 150% 0px; }
+  100% { background-position: -50% 0px; }
+}
+
+@keyframes cds-reveal-in {=20
+  0% { opacity: 0; transform: translateY(4px); }
+  100% { opacity: 1; transform: none; }
+}
+
+:root { --cds-radius: .25rem; --cds-border: currentColor; --cds-shadow-sm: =
+0 1px 2px 0 #0000000d; --cds-shadow-md: 0 4px 6px -1px #0000001a, 0 2px 4px=
+ -2px #0000001a; --cds-shadow-lg: 0 10px 15px -3px #0000001a, 0 4px 6px -4p=
+x #0000001a; --cds-font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, =
+Consolas, "Liberation Mono", "Courier New", monospace; --cds-font-system: u=
+i-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; --c=
+ds-font-sans: var(--cds-font-system); --cds-ease-out: cubic-bezier(0, 0, .2=
+, 1); --cds-black: #000; --cds-oncolor-200: #f8f8f7bf; --cds-oncolor-300: #=
+f8f8f780; --cds-clay: #d97757; --cds-clay-emphasized: #c6613f; --cds-heathe=
+r: #cbcadb; --cds-plum: #827dbd; --cds-cactus: #bcd1ca; --cds-mineral: #629=
+987; --cds-peach: #ebc9b7; --cds-gray-80: #e7e6e1; --cds-gray-650: #454442;=
+ --cds-pictogram-highlight-default: var(--cds-gray-80); --cds-pictogram-hig=
+hlight-heather: var(--cds-heather); --cds-pictogram-highlight-cactus: var(-=
+-cds-cactus); --cds-pictogram-highlight-peach: var(--cds-peach); }
+
+[data-mode=3D"dark"] { --cds-pictogram-highlight-default: var(--cds-gray-65=
+0); --cds-pictogram-highlight-heather: var(--cds-plum); --cds-pictogram-hig=
+hlight-cactus: var(--cds-mineral); --cds-pictogram-highlight-peach: var(--c=
+ds-clay-emphasized); }
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-mode=3D"light"]) { --cds-pictogram-highlight-default: var=
+(--cds-gray-650); --cds-pictogram-highlight-heather: var(--cds-plum); --cds=
+-pictogram-highlight-cactus: var(--cds-mineral); --cds-pictogram-highlight-=
+peach: var(--cds-clay-emphasized); }
+}
+
+.cds-root { --cds-radius: 6px; --cds-h-control: 24px; --cds-h-control-neste=
+d: 18px; --cds-icon: 16px; --cds-pad-sm: 6px; --cds-pad-md: 8px; --cds-pad-=
+lg: 12px; --cds-pad-xl: 20px; --cds-gap-xs: 6px; --cds-gap-sm: 8px; --cds-g=
+ap-md: 12px; --cds-gap-lg: 20px; --cds-gap-xl: 32px; --cds-border: var(--cd=
+s-alpha-2); --cds-border-accent: var(--cds-blue-250); --cds-border-danger: =
+var(--cds-red-250); --cds-border-success: var(--cds-green-250); --cds-borde=
+r-warning: var(--cds-yellow-250); --cds-border-pro: var(--cds-violet-250); =
+--cds-border-strong: var(--cds-alpha-3); --cds-border-stronger: hsl(from va=
+r(--cds-neutral-900) h s l / 40%); --cds-shadow-sm: 0 1px 2px 0 hsl(from va=
+r(--cds-gray-900) h s l / 6%), 0 2px 8px 0 var(--cds-shadow-color); --cds-s=
+hadow-md: 0 2px 4px 0 hsl(from var(--cds-gray-900) h s l / 7%), 0 6px 16px =
+0 var(--cds-shadow-color); --cds-shadow-lg: 0 4px 8px 0 hsl(from var(--cds-=
+gray-900) h s l / 8%), 0 12px 28px -2px var(--cds-shadow-color); --cds-shad=
+ow-color: hsl(from var(--cds-gray-900) h s l / 8%); --cds-shadow-popover: 0=
+ 8px 24px #0000001f, 0 2px 6px #00000014; --cds-ring-outer: 1px; --cds-ring=
+-inner: 0px; --cds-ring-color: var(--cds-border); --cds-focus-shadow: inset=
+ 0 0 0 1px var(--cds-page-bg), 0 0 0 1px var(--cds-fill-accent), 0 0 6px 1p=
+x var(--cds-bg-accent); --cds-font-mono: var(--font-anthropic-mono,"Anthrop=
+ic Mono Variable"), "Anthropic Mono", "SF Mono", ui-monospace, Menlo, Conso=
+las, monospace; --cds-font-sans: var(--font-anthropic-sans,"Anthropic Sans =
+Variable", "Anthropic Sans"), var(--cds-font-system); --cds-font-voice: var=
+(--font-anthropic-serif,"Anthropic Serif Variable", "Anthropic Serif"), ui-=
+serif, Georgia, "Times New Roman", serif; --cds-ease-out: cubic-bezier(.165=
+, .84, .44, 1); --cds-ease-snap: cubic-bezier(.32, .72, 0, 1); --cds-ease-o=
+vershoot: cubic-bezier(.34, 1.3, .64, 1); --cds-dur-fast: 60ms; --cds-dur-s=
+nap: .12s; --cds-dur-base: .2s; --cds-dur-slow: .45s; --cds-btn-spring: lin=
+ear(0, .2459, .6526, .9468, 1.0764, 1.0915, 1.0585, 1.0219, .9993, .9914, .=
+9921, .9957, .9988, 1.0004, 1); --cds-clay: #d97757; --cds-clay-emphasized:=
+ #c6613f; --cds-heather: #cbcadb; --cds-plum: #827dbd; --cds-cactus: #bcd1c=
+a; --cds-mineral: #629987; --cds-peach: #ebc9b7; --cds-gray-0: #fff; --cds-=
+gray-10: #fcfcfb; --cds-gray-20: #f9f9f7; --cds-gray-30: #f6f6f4; --cds-gra=
+y-40: #f3f3f0; --cds-gray-50: #f0efec; --cds-gray-60: #edece8; --cds-gray-7=
+0: #eae9e4; --cds-gray-80: #e7e6e1; --cds-gray-90: #e4e3dd; --cds-gray-100:=
+ #e1e0d9; --cds-gray-150: #d2d1c7; --cds-gray-200: #c3c2b7; --cds-gray-250:=
+ #b4b3a8; --cds-gray-300: #a5a49a; --cds-gray-350: #97958d; --cds-gray-400:=
+ #898781; --cds-gray-450: #7b7974; --cds-gray-500: #6d6b67; --cds-gray-550:=
+ #5f5e5a; --cds-gray-600: #52514e; --cds-gray-650: #454442; --cds-gray-700:=
+ #383835; --cds-gray-750: #2c2c2a; --cds-gray-800: #20201f; --cds-gray-810:=
+ #1e1e1d; --cds-gray-820: #1c1c1b; --cds-gray-830: #1a1a19; --cds-gray-840:=
+ #181817; --cds-gray-850: #151515; --cds-gray-860: #131313; --cds-gray-870:=
+ #111; --cds-gray-880: #0f0f0f; --cds-gray-890: #0d0d0d; --cds-gray-900: #0=
+b0b0b; --cds-red-0: #fff; --cds-red-10: #fffbfb; --cds-red-20: #fef7f7; --c=
+ds-red-30: #fef3f3; --cds-red-40: #fdefef; --cds-red-50: #fbebeb; --cds-red=
+-60: #fae7e7; --cds-red-70: #fae3e3; --cds-red-80: #fadfdf; --cds-red-90: #=
+fadada; --cds-red-100: #fad6d6; --cds-red-150: #f7c1c1; --cds-red-200: #f4a=
+bab; --cds-red-250: #f09595; --cds-red-300: #ec7e7e; --cds-red-350: #e66767=
+; --cds-red-400: #e34948; --cds-red-450: #d03b3b; --cds-red-500: #b93535; -=
+-cds-red-550: #a32c2c; --cds-red-600: #8e2626; --cds-red-650: #791e1e; --cd=
+s-red-700: #641919; --cds-red-750: #511212; --cds-red-800: #3c0e0e; --cds-r=
+ed-810: #380d0d; --cds-red-820: #340c0c; --cds-red-830: #310b0b; --cds-red-=
+840: #2d0a0a; --cds-red-850: #280a0a; --cds-red-860: #230b0a; --cds-red-870=
+: #1d0b0a; --cds-red-880: #170c0b; --cds-red-890: #110c0b; --cds-red-900: #=
+0b0b0b; --cds-orange-0: #fff; --cds-orange-10: #fefbfa; --cds-orange-20: #f=
+df7f5; --cds-orange-30: #fcf4f0; --cds-orange-40: #faf0ec; --cds-orange-50:=
+ #f9ece7; --cds-orange-60: #f8e9e2; --cds-orange-70: #f7e5dd; --cds-orange-=
+80: #f7e1d7; --cds-orange-90: #f7dcd1; --cds-orange-100: #f7d8cb; --cds-ora=
+nge-150: #f3c5b2; --cds-orange-200: #f4ae94; --cds-orange-250: #f09978; --c=
+ds-orange-300: #ec835a; --cds-orange-350: #eb6834; --cds-orange-400: #d9592=
+6; --cds-orange-450: #c25124; --cds-orange-500: #ae461c; --cds-orange-550: =
+#993d19; --cds-orange-600: #863311; --cds-orange-650: #712b0f; --cds-orange=
+-700: #5d230b; --cds-orange-750: #4b1b08; --cds-orange-800: #371407; --cds-=
+orange-810: #341307; --cds-orange-820: #301106; --cds-orange-830: #2d1006; =
+--cds-orange-840: #290f06; --cds-orange-850: #240e07; --cds-orange-860: #1f=
+0e08; --cds-orange-870: #1a0e09; --cds-orange-880: #150d0a; --cds-orange-89=
+0: #100c0b; --cds-orange-900: #0b0b0b; --cds-yellow-0: #fff; --cds-yellow-1=
+0: #fefcf8; --cds-yellow-20: #fcf8f1; --cds-yellow-30: #fbf5ea; --cds-yello=
+w-40: #f9f2e4; --cds-yellow-50: #f9eeda; --cds-yellow-60: #faebce; --cds-ye=
+llow-70: #fae7c2; --cds-yellow-80: #fae3b8; --cds-yellow-90: #f9e0b0; --cds=
+-yellow-100: #f9dca4; --cds-yellow-150: #f9c868; --cds-yellow-200: #fab219;=
+ --cds-yellow-250: #eda100; --cds-yellow-300: #db9300; --cds-yellow-350: #c=
+98500; --cds-yellow-400: #b77700; --cds-yellow-450: #a66a00; --cds-yellow-5=
+00: #945d00; --cds-yellow-550: #835100; --cds-yellow-600: #734500; --cds-ye=
+llow-650: #623900; --cds-yellow-700: #512e00; --cds-yellow-750: #412400; --=
+cds-yellow-800: #311a00; --cds-yellow-810: #2e1800; --cds-yellow-820: #2b17=
+00; --cds-yellow-830: #271500; --cds-yellow-840: #231402; --cds-yellow-850:=
+ #1f1204; --cds-yellow-860: #1b1106; --cds-yellow-870: #171007; --cds-yello=
+w-880: #130e09; --cds-yellow-890: #0f0d0a; --cds-yellow-900: #0b0b0b; --cds=
+-green-0: #fff; --cds-green-10: #fafdfa; --cds-green-20: #f5fbf4; --cds-gre=
+en-30: #f0f9ef; --cds-green-40: #ebf7e9; --cds-green-50: #e5f4e4; --cds-gre=
+en-60: #e0f2de; --cds-green-70: #dbf0d8; --cds-green-80: #d5eed3; --cds-gre=
+en-90: #d0eccd; --cds-green-100: #caeac7; --cds-green-150: #aee0a9; --cds-g=
+reen-200: #91d68b; --cds-green-250: #73cb6d; --cds-green-300: #55bf50; --cd=
+s-green-350: #35b231; --cds-green-400: #0ca30c; --cds-green-450: #009300; -=
+-cds-green-500: #008300; --cds-green-550: #007300; --cds-green-600: #006300=
+; --cds-green-650: #005400; --cds-green-700: #074506; --cds-green-750: #0f3=
+50d; --cds-green-800: #11260f; --cds-green-810: #10230f; --cds-green-820: #=
+10210f; --cds-green-830: #101e0f; --cds-green-840: #101b0f; --cds-green-850=
+: #0f180e; --cds-green-860: #0e160e; --cds-green-870: #0e130d; --cds-green-=
+880: #0d100d; --cds-green-890: #0c0e0c; --cds-green-900: #0b0b0b; --cds-aqu=
+a-0: #fff; --cds-aqua-10: #f9fdfb; --cds-aqua-20: #f3fbf8; --cds-aqua-30: #=
+edf9f4; --cds-aqua-40: #e8f7f1; --cds-aqua-50: #e2f4ed; --cds-aqua-60: #dcf=
+2ea; --cds-aqua-70: #d5f0e6; --cds-aqua-80: #ceefe2; --cds-aqua-90: #c7eddf=
+; --cds-aqua-100: #bfebdb; --cds-aqua-150: #a0e1c9; --cds-aqua-200: #7ad7b4=
+; --cds-aqua-250: #5acba0; --cds-aqua-300: #3bbd8c; --cds-aqua-350: #1baf7a=
+; --cds-aqua-400: #199e70; --cds-aqua-450: #138e65; --cds-aqua-500: #0f7e5c=
+; --cds-aqua-550: #0e6e53; --cds-aqua-600: #065f49; --cds-aqua-650: #095040=
+; --cds-aqua-700: #034235; --cds-aqua-750: #02342b; --cds-aqua-800: #022720=
+; --cds-aqua-810: #02241e; --cds-aqua-820: #02221c; --cds-aqua-830: #021f1a=
+; --cds-aqua-840: #031c18; --cds-aqua-850: #051a16; --cds-aqua-860: #071713=
+; --cds-aqua-870: #081411; --cds-aqua-880: #0a110f; --cds-aqua-890: #0b0e0d=
+; --cds-aqua-900: #0b0b0b; --cds-blue-0: #fff; --cds-blue-10: #fafcff; --cd=
+s-blue-20: #f5f9fe; --cds-blue-30: #f0f7fe; --cds-blue-40: #ebf4fc; --cds-b=
+lue-50: #e7f1fb; --cds-blue-60: #e2eefa; --cds-blue-70: #ddebfa; --cds-blue=
+-80: #d7e8fa; --cds-blue-90: #d2e5fa; --cds-blue-100: #cde2fb; --cds-blue-1=
+50: #b7d3f6; --cds-blue-200: #9ec5f4; --cds-blue-250: #86b6ef; --cds-blue-3=
+00: #6da7ec; --cds-blue-350: #5598e7; --cds-blue-400: #3987e5; --cds-blue-4=
+50: #2a78d6; --cds-blue-500: #256abf; --cds-blue-550: #1c5cab; --cds-blue-6=
+00: #184f95; --cds-blue-650: #104281; --cds-blue-700: #0d366b; --cds-blue-7=
+50: #062b57; --cds-blue-800: #032042; --cds-blue-810: #031e3d; --cds-blue-8=
+20: #021c39; --cds-blue-830: #021a36; --cds-blue-840: #021831; --cds-blue-8=
+50: #03162c; --cds-blue-860: #051426; --cds-blue-870: #07121f; --cds-blue-8=
+80: #091018; --cds-blue-890: #0a0d11; --cds-blue-900: #0b0b0b; --cds-violet=
+-0: #fff; --cds-violet-10: #fcfbff; --cds-violet-20: #f8f8ff; --cds-violet-=
+30: #f5f4ff; --cds-violet-40: #f2f1ff; --cds-violet-50: #efedff; --cds-viol=
+et-60: #ebeafe; --cds-violet-70: #e8e6fe; --cds-violet-80: #e5e2fd; --cds-v=
+iolet-90: #e2dffd; --cds-violet-100: #dfdbfd; --cds-violet-150: #cfcafb; --=
+cds-violet-200: #bfb9f5; --cds-violet-250: #b0a7f2; --cds-violet-300: #a096=
+eb; --cds-violet-350: #9085e9; --cds-violet-400: #8173e3; --cds-violet-450:=
+ #7161e0; --cds-violet-500: #6250d6; --cds-violet-550: #5645be; --cds-viole=
+t-600: #4a3aa7; --cds-violet-650: #3e318e; --cds-violet-700: #322777; --cds=
+-violet-750: #271e60; --cds-violet-800: #1d1649; --cds-violet-810: #1b1544;=
+ --cds-violet-820: #19133f; --cds-violet-830: #17123b; --cds-violet-840: #1=
+51036; --cds-violet-850: #130f32; --cds-violet-860: #110e2b; --cds-violet-8=
+70: #0f0e23; --cds-violet-880: #0e0d1b; --cds-violet-890: #0c0c13; --cds-vi=
+olet-900: #0b0b0b; --cds-magenta-0: #fff; --cds-magenta-10: #fefbfc; --cds-=
+magenta-20: #fef6f9; --cds-magenta-30: #fdf2f6; --cds-magenta-40: #fbeff3; =
+--cds-magenta-50: #faebf0; --cds-magenta-60: #f9e6ed; --cds-magenta-70: #f9=
+e2eb; --cds-magenta-80: #f9dee8; --cds-magenta-90: #f9d9e5; --cds-magenta-1=
+00: #f9d4e2; --cds-magenta-150: #f3c0d3; --cds-magenta-200: #f3a8c3; --cds-=
+magenta-250: #ed93b4; --cds-magenta-300: #e87ba4; --cds-magenta-350: #e4619=
+1; --cds-magenta-400: #d55181; --cds-magenta-450: #c04873; --cds-magenta-50=
+0: #ad3d66; --cds-magenta-550: #993458; --cds-magenta-600: #862a4c; --cds-m=
+agenta-650: #722340; --cds-magenta-700: #5e1c34; --cds-magenta-750: #4c1429=
+; --cds-magenta-800: #390f1f; --cds-magenta-810: #360d1c; --cds-magenta-820=
+: #320c1a; --cds-magenta-830: #2f0b18; --cds-magenta-840: #2b0a16; --cds-ma=
+genta-850: #270a14; --cds-magenta-860: #220a12; --cds-magenta-870: #1c0b11;=
+ --cds-magenta-880: #170b0f; --cds-magenta-890: #110b0d; --cds-magenta-900:=
+ #0b0b0b; --cds-pictogram-highlight-default: var(--cds-gray-80); --cds-pict=
+ogram-highlight-heather: var(--cds-heather); --cds-pictogram-highlight-cact=
+us: var(--cds-cactus); --cds-pictogram-highlight-peach: var(--cds-peach); -=
+-cds-cursor-interactive: pointer; --cds-neutral-0: var(--cds-gray-0); --cds=
+-neutral-10: var(--cds-gray-10); --cds-neutral-20: var(--cds-gray-20); --cd=
+s-neutral-30: var(--cds-gray-30); --cds-neutral-40: var(--cds-gray-40); --c=
+ds-neutral-50: var(--cds-gray-50); --cds-neutral-60: var(--cds-gray-60); --=
+cds-neutral-70: var(--cds-gray-70); --cds-neutral-80: var(--cds-gray-80); -=
+-cds-neutral-90: var(--cds-gray-90); --cds-neutral-100: var(--cds-gray-100)=
+; --cds-neutral-150: var(--cds-gray-150); --cds-neutral-200: var(--cds-gray=
+-200); --cds-neutral-250: var(--cds-gray-250); --cds-neutral-300: var(--cds=
+-gray-300); --cds-neutral-350: var(--cds-gray-350); --cds-neutral-400: var(=
+--cds-gray-400); --cds-neutral-450: var(--cds-gray-450); --cds-neutral-500:=
+ var(--cds-gray-500); --cds-neutral-550: var(--cds-gray-550); --cds-neutral=
+-600: var(--cds-gray-600); --cds-neutral-650: var(--cds-gray-650); --cds-ne=
+utral-700: var(--cds-gray-700); --cds-neutral-750: var(--cds-gray-750); --c=
+ds-neutral-800: var(--cds-gray-800); --cds-neutral-810: var(--cds-gray-810)=
+; --cds-neutral-820: var(--cds-gray-820); --cds-neutral-830: var(--cds-gray=
+-830); --cds-neutral-840: var(--cds-gray-840); --cds-neutral-850: var(--cds=
+-gray-850); --cds-neutral-860: var(--cds-gray-860); --cds-neutral-870: var(=
+--cds-gray-870); --cds-neutral-880: var(--cds-gray-880); --cds-neutral-890:=
+ var(--cds-gray-890); --cds-neutral-900: var(--cds-gray-900); --cds-alpha-0=
+: hsl(from var(--cds-neutral-900) h s l / 0%); --cds-alpha-1: hsl(from var(=
+--cds-neutral-900) h s l / 5%); --cds-alpha-2: hsl(from var(--cds-neutral-9=
+00) h s l / 10%); --cds-alpha-3: hsl(from var(--cds-neutral-900) h s l / 20=
+%); --cds-alpha-4: hsl(from var(--cds-neutral-900) h s l / 35%); --cds-alph=
+a-5: hsl(from var(--cds-neutral-900) h s l / 50%); --cds-alpha-6: hsl(from =
+var(--cds-neutral-900) h s l / 60%); --cds-alpha-7: hsl(from var(--cds-neut=
+ral-900) h s l / 70%); --cds-alpha-8: hsl(from var(--cds-neutral-900) h s l=
+ / 85%); --cds-alpha-9: hsl(from var(--cds-neutral-900) h s l / 95%); --cds=
+-surface-0: var(--cds-gray-20); --cds-surface-1: var(--cds-gray-10); --cds-=
+surface-2: var(--cds-gray-0); --cds-surface-3: var(--cds-gray-0); --cds-sur=
+face-popover: var(--cds-surface-3); --cds-surface-panel: var(--cds-surface-=
+2); --cds-page-bg: var(--cds-surface-0); --cds-fill-accent: var(--cds-blue-=
+450); --cds-fill-accent-hover: var(--cds-blue-400); --cds-fill-danger: var(=
+--cds-red-450); --cds-fill-danger-hover: var(--cds-red-400); --cds-fill-suc=
+cess: var(--cds-green-450); --cds-fill-success-hover: var(--cds-green-400);=
+ --cds-fill-warning: var(--cds-yellow-200); --cds-fill-warning-hover: var(-=
+-cds-yellow-250); --cds-fill-pro: var(--cds-violet-450); --cds-fill-pro-hov=
+er: var(--cds-violet-400); --cds-fill-brand: var(--cds-clay-emphasized); --=
+cds-fill-brand-hover: var(--cds-clay); --cds-fill-primary: var(--cds-neutra=
+l-900); --cds-fill-primary-hover: var(--cds-neutral-750); --cds-fill-second=
+ary: #ffffff1a; --cds-fill-secondary-hover: var(--cds-alpha-1); --cds-fill-=
+secondary-ring: var(--cds-border); --cds-fill-field: #ffffff80; --cds-fill-=
+ghost-hover: var(--cds-alpha-1); --cds-fill-disabled: var(--cds-alpha-1); -=
+-cds-fill-control: var(--cds-alpha-2); --cds-fill-control-hover: var(--cds-=
+alpha-3); --cds-bg-accent: var(--cds-blue-100); --cds-bg-accent-chip: var(-=
+-cds-bg-accent); --cds-bg-danger: var(--cds-red-100); --cds-bg-danger-chip:=
+ var(--cds-bg-danger); --cds-bg-success: var(--cds-green-100); --cds-bg-suc=
+cess-chip: var(--cds-bg-success); --cds-bg-warning: var(--cds-yellow-100); =
+--cds-bg-warning-chip: var(--cds-bg-warning); --cds-bg-pro: var(--cds-viole=
+t-100); --cds-bg-pro-chip: var(--cds-bg-pro); --cds-bg-pink: var(--cds-mage=
+nta-50); --cds-bg-pink-chip: var(--cds-bg-pink); --cds-bg-neutral: var(--cd=
+s-alpha-1); --cds-bg-neutral-hover: var(--cds-alpha-2); --cds-bg-neutral-ch=
+ip: var(--cds-bg-neutral); --cds-bg-neutral-chip-hover: var(--cds-bg-neutra=
+l-hover); --cds-backdrop: #0006; --cds-text-accent: var(--cds-blue-600); --=
+cds-text-danger: var(--cds-red-600); --cds-text-success: var(--cds-green-60=
+0); --cds-text-warning: var(--cds-yellow-600); --cds-text-pro: var(--cds-vi=
+olet-600); --cds-text-pink: var(--cds-magenta-600); --cds-text-primary: var=
+(--cds-neutral-900); --cds-text-secondary: var(--cds-neutral-600); --cds-te=
+xt-muted: var(--cds-neutral-400); --cds-text-disabled: var(--cds-alpha-4); =
+--cds-font-size-caption: 11px; --cds-font-size-footnote: 12px; --cds-font-s=
+ize-code: 12px; --cds-font-size-body: 13px; --cds-font-size-heading: 14px; =
+--cds-font-size-title: 20px; --cds-leading-caption: 14px; --cds-leading-foo=
+tnote: 14px; --cds-leading-code: 17px; --cds-leading-body: 18px; --cds-lead=
+ing-heading: 18px; --cds-leading-title: 24px; --cds-on-primary: var(--cds-n=
+eutral-0); --cds-on-accent: var(--cds-gray-0); --cds-on-danger: var(--cds-g=
+ray-0); --cds-on-success: var(--cds-gray-900); --cds-on-warning: var(--cds-=
+gray-900); --cds-on-pro: var(--cds-gray-0); --cds-on-brand: var(--cds-gray-=
+0); --cds-z-modal: 40; --cds-z-popover: 50; --cds-z-tooltip: 50; --cds-z-to=
+ast: 60; --cds-avatar-sm: 20px; --cds-avatar-md: 28px; --cds-avatar-lg: 36p=
+x; --cds-checkbox: 16px; --cds-checkbox-glyph: 16px; --cds-checkbox-radius:=
+ 4px; --cds-segmented-control-thumb: var(--cds-surface-popover); --cds-segm=
+ented-control-track: var(--cds-alpha-1); --cds-skeleton-base: var(--cds-alp=
+ha-2); --cds-skeleton-sheen: var(--cds-alpha-2); --cds-switch-knob: var(--c=
+ds-gray-0); --cds-switch-track: var(--cds-alpha-3); --cds-switch-track-hove=
+r: var(--cds-alpha-4); --cds-switch-h: 16px; }
+
+[data-mode=3D"dark"] .cds-root:not([data-mode=3D"light"]):not([data-mode=3D=
+"system"]), .cds-root[data-mode=3D"dark"] { --cds-border-accent: var(--cds-=
+blue-700); --cds-border-danger: var(--cds-red-700); --cds-border-success: v=
+ar(--cds-green-700); --cds-border-warning: var(--cds-yellow-700); --cds-bor=
+der-pro: var(--cds-violet-700); --cds-shadow-color: #0000003d; --cds-shadow=
+-popover: 0 8px 24px #00000052, 0 2px 6px #0003; --cds-ring-outer: 0px; --c=
+ds-ring-inner: 1px; --cds-ring-color: var(--cds-alpha-2); --cds-focus-shado=
+w: inset 0 0 0 1px var(--cds-page-bg), 0 0 0 1px var(--cds-fill-accent), 0 =
+0 6px 1px hsl(from var(--cds-blue-600) h s l / 60%); --cds-pictogram-highli=
+ght-default: var(--cds-gray-650); --cds-pictogram-highlight-heather: var(--=
+cds-plum); --cds-pictogram-highlight-cactus: var(--cds-mineral); --cds-pict=
+ogram-highlight-peach: var(--cds-clay-emphasized); --cds-neutral-0: var(--c=
+ds-gray-900); --cds-neutral-10: var(--cds-gray-890); --cds-neutral-20: var(=
+--cds-gray-880); --cds-neutral-30: var(--cds-gray-870); --cds-neutral-40: v=
+ar(--cds-gray-860); --cds-neutral-50: var(--cds-gray-850); --cds-neutral-60=
+: var(--cds-gray-840); --cds-neutral-70: var(--cds-gray-830); --cds-neutral=
+-80: var(--cds-gray-820); --cds-neutral-90: var(--cds-gray-810); --cds-neut=
+ral-100: var(--cds-gray-800); --cds-neutral-150: var(--cds-gray-750); --cds=
+-neutral-200: var(--cds-gray-700); --cds-neutral-250: var(--cds-gray-650); =
+--cds-neutral-300: var(--cds-gray-600); --cds-neutral-350: var(--cds-gray-5=
+50); --cds-neutral-400: var(--cds-gray-500); --cds-neutral-450: var(--cds-g=
+ray-450); --cds-neutral-500: var(--cds-gray-400); --cds-neutral-550: var(--=
+cds-gray-350); --cds-neutral-600: var(--cds-gray-300); --cds-neutral-650: v=
+ar(--cds-gray-250); --cds-neutral-700: var(--cds-gray-200); --cds-neutral-7=
+50: var(--cds-gray-150); --cds-neutral-800: var(--cds-gray-100); --cds-neut=
+ral-810: var(--cds-gray-90); --cds-neutral-820: var(--cds-gray-80); --cds-n=
+eutral-830: var(--cds-gray-70); --cds-neutral-840: var(--cds-gray-60); --cd=
+s-neutral-850: var(--cds-gray-50); --cds-neutral-860: var(--cds-gray-40); -=
+-cds-neutral-870: var(--cds-gray-30); --cds-neutral-880: var(--cds-gray-20)=
+; --cds-neutral-890: var(--cds-gray-10); --cds-neutral-900: var(--cds-gray-=
+0); --cds-surface-0: var(--cds-gray-890); --cds-surface-1: var(--cds-gray-8=
+30); --cds-surface-2: var(--cds-gray-750); --cds-surface-3: var(--cds-gray-=
+700); --cds-fill-primary-hover: var(--cds-gray-100); --cds-fill-secondary: =
+var(--cds-alpha-2); --cds-fill-secondary-hover: #ffffff24; --cds-fill-secon=
+dary-ring: transparent; --cds-fill-field: var(--cds-fill-secondary); --cds-=
+bg-accent: var(--cds-blue-800); --cds-bg-danger: var(--cds-red-800); --cds-=
+bg-success: var(--cds-green-800); --cds-bg-warning: var(--cds-yellow-800); =
+--cds-bg-pro: var(--cds-violet-800); --cds-bg-pink: var(--cds-magenta-800);=
+ --cds-backdrop: #00000080; --cds-text-accent: var(--cds-blue-300); --cds-t=
+ext-danger: var(--cds-red-300); --cds-text-success: var(--cds-green-400); -=
+-cds-text-warning: var(--cds-yellow-300); --cds-text-pro: var(--cds-violet-=
+300); --cds-text-pink: var(--cds-magenta-400); --cds-text-secondary: var(--=
+cds-gray-200); --cds-text-muted: var(--cds-gray-400); --cds-segmented-contr=
+ol-thumb: var(--cds-alpha-3); }
+
+@media (prefers-color-scheme: dark) {
+  [data-mode=3D"system"] .cds-root:not([data-mode=3D"light"]):not([data-mod=
+e=3D"dark"]), .cds-root[data-mode=3D"system"], .cds-root:not([data-mode]):n=
+ot([data-mode] *) { --cds-border-accent: var(--cds-blue-700); --cds-border-=
+danger: var(--cds-red-700); --cds-border-success: var(--cds-green-700); --c=
+ds-border-warning: var(--cds-yellow-700); --cds-border-pro: var(--cds-viole=
+t-700); --cds-shadow-color: #0000003d; --cds-shadow-popover: 0 8px 24px #00=
+000052, 0 2px 6px #0003; --cds-ring-outer: 0px; --cds-ring-inner: 1px; --cd=
+s-ring-color: var(--cds-alpha-2); --cds-focus-shadow: inset 0 0 0 1px var(-=
+-cds-page-bg), 0 0 0 1px var(--cds-fill-accent), 0 0 6px 1px hsl(from var(-=
+-cds-blue-600) h s l / 60%); --cds-pictogram-highlight-default: var(--cds-g=
+ray-650); --cds-pictogram-highlight-heather: var(--cds-plum); --cds-pictogr=
+am-highlight-cactus: var(--cds-mineral); --cds-pictogram-highlight-peach: v=
+ar(--cds-clay-emphasized); --cds-neutral-0: var(--cds-gray-900); --cds-neut=
+ral-10: var(--cds-gray-890); --cds-neutral-20: var(--cds-gray-880); --cds-n=
+eutral-30: var(--cds-gray-870); --cds-neutral-40: var(--cds-gray-860); --cd=
+s-neutral-50: var(--cds-gray-850); --cds-neutral-60: var(--cds-gray-840); -=
+-cds-neutral-70: var(--cds-gray-830); --cds-neutral-80: var(--cds-gray-820)=
+; --cds-neutral-90: var(--cds-gray-810); --cds-neutral-100: var(--cds-gray-=
+800); --cds-neutral-150: var(--cds-gray-750); --cds-neutral-200: var(--cds-=
+gray-700); --cds-neutral-250: var(--cds-gray-650); --cds-neutral-300: var(-=
+-cds-gray-600); --cds-neutral-350: var(--cds-gray-550); --cds-neutral-400: =
+var(--cds-gray-500); --cds-neutral-450: var(--cds-gray-450); --cds-neutral-=
+500: var(--cds-gray-400); --cds-neutral-550: var(--cds-gray-350); --cds-neu=
+tral-600: var(--cds-gray-300); --cds-neutral-650: var(--cds-gray-250); --cd=
+s-neutral-700: var(--cds-gray-200); --cds-neutral-750: var(--cds-gray-150);=
+ --cds-neutral-800: var(--cds-gray-100); --cds-neutral-810: var(--cds-gray-=
+90); --cds-neutral-820: var(--cds-gray-80); --cds-neutral-830: var(--cds-gr=
+ay-70); --cds-neutral-840: var(--cds-gray-60); --cds-neutral-850: var(--cds=
+-gray-50); --cds-neutral-860: var(--cds-gray-40); --cds-neutral-870: var(--=
+cds-gray-30); --cds-neutral-880: var(--cds-gray-20); --cds-neutral-890: var=
+(--cds-gray-10); --cds-neutral-900: var(--cds-gray-0); --cds-surface-0: var=
+(--cds-gray-890); --cds-surface-1: var(--cds-gray-830); --cds-surface-2: va=
+r(--cds-gray-750); --cds-surface-3: var(--cds-gray-700); --cds-fill-primary=
+-hover: var(--cds-gray-100); --cds-fill-secondary: var(--cds-alpha-2); --cd=
+s-fill-secondary-hover: #ffffff24; --cds-fill-secondary-ring: transparent; =
+--cds-fill-field: var(--cds-fill-secondary); --cds-bg-accent: var(--cds-blu=
+e-800); --cds-bg-danger: var(--cds-red-800); --cds-bg-success: var(--cds-gr=
+een-800); --cds-bg-warning: var(--cds-yellow-800); --cds-bg-pro: var(--cds-=
+violet-800); --cds-bg-pink: var(--cds-magenta-800); --cds-backdrop: #000000=
+80; --cds-text-accent: var(--cds-blue-300); --cds-text-danger: var(--cds-re=
+d-300); --cds-text-success: var(--cds-green-400); --cds-text-warning: var(-=
+-cds-yellow-300); --cds-text-pro: var(--cds-violet-300); --cds-text-pink: v=
+ar(--cds-magenta-400); --cds-text-secondary: var(--cds-gray-200); --cds-tex=
+t-muted: var(--cds-gray-400); --cds-segmented-control-thumb: var(--cds-alph=
+a-3); }
+}
+
+.cds-root[data-font=3D"system"] { --cds-font-sans: var(--cds-font-system); =
+}
+
+.cds-root[data-platform=3D"desktop"] { --cds-cursor-interactive: default; }
+
+.cds-root[data-density=3D"comfortable"] { --cds-radius: 8px; --cds-h-contro=
+l: 32px; --cds-h-control-nested: 22px; --cds-icon: 20px; --cds-pad-sm: 8px;=
+ --cds-pad-md: 12px; --cds-pad-lg: 16px; --cds-pad-xl: 24px; --cds-gap-xs: =
+8px; --cds-gap-sm: 12px; --cds-gap-md: 16px; --cds-gap-lg: 28px; --cds-gap-=
+xl: 40px; --cds-font-size-caption: 12px; --cds-font-size-footnote: 13px; --=
+cds-font-size-code: 13px; --cds-font-size-body: 14px; --cds-font-size-headi=
+ng: 15px; --cds-font-size-title: 22px; --cds-leading-caption: 14px; --cds-l=
+eading-footnote: 16px; --cds-leading-code: 19px; --cds-leading-body: 20px; =
+--cds-leading-heading: 20px; --cds-leading-title: 26px; --cds-avatar-sm: 24=
+px; --cds-avatar-md: 32px; --cds-avatar-lg: 40px; --cds-checkbox: 20px; --c=
+ds-checkbox-glyph: 16px; --cds-checkbox-radius: 5px; --cds-switch-h: 20px; =
+}
+
+.cds-root [data-step=3D"1"], .cds-root[data-density=3D"compact"] [data-size=
+=3D"xs"], .cds-root[data-density=3D"compact"] [data-size=3D"sm"] { --cds-ra=
+dius: 5px; --cds-h-control: 20px; --cds-h-control-nested: 16px; --cds-icon:=
+ 12px; --cds-pad-sm: 4px; --cds-pad-md: 6px; --cds-pad-lg: 10px; --cds-pad-=
+xl: 14px; --cds-font-size-caption: 10px; --cds-font-size-body: 12px; --cds-=
+checkbox: 14px; --cds-checkbox-glyph: 14px; --cds-checkbox-radius: 4px; --c=
+ds-switch-h: 14px; }
+
+.cds-root [data-step=3D"2"], .cds-root[data-density=3D"comfortable"] [data-=
+size=3D"xs"] { --cds-radius: 6px; --cds-h-control: 24px; --cds-h-control-ne=
+sted: 18px; --cds-icon: 16px; --cds-pad-sm: 6px; --cds-pad-md: 8px; --cds-p=
+ad-lg: 12px; --cds-pad-xl: 20px; --cds-font-size-caption: 11px; --cds-font-=
+size-body: 13px; --cds-checkbox: 16px; --cds-checkbox-glyph: 16px; --cds-ch=
+eckbox-radius: 4px; --cds-switch-h: 16px; }
+
+.cds-root [data-step=3D"3"], .cds-root[data-density=3D"compact"] [data-size=
+=3D"lg"], .cds-root[data-density=3D"comfortable"] [data-size=3D"sm"] { --cd=
+s-radius: 7px; --cds-h-control: 28px; --cds-h-control-nested: 20px; --cds-i=
+con: 16px; --cds-pad-sm: 8px; --cds-pad-md: 10px; --cds-pad-lg: 14px; --cds=
+-pad-xl: 22px; --cds-font-size-caption: 12px; --cds-font-size-body: 14px; -=
+-cds-checkbox: 18px; --cds-checkbox-glyph: 16px; --cds-checkbox-radius: 5px=
+; --cds-switch-h: 18px; }
+
+.cds-root [data-step=3D"4"] { --cds-radius: 8px; --cds-h-control: 32px; --c=
+ds-h-control-nested: 22px; --cds-icon: 20px; --cds-pad-sm: 8px; --cds-pad-m=
+d: 12px; --cds-pad-lg: 16px; --cds-pad-xl: 24px; --cds-font-size-caption: 1=
+2px; --cds-font-size-body: 14px; --cds-checkbox: 20px; --cds-checkbox-glyph=
+: 16px; --cds-checkbox-radius: 5px; --cds-switch-h: 20px; }
+
+.cds-root [data-step=3D"5"], .cds-root[data-density=3D"comfortable"] [data-=
+size=3D"lg"] { --cds-radius: 10px; --cds-h-control: 40px; --cds-h-control-n=
+ested: 28px; --cds-icon: 24px; --cds-pad-sm: 12px; --cds-pad-md: 16px; --cd=
+s-pad-lg: 20px; --cds-pad-xl: 28px; --cds-font-size-caption: 13px; --cds-fo=
+nt-size-body: 15px; --cds-checkbox: 24px; --cds-checkbox-glyph: 20px; --cds=
+-checkbox-radius: 6px; --cds-switch-h: 24px; }
+
+*, ::before, ::after, ::backdrop { --tw-border-spacing-x: 0; --tw-border-sp=
+acing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-=
+skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; =
+--tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --=
+tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to=
+-position: ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --=
+tw-numeric-spacing: ; --tw-numeric-fraction: ; --tw-ring-inset: ; --tw-ring=
+-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color: #93c5fd8=
+0; --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-sh=
+adow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightne=
+ss: ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; =
+--tw-saturate: ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --=
+tw-backdrop-brightness: ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale=
+: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert: ; --tw-backdrop-opaci=
+ty: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia: ; --tw-contain-size: ;=
+ --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style: ; }
+
+html:where(.cds-root), html:where(.cds-root)::before, html:where(.cds-root)=
+::after, html:where(.cds-root) *, html:where(.cds-root) ::before, html:wher=
+e(.cds-root) ::after, html :where(.cds-root), html :where(.cds-root)::befor=
+e, html :where(.cds-root)::after, html :where(.cds-root) *, html :where(.cd=
+s-root) ::before, html :where(.cds-root) ::after { border-color: var(--cds-=
+border); }
+
+:where(.cds-root) :where(button, [role=3D"button"], [role=3D"tab"], [role=
+=3D"menuitem"], [role=3D"menuitemcheckbox"], [role=3D"menuitemradio"], [rol=
+e=3D"option"], [role=3D"switch"], [role=3D"checkbox"], [role=3D"radio"]) { =
+cursor: var(--cds-cursor-interactive); }
+
+:where(.cds-root) :where(button, [role]):where(:disabled, [aria-disabled=3D=
+"true"], [data-disabled]) { cursor: default; }
+
+:where(.cds-root) :where(input, textarea, select).cds-input { appearance: n=
+one; box-shadow: none; font: inherit; color: inherit; background: 0px 0px; =
+border: 0px; border-radius: 0px; outline: none; padding: 0px; }
+
+:where(.cds-root) :where(input, textarea).cds-input.cds-input:focus { box-s=
+hadow: none; border-color: var(--cds-border); outline: none; }
+
+:where(.cds-root) :where(input, textarea).cds-input.cds-input:focus-visible=
+ { box-shadow: var(--cds-focus-shadow); }
+
+:where(.cds-root) ::selection { background-color: var(--cds-alpha-3); }
+
+:where(.cds-root) *, :where(.cds-root) ::before, :where(.cds-root) ::after =
+{ border-color: var(--cds-border,currentColor); }
+
+:where(.cds-root) :where(button, input, select, textarea) { font: inherit; =
+color: inherit; background: 0px 0px; margin: 0px; padding: 0px; }
+
+.\!container { width: 100% !important; }
+
+.container { width: 100%; }
+
+@media (width >=3D 640px) {
+  .\!container { max-width: 640px !important; }
+  .container { max-width: 640px; }
+}
+
+@media (width >=3D 768px) {
+  .\!container { max-width: 768px !important; }
+  .container { max-width: 768px; }
+}
+
+@media (width >=3D 1024px) {
+  .\!container { max-width: 1024px !important; }
+  .container { max-width: 1024px; }
+}
+
+@media (width >=3D 1280px) {
+  .\!container { max-width: 1280px !important; }
+  .container { max-width: 1280px; }
+}
+
+@media (width >=3D 1536px) {
+  .\!container { max-width: 1536px !important; }
+  .container { max-width: 1536px; }
+}
+
+.sr-only { clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border-widt=
+h: 0px; width: 1px; height: 1px; margin: -1px; padding: 0px; position: abso=
+lute; overflow: hidden; }
+
+.pointer-events-none { pointer-events: none; }
+
+.pointer-events-auto { pointer-events: auto; }
+
+.\!visible { visibility: visible !important; }
+
+.visible { visibility: visible; }
+
+.invisible { visibility: hidden; }
+
+.collapse { visibility: collapse; }
+
+.static { position: static; }
+
+.\!fixed { position: fixed !important; }
+
+.fixed { position: fixed; }
+
+.absolute { position: absolute; }
+
+.relative { position: relative; }
+
+.\!sticky { position: sticky !important; }
+
+.sticky { position: sticky; }
+
+.inset-0 { inset: 0px; }
+
+.inset-1\.5 { inset: 0.375rem; }
+
+.inset-4 { inset: 1rem; }
+
+.inset-\[0\.5px\] { inset: 0.5px; }
+
+.inset-x-0 { left: 0px; right: 0px; }
+
+.inset-y-0 { top: 0px; bottom: 0px; }
+
+.inset-y-\[4px\] { top: 4px; bottom: 4px; }
+
+.-bottom-1 { bottom: -0.25rem; }
+
+.-left-\[19px\] { left: -19px; }
+
+.-right-1 { right: -0.25rem; }
+
+.-right-1\.5 { right: -0.375rem; }
+
+.-right-2 { right: -0.5rem; }
+
+.-top-0\.5 { top: -0.125rem; }
+
+.-top-1 { top: -0.25rem; }
+
+.-top-1\.5 { top: -0.375rem; }
+
+.-top-2 { top: -0.5rem; }
+
+.bottom-0 { bottom: 0px; }
+
+.bottom-0\.5 { bottom: 0.125rem; }
+
+.bottom-1\.5 { bottom: 0.375rem; }
+
+.bottom-2\.5 { bottom: 0.625rem; }
+
+.bottom-4 { bottom: 1rem; }
+
+.bottom-5 { bottom: 1.25rem; }
+
+.bottom-\[-8px\] { bottom: -8px; }
+
+.bottom-\[14px\] { bottom: 14px; }
+
+.bottom-\[18px\] { bottom: 18px; }
+
+.bottom-\[50px\] { bottom: 50px; }
+
+.bottom-full { bottom: 100%; }
+
+.bottom-px { bottom: 1px; }
+
+.left-0 { left: 0px; }
+
+.left-1\.5 { left: 0.375rem; }
+
+.left-1\/2 { left: 50%; }
+
+.left-2\.5 { left: 0.625rem; }
+
+.left-\[-2px\] { left: -2px; }
+
+.left-\[-9999px\] { left: -9999px; }
+
+.left-\[3px\] { left: 3px; }
+
+.left-\[var\(--active-tab-left\)\] { left: var(--active-tab-left); }
+
+.right-0 { right: 0px; }
+
+.right-1 { right: 0.25rem; }
+
+.right-1\.5 { right: 0.375rem; }
+
+.right-2 { right: 0.5rem; }
+
+.right-3 { right: 0.75rem; }
+
+.right-4 { right: 1rem; }
+
+.right-\[-2px\] { right: -2px; }
+
+.right-\[18px\] { right: 18px; }
+
+.right-\[3px\] { right: 3px; }
+
+.top-0 { top: 0px; }
+
+.top-0\.5 { top: 0.125rem; }
+
+.top-1 { top: 0.25rem; }
+
+.top-1\.5 { top: 0.375rem; }
+
+.top-1\/2 { top: 50%; }
+
+.top-2 { top: 0.5rem; }
+
+.top-2\.5 { top: 0.625rem; }
+
+.top-3 { top: 0.75rem; }
+
+.top-4 { top: 1rem; }
+
+.top-9 { top: 2.25rem; }
+
+.top-\[-3px\] { top: -3px; }
+
+.top-\[-9999px\] { top: -9999px; }
+
+.top-\[18px\] { top: 18px; }
+
+.top-\[30px\] { top: 30px; }
+
+.top-\[3px\] { top: 3px; }
+
+.top-\[var\(--active-tab-top\)\] { top: var(--active-tab-top); }
+
+.top-full { top: 100%; }
+
+.top-px { top: 1px; }
+
+.isolate { isolation: isolate; }
+
+.-z-10 { z-index: -10; }
+
+.-z-\[1\] { z-index: -1; }
+
+.z-0 { z-index: 0; }
+
+.z-10 { z-index: 10; }
+
+.z-20 { z-index: 20; }
+
+.z-50 { z-index: 50; }
+
+.z-\[10000\] { z-index: 10000; }
+
+.z-\[1000\] { z-index: 1000; }
+
+.z-\[1001\] { z-index: 1001; }
+
+.z-\[100\] { z-index: 100; }
+
+.z-\[110\] { z-index: 110; }
+
+.z-\[1999\] { z-index: 1999; }
+
+.z-\[1\] { z-index: 1; }
+
+.z-\[2000\] { z-index: 2000; }
+
+.z-\[2001\] { z-index: 2001; }
+
+.z-\[2\] { z-index: 2; }
+
+.z-\[5\] { z-index: 5; }
+
+.z-\[60\] { z-index: 60; }
+
+.z-\[75\] { z-index: 75; }
+
+.z-\[9999\] { z-index: 9999; }
+
+.z-modal { z-index: var(--cds-z-modal); }
+
+.z-om-modal { z-index: var(--om-z-modal); }
+
+.z-om-modal-top { z-index: var(--om-z-modal-top); }
+
+.z-om-popover { z-index: var(--om-z-popover); }
+
+.z-om-toast { z-index: var(--om-z-toast); }
+
+.z-popover { z-index: var(--cds-z-popover); }
+
+.z-toast { z-index: var(--cds-z-toast); }
+
+.z-tooltip { z-index: var(--cds-z-tooltip); }
+
+.col-\[1_\/_-1\] { grid-column: 1 / -1; }
+
+.col-auto { grid-column: auto; }
+
+.col-span-2 { grid-column: span 2 / span 2; }
+
+.col-span-full { grid-column: 1 / -1; }
+
+.col-start-1 { grid-column-start: 1; }
+
+.row-start-1 { grid-row-start: 1; }
+
+.-m-1 { margin: -0.25rem; }
+
+.-m-\[3px\] { margin: -3px; }
+
+.m-0 { margin: 0px; }
+
+.m-1 { margin: 0.25rem; }
+
+.m-2\.5 { margin: 0.625rem; }
+
+.m-\[12px_14px_4px\] { margin: 12px 14px 4px; }
+
+.m-\[6px_0_0_15px\] { margin: 6px 0px 0px 15px; }
+
+.m-auto { margin: auto; }
+
+.-mx-1 { margin-left: -0.25rem; margin-right: -0.25rem; }
+
+.-mx-11 { margin-left: -2.75rem; margin-right: -2.75rem; }
+
+.-mx-2 { margin-left: -0.5rem; margin-right: -0.5rem; }
+
+.-mx-3 { margin-left: -0.75rem; margin-right: -0.75rem; }
+
+.-mx-\[calc\(0\.5rem\+var\(--dt-flush-bleed\)\)\] { margin-left: calc(calc(=
+.5rem + var(--dt-flush-bleed)) * -1); margin-right: calc(calc(.5rem + var(-=
+-dt-flush-bleed)) * -1); }
+
+.-my-1 { margin-top: -0.25rem; margin-bottom: -0.25rem; }
+
+.-my-2 { margin-top: -0.5rem; margin-bottom: -0.5rem; }
+
+.-my-px { margin-top: -1px; margin-bottom: -1px; }
+
+.mx-0 { margin-left: 0px; margin-right: 0px; }
+
+.mx-0\.5 { margin-left: 0.125rem; margin-right: 0.125rem; }
+
+.mx-1 { margin-left: 0.25rem; margin-right: 0.25rem; }
+
+.mx-1\.5 { margin-left: 0.375rem; margin-right: 0.375rem; }
+
+.mx-2 { margin-left: 0.5rem; margin-right: 0.5rem; }
+
+.mx-3 { margin-left: 0.75rem; margin-right: 0.75rem; }
+
+.mx-3\.5 { margin-left: 0.875rem; margin-right: 0.875rem; }
+
+.mx-4 { margin-left: 1rem; margin-right: 1rem; }
+
+.mx-5 { margin-left: 1.25rem; margin-right: 1.25rem; }
+
+.mx-\[-10px\] { margin-left: -10px; margin-right: -10px; }
+
+.mx-\[-2px\] { margin-left: -2px; margin-right: -2px; }
+
+.mx-\[-3px\] { margin-left: -3px; margin-right: -3px; }
+
+.mx-\[-8px\] { margin-left: -8px; margin-right: -8px; }
+
+.mx-\[5px\] { margin-left: 5px; margin-right: 5px; }
+
+.mx-auto { margin-left: auto; margin-right: auto; }
+
+.mx-pad-md { margin-left: var(--cds-pad-md); margin-right: var(--cds-pad-md=
+); }
+
+.mx-px { margin-left: 1px; margin-right: 1px; }
+
+.my-0 { margin-top: 0px; margin-bottom: 0px; }
+
+.my-1 { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+
+.my-1\.5 { margin-top: 0.375rem; margin-bottom: 0.375rem; }
+
+.my-2 { margin-top: 0.5rem; margin-bottom: 0.5rem; }
+
+.my-2\.5 { margin-top: 0.625rem; margin-bottom: 0.625rem; }
+
+.my-3 { margin-top: 0.75rem; margin-bottom: 0.75rem; }
+
+.my-3\.5 { margin-top: 0.875rem; margin-bottom: 0.875rem; }
+
+.my-\[3px\] { margin-top: 3px; margin-bottom: 3px; }
+
+.my-\[5px\] { margin-top: 5px; margin-bottom: 5px; }
+
+.-mb-1 { margin-bottom: -0.25rem; }
+
+.-mb-2 { margin-bottom: -0.5rem; }
+
+.-mb-px { margin-bottom: -1px; }
+
+.-ml-1 { margin-left: -0.25rem; }
+
+.-ml-\[13px\] { margin-left: -13px; }
+
+.-ml-\[2px\] { margin-left: -2px; }
+
+.-ml-\[calc\(var\(--cds-pad-md\)-\(var\(--cds-h-control\)-var\(--cds-checkb=
+ox\)\)\/2\)\] { margin-left: calc(calc(var(--cds-pad-md) - (var(--cds-h-con=
+trol) - var(--cds-checkbox)) / 2) * -1); }
+
+.-ml-pad-md { margin-left: calc(var(--cds-pad-md) * -1); }
+
+.-mr-1 { margin-right: -0.25rem; }
+
+.-mr-\[calc\(var\(--cds-pad-md\)-2px\)\] { margin-right: calc(calc(var(--cd=
+s-pad-md) - 2px) * -1); }
+
+.-mr-\[calc\(var\(--cds-pad-md\)-6px\)\] { margin-right: calc(calc(var(--cd=
+s-pad-md) - 6px) * -1); }
+
+.-mr-pad-sm { margin-right: calc(var(--cds-pad-sm) * -1); }
+
+.-mt-0\.5 { margin-top: -0.125rem; }
+
+.-mt-1 { margin-top: -0.25rem; }
+
+.-mt-7 { margin-top: -1.75rem; }
+
+.-mt-pad-sm { margin-top: calc(var(--cds-pad-sm) * -1); }
+
+.-mt-px { margin-top: -1px; }
+
+.mb-0 { margin-bottom: 0px; }
+
+.mb-0\.5 { margin-bottom: 0.125rem; }
+
+.mb-1 { margin-bottom: 0.25rem; }
+
+.mb-1\.5 { margin-bottom: 0.375rem; }
+
+.mb-2 { margin-bottom: 0.5rem; }
+
+.mb-2\.5 { margin-bottom: 0.625rem; }
+
+.mb-20 { margin-bottom: 5rem; }
+
+.mb-3 { margin-bottom: 0.75rem; }
+
+.mb-3\.5 { margin-bottom: 0.875rem; }
+
+.mb-4 { margin-bottom: 1rem; }
+
+.mb-5 { margin-bottom: 1.25rem; }
+
+.mb-6 { margin-bottom: 1.5rem; }
+
+.mb-7 { margin-bottom: 1.75rem; }
+
+.mb-9 { margin-bottom: 2.25rem; }
+
+.mb-\[-8px\] { margin-bottom: -8px; }
+
+.mb-\[13px\] { margin-bottom: 13px; }
+
+.mb-\[18px\] { margin-bottom: 18px; }
+
+.mb-\[22px\] { margin-bottom: 22px; }
+
+.mb-\[2px\] { margin-bottom: 2px; }
+
+.mb-\[3px\] { margin-bottom: 3px; }
+
+.mb-\[5px\] { margin-bottom: 5px; }
+
+.mb-\[7px\] { margin-bottom: 7px; }
+
+.mb-pad-md { margin-bottom: var(--cds-pad-md); }
+
+.mb-px { margin-bottom: 1px; }
+
+.ml-0 { margin-left: 0px; }
+
+.ml-0\.5 { margin-left: 0.125rem; }
+
+.ml-1 { margin-left: 0.25rem; }
+
+.ml-1\.5 { margin-left: 0.375rem; }
+
+.ml-14 { margin-left: 3.5rem; }
+
+.ml-2 { margin-left: 0.5rem; }
+
+.ml-2\.5 { margin-left: 0.625rem; }
+
+.ml-3 { margin-left: 0.75rem; }
+
+.ml-3\.5 { margin-left: 0.875rem; }
+
+.ml-4 { margin-left: 1rem; }
+
+.ml-7 { margin-left: 1.75rem; }
+
+.ml-\[-17px\] { margin-left: -17px; }
+
+.ml-\[22px\] { margin-left: 22px; }
+
+.ml-\[5px\] { margin-left: 5px; }
+
+.ml-auto { margin-left: auto; }
+
+.ml-md { margin-left: var(--cds-gap-md); }
+
+.ml-px { margin-left: 1px; }
+
+.mr-0 { margin-right: 0px; }
+
+.mr-0\.5 { margin-right: 0.125rem; }
+
+.mr-1 { margin-right: 0.25rem; }
+
+.mr-1\.5 { margin-right: 0.375rem; }
+
+.mr-14 { margin-right: 3.5rem; }
+
+.mr-2 { margin-right: 0.5rem; }
+
+.mr-2\.5 { margin-right: 0.625rem; }
+
+.mr-3 { margin-right: 0.75rem; }
+
+.mr-\[-3px\] { margin-right: -3px; }
+
+.mr-\[45px\] { margin-right: 45px; }
+
+.mr-\[5px\] { margin-right: 5px; }
+
+.ms-auto { margin-inline-start: auto; }
+
+.mt-0 { margin-top: 0px; }
+
+.mt-0\.5 { margin-top: 0.125rem; }
+
+.mt-1 { margin-top: 0.25rem; }
+
+.mt-1\.5 { margin-top: 0.375rem; }
+
+.mt-10 { margin-top: 2.5rem; }
+
+.mt-2 { margin-top: 0.5rem; }
+
+.mt-2\.5 { margin-top: 0.625rem; }
+
+.mt-3 { margin-top: 0.75rem; }
+
+.mt-3\.5 { margin-top: 0.875rem; }
+
+.mt-4 { margin-top: 1rem; }
+
+.mt-5 { margin-top: 1.25rem; }
+
+.mt-6 { margin-top: 1.5rem; }
+
+.mt-\[-3px\] { margin-top: -3px; }
+
+.mt-\[18px\] { margin-top: 18px; }
+
+.mt-\[30px\] { margin-top: 30px; }
+
+.mt-\[3px\] { margin-top: 3px; }
+
+.mt-\[5px\] { margin-top: 5px; }
+
+.mt-\[7px\] { margin-top: 7px; }
+
+.mt-\[9px\] { margin-top: 9px; }
+
+.mt-\[calc\(\(var\(--cds-leading-body\,20px\)-var\(--cds-checkbox\,16px\)\)=
+\/2\)\] { margin-top: calc((var(--cds-leading-body,20px) - var(--cds-checkb=
+ox,16px)) / 2); }
+
+.mt-pad-lg { margin-top: var(--cds-pad-lg); }
+
+.mt-pad-md { margin-top: var(--cds-pad-md); }
+
+.mt-px { margin-top: 1px; }
+
+.mt-sm { margin-top: var(--cds-gap-sm); }
+
+.mt-xs { margin-top: var(--cds-gap-xs); }
+
+.box-border { box-sizing: border-box; }
+
+.box-content { box-sizing: content-box; }
+
+.line-clamp-2 { -webkit-line-clamp: 2; -webkit-box-orient: vertical; displa=
+y: -webkit-box; overflow: hidden; }
+
+.\!block { display: block !important; }
+
+.block { display: block; }
+
+.inline-block { display: inline-block; }
+
+.inline { display: inline; }
+
+.flex { display: flex; }
+
+.inline-flex { display: inline-flex; }
+
+.\!table { display: table !important; }
+
+.table { display: table; }
+
+.table-cell { display: table-cell; }
+
+.table-row { display: table-row; }
+
+.\!grid { display: grid !important; }
+
+.grid { display: grid; }
+
+.inline-grid { display: inline-grid; }
+
+.contents { display: contents; }
+
+.list-item { display: list-item; }
+
+.\!hidden { display: none !important; }
+
+.hidden { display: none; }
+
+.aspect-\[16\/10\] { aspect-ratio: 16 / 10; }
+
+.aspect-\[16\/9\] { aspect-ratio: 16 / 9; }
+
+.aspect-\[4\/3\] { aspect-ratio: 4 / 3; }
+
+.aspect-\[80\/56\] { aspect-ratio: 80 / 56; }
+
+.aspect-square { aspect-ratio: 1 / 1; }
+
+.aspect-video { aspect-ratio: 16 / 9; }
+
+.\!size-\[var\(--fhn\)\] { width: var(--fhn) !important; height: var(--fhn)=
+ !important; }
+
+.size-2 { width: 0.5rem; height: 0.5rem; }
+
+.size-\[16px\] { width: 16px; height: 16px; }
+
+.size-\[1lh\] { width: 1lh; height: 1lh; }
+
+.size-\[6px\] { width: 6px; height: 6px; }
+
+.size-\[calc\(var\(--cds-checkbox\,16px\)-8px\)\] { width: calc(var(--cds-c=
+heckbox,16px) - 8px); height: calc(var(--cds-checkbox,16px) - 8px); }
+
+.size-\[calc\(var\(--cds-h-control-nested\)-4px\)\] { width: calc(var(--cds=
+-h-control-nested) - 4px); height: calc(var(--cds-h-control-nested) - 4px);=
+ }
+
+.size-\[calc\(var\(--cds-switch-h\,20px\)-4px\)\] { width: calc(var(--cds-s=
+witch-h,20px) - 4px); height: calc(var(--cds-switch-h,20px) - 4px); }
+
+.size-\[var\(--cds-avatar-lg\)\] { width: var(--cds-avatar-lg); height: var=
+(--cds-avatar-lg); }
+
+.size-\[var\(--cds-avatar-md\)\] { width: var(--cds-avatar-md); height: var=
+(--cds-avatar-md); }
+
+.size-\[var\(--cds-avatar-sm\)\] { width: var(--cds-avatar-sm); height: var=
+(--cds-avatar-sm); }
+
+.size-\[var\(--cds-checkbox\)\] { width: var(--cds-checkbox); height: var(-=
+-cds-checkbox); }
+
+.size-full { width: 100%; height: 100%; }
+
+.size-icon { width: var(--cds-icon); height: var(--cds-icon); }
+
+.\!h-px { height: 1px !important; }
+
+.h-0 { height: 0px; }
+
+.h-0\.5 { height: 0.125rem; }
+
+.h-1 { height: 0.25rem; }
+
+.h-1\.5 { height: 0.375rem; }
+
+.h-10 { height: 2.5rem; }
+
+.h-11 { height: 2.75rem; }
+
+.h-12 { height: 3rem; }
+
+.h-14 { height: 3.5rem; }
+
+.h-16 { height: 4rem; }
+
+.h-2 { height: 0.5rem; }
+
+.h-20 { height: 5rem; }
+
+.h-3 { height: 0.75rem; }
+
+.h-3\.5 { height: 0.875rem; }
+
+.h-4 { height: 1rem; }
+
+.h-5 { height: 1.25rem; }
+
+.h-6 { height: 1.5rem; }
+
+.h-7 { height: 1.75rem; }
+
+.h-8 { height: 2rem; }
+
+.h-9 { height: 2.25rem; }
+
+.h-\[1\.6em\] { height: 1.6em; }
+
+.h-\[108px\] { height: 108px; }
+
+.h-\[11px\] { height: 11px; }
+
+.h-\[13px\] { height: 13px; }
+
+.h-\[140px\] { height: 140px; }
+
+.h-\[15px\] { height: 15px; }
+
+.h-\[17\.6px\] { height: 17.6px; }
+
+.h-\[18px\] { height: 18px; }
+
+.h-\[19px\] { height: 19px; }
+
+.h-\[1em\] { height: 1em; }
+
+.h-\[1lh\] { height: 1lh; }
+
+.h-\[22px\] { height: 22px; }
+
+.h-\[25px\] { height: 25px; }
+
+.h-\[26px\] { height: 26px; }
+
+.h-\[28px\] { height: 28px; }
+
+.h-\[29px\] { height: 29px; }
+
+.h-\[30px\] { height: 30px; }
+
+.h-\[30vh\] { height: 30vh; }
+
+.h-\[34px\] { height: 34px; }
+
+.h-\[38px\] { height: 38px; }
+
+.h-\[39px\] { height: 39px; }
+
+.h-\[3px\] { height: 3px; }
+
+.h-\[42px\] { height: 42px; }
+
+.h-\[46px\] { height: 46px; }
+
+.h-\[48px\] { height: 48px; }
+
+.h-\[52px\] { height: 52px; }
+
+.h-\[56px\] { height: 56px; }
+
+.h-\[580px\] { height: 580px; }
+
+.h-\[5px\] { height: 5px; }
+
+.h-\[60px\] { height: 60px; }
+
+.h-\[68px\] { height: 68px; }
+
+.h-\[7px\] { height: 7px; }
+
+.h-\[80vh\] { height: 80vh; }
+
+.h-\[88px\] { height: 88px; }
+
+.h-\[9px\] { height: 9px; }
+
+.h-\[a-z0-9\] { }
+
+.h-\[calc\(100dvh-2rem\)\] { height: calc(-2rem + 100dvh); }
+
+.h-\[var\(--accordion-panel-height\)\] { height: var(--accordion-panel-heig=
+ht); }
+
+.h-\[var\(--active-tab-height\)\] { height: var(--active-tab-height); }
+
+.h-\[var\(--cds-avatar-lg\)\] { height: var(--cds-avatar-lg); }
+
+.h-\[var\(--cds-avatar-md\)\] { height: var(--cds-avatar-md); }
+
+.h-\[var\(--cds-avatar-sm\)\] { height: var(--cds-avatar-sm); }
+
+.h-\[var\(--cds-h-control\,28px\)\] { height: var(--cds-h-control,28px); }
+
+.h-\[var\(--cds-h-control\,32px\)\] { height: var(--cds-h-control,32px); }
+
+.h-\[var\(--cds-switch-h\)\] { height: var(--cds-switch-h); }
+
+.h-\[var\(--collapsible-panel-height\)\] { height: var(--collapsible-panel-=
+height); }
+
+.h-auto { height: auto; }
+
+.h-control { height: var(--cds-h-control); }
+
+.h-control-nested { height: var(--cds-h-control-nested); }
+
+.h-dvh { height: 100dvh; }
+
+.h-fit { height: fit-content; }
+
+.h-full { height: 100%; }
+
+.h-icon { height: var(--cds-icon); }
+
+.h-px { height: 1px; }
+
+.max-h-\[140px\] { max-height: 140px; }
+
+.max-h-\[160px\] { max-height: 160px; }
+
+.max-h-\[176px\] { max-height: 176px; }
+
+.max-h-\[200px\] { max-height: 200px; }
+
+.max-h-\[220px\] { max-height: 220px; }
+
+.max-h-\[260px\] { max-height: 260px; }
+
+.max-h-\[280px\] { max-height: 280px; }
+
+.max-h-\[320px\] { max-height: 320px; }
+
+.max-h-\[440px\] { max-height: 440px; }
+
+.max-h-\[50vh\] { max-height: 50vh; }
+
+.max-h-\[600px\] { max-height: 600px; }
+
+.max-h-\[70vh\] { max-height: 70vh; }
+
+.max-h-\[80vh\] { max-height: 80vh; }
+
+.max-h-\[90vh\] { max-height: 90vh; }
+
+.max-h-\[calc\(100dvh-2rem\)\] { max-height: calc(-2rem + 100dvh); }
+
+.max-h-\[calc\(100vh-32px\)\] { max-height: calc(-32px + 100vh); }
+
+.max-h-\[calc\(100vh-64px\)\] { max-height: calc(-64px + 100vh); }
+
+.max-h-\[min\(600px\,calc\(100vh-58px\)\)\] { max-height: min(600px, -58px =
++ 100vh); }
+
+.max-h-\[min\(60vh\,520px\)\] { max-height: min(60vh, 520px); }
+
+.max-h-\[min\(640px\,calc\(100vh-64px\)\)\] { max-height: min(640px, -64px =
++ 100vh); }
+
+.max-h-\[min\(var\(--available-height\)\,var\(--cds-popup-max-h\,320px\)\)\=
+] { max-height: min(var(--available-height), var(--cds-popup-max-h,320px));=
+ }
+
+.max-h-\[var\(--available-height\)\] { max-height: var(--available-height);=
+ }
+
+.max-h-full { max-height: 100%; }
+
+.min-h-0 { min-height: 0px; }
+
+.min-h-20 { min-height: 5rem; }
+
+.min-h-6 { min-height: 1.5rem; }
+
+.min-h-8 { min-height: 2rem; }
+
+.min-h-\[13px\] { min-height: 13px; }
+
+.min-h-\[200px\] { min-height: 200px; }
+
+.min-h-\[20px\] { min-height: 20px; }
+
+.min-h-\[22px\] { min-height: 22px; }
+
+.min-h-\[240px\] { min-height: 240px; }
+
+.min-h-\[30px\] { min-height: 30px; }
+
+.min-h-\[36px\] { min-height: 36px; }
+
+.min-h-\[44px\] { min-height: 44px; }
+
+.min-h-\[46px\] { min-height: 46px; }
+
+.min-h-\[48px\] { min-height: 48px; }
+
+.min-h-\[80px\] { min-height: 80px; }
+
+.min-h-\[var\(--cds-leading-body\)\] { min-height: var(--cds-leading-body);=
+ }
+
+.min-h-control { min-height: var(--cds-h-control); }
+
+.min-h-full { min-height: 100%; }
+
+.min-h-screen { min-height: 100vh; }
+
+.w-1 { width: 0.25rem; }
+
+.w-1\.5 { width: 0.375rem; }
+
+.w-10 { width: 2.5rem; }
+
+.w-12 { width: 3rem; }
+
+.w-14 { width: 3.5rem; }
+
+.w-2 { width: 0.5rem; }
+
+.w-2\/3 { width: 66.6667%; }
+
+.w-20 { width: 5rem; }
+
+.w-24 { width: 6rem; }
+
+.w-3 { width: 0.75rem; }
+
+.w-3\.5 { width: 0.875rem; }
+
+.w-4 { width: 1rem; }
+
+.w-5 { width: 1.25rem; }
+
+.w-6 { width: 1.5rem; }
+
+.w-7 { width: 1.75rem; }
+
+.w-8 { width: 2rem; }
+
+.w-9 { width: 2.25rem; }
+
+.w-\[1\.5px\] { width: 1.5px; }
+
+.w-\[110px\] { width: 110px; }
+
+.w-\[11px\] { width: 11px; }
+
+.w-\[120px\] { width: 120px; }
+
+.w-\[128px\] { width: 128px; }
+
+.w-\[13px\] { width: 13px; }
+
+.w-\[13rem\] { width: 13rem; }
+
+.w-\[150px\] { width: 150px; }
+
+.w-\[15px\] { width: 15px; }
+
+.w-\[160px\] { width: 160px; }
+
+.w-\[162px\] { width: 162px; }
+
+.w-\[17\.6px\] { width: 17.6px; }
+
+.w-\[170px\] { width: 170px; }
+
+.w-\[180px\] { width: 180px; }
+
+.w-\[18px\] { width: 18px; }
+
+.w-\[190px\] { width: 190px; }
+
+.w-\[19px\] { width: 19px; }
+
+.w-\[1em\] { width: 1em; }
+
+.w-\[200px\] { width: 200px; }
+
+.w-\[220px\] { width: 220px; }
+
+.w-\[22px\] { width: 22px; }
+
+.w-\[240px\] { width: 240px; }
+
+.w-\[25px\] { width: 25px; }
+
+.w-\[260px\] { width: 260px; }
+
+.w-\[264px\] { width: 264px; }
+
+.w-\[26px\] { width: 26px; }
+
+.w-\[288px\] { width: 288px; }
+
+.w-\[300px\] { width: 300px; }
+
+.w-\[30px\] { width: 30px; }
+
+.w-\[318px\] { width: 318px; }
+
+.w-\[34\%\] { width: 34%; }
+
+.w-\[340px\] { width: 340px; }
+
+.w-\[360px\] { width: 360px; }
+
+.w-\[40\%\] { width: 40%; }
+
+.w-\[420px\] { width: 420px; }
+
+.w-\[42px\] { width: 42px; }
+
+.w-\[432px\] { width: 432px; }
+
+.w-\[44px\] { width: 44px; }
+
+.w-\[460px\] { width: 460px; }
+
+.w-\[480px\] { width: 480px; }
+
+.w-\[500px\] { width: 500px; }
+
+.w-\[50px\] { width: 50px; }
+
+.w-\[520px\] { width: 520px; }
+
+.w-\[52px\] { width: 52px; }
+
+.w-\[540px\] { width: 540px; }
+
+.w-\[56px\] { width: 56px; }
+
+.w-\[580px\] { width: 580px; }
+
+.w-\[5px\] { width: 5px; }
+
+.w-\[68px\] { width: 68px; }
+
+.w-\[72px\] { width: 72px; }
+
+.w-\[74px\] { width: 74px; }
+
+.w-\[780px\] { width: 780px; }
+
+.w-\[80px\] { width: 80px; }
+
+.w-\[80vw\] { width: 80vw; }
+
+.w-\[84px\] { width: 84px; }
+
+.w-\[88px\] { width: 88px; }
+
+.w-\[90px\] { width: 90px; }
+
+.w-\[96px\] { width: 96px; }
+
+.w-\[9px\] { width: 9px; }
+
+.w-\[calc\(100\%\+16px\)\] { width: calc(100% + 16px); }
+
+.w-\[calc\(100\%\+8px\)\] { width: calc(100% + 8px); }
+
+.w-\[calc\(100\%-20px\)\] { width: calc(100% - 20px); }
+
+.w-\[calc\(100vw-2rem\)\] { width: calc(-2rem + 100vw); }
+
+.w-\[calc\(var\(--cds-switch-h\,20px\)\*1\.8\)\] { width: calc(var(--cds-sw=
+itch-h,20px) * 1.8); }
+
+.w-\[min\(600px\,calc\(100\%-100px\)\)\] { width: min(600px, 100% - 100px);=
+ }
+
+.w-\[min\(640px\,92vw\)\] { width: min(640px, 92vw); }
+
+.w-\[var\(--active-tab-width\)\] { width: var(--active-tab-width); }
+
+.w-\[var\(--anchor-width\)\] { width: var(--anchor-width); }
+
+.w-\[var\(--left\)\] { width: var(--left); }
+
+.w-\[=E2=80=A6\] { }
+
+.w-auto { width: auto; }
+
+.w-control { width: var(--cds-h-control); }
+
+.w-fit { width: fit-content; }
+
+.w-full { width: 100%; }
+
+.w-px { width: 1px; }
+
+.min-w-0 { min-width: 0px; }
+
+.min-w-10 { min-width: 2.5rem; }
+
+.min-w-12 { min-width: 3rem; }
+
+.min-w-\[1\.5em\] { min-width: 1.5em; }
+
+.min-w-\[128px\] { min-width: 128px; }
+
+.min-w-\[12rem\] { min-width: 12rem; }
+
+.min-w-\[13px\] { min-width: 13px; }
+
+.min-w-\[140px\] { min-width: 140px; }
+
+.min-w-\[150px\] { min-width: 150px; }
+
+.min-w-\[17rem\] { min-width: 17rem; }
+
+.min-w-\[180px\] { min-width: 180px; }
+
+.min-w-\[200px\] { min-width: 200px; }
+
+.min-w-\[21rem\] { min-width: 21rem; }
+
+.min-w-\[240px\] { min-width: 240px; }
+
+.min-w-\[24px\] { min-width: 24px; }
+
+.min-w-\[280px\] { min-width: 280px; }
+
+.min-w-\[2ch\] { min-width: 2ch; }
+
+.min-w-\[2px\] { min-width: 2px; }
+
+.min-w-\[36px\] { min-width: 36px; }
+
+.min-w-\[40px\] { min-width: 40px; }
+
+.min-w-\[44px\] { min-width: 44px; }
+
+.min-w-\[48px\] { min-width: 48px; }
+
+.min-w-\[5\.5rem\] { min-width: 5.5rem; }
+
+.min-w-\[80px\] { min-width: 80px; }
+
+.min-w-\[min\(20ch\,100\%\)\] { min-width: min(20ch, 100%); }
+
+.min-w-\[var\(--cds-avatar-lg\)\] { min-width: var(--cds-avatar-lg); }
+
+.min-w-\[var\(--cds-avatar-md\)\] { min-width: var(--cds-avatar-md); }
+
+.min-w-\[var\(--cds-avatar-sm\)\] { min-width: var(--cds-avatar-sm); }
+
+.min-w-\[var\(--cds-h-control-nested\)\] { min-width: var(--cds-h-control-n=
+ested); }
+
+.\!max-w-fit { max-width: fit-content !important; }
+
+.max-w-4xl { max-width: 56rem; }
+
+.max-w-\[1024px\] { max-width: 1024px; }
+
+.max-w-\[1064px\] { max-width: 1064px; }
+
+.max-w-\[1152px\] { max-width: 1152px; }
+
+.max-w-\[120px\] { max-width: 120px; }
+
+.max-w-\[1480px\] { max-width: 1480px; }
+
+.max-w-\[150px\] { max-width: 150px; }
+
+.max-w-\[160px\] { max-width: 160px; }
+
+.max-w-\[240px\] { max-width: 240px; }
+
+.max-w-\[260px\] { max-width: 260px; }
+
+.max-w-\[280px\] { max-width: 280px; }
+
+.max-w-\[300px\] { max-width: 300px; }
+
+.max-w-\[320px\] { max-width: 320px; }
+
+.max-w-\[36rem\] { max-width: 36rem; }
+
+.max-w-\[400px\] { max-width: 400px; }
+
+.max-w-\[420px\] { max-width: 420px; }
+
+.max-w-\[520px\] { max-width: 520px; }
+
+.max-w-\[560px\] { max-width: 560px; }
+
+.max-w-\[620px\] { max-width: 620px; }
+
+.max-w-\[640px\] { max-width: 640px; }
+
+.max-w-\[720px\] { max-width: 720px; }
+
+.max-w-\[760px\] { max-width: 760px; }
+
+.max-w-\[80\%\] { max-width: 80%; }
+
+.max-w-\[800px\] { max-width: 800px; }
+
+.max-w-\[82\%\] { max-width: 82%; }
+
+.max-w-\[85\%\] { max-width: 85%; }
+
+.max-w-\[880px\] { max-width: 880px; }
+
+.max-w-\[90vw\] { max-width: 90vw; }
+
+.max-w-\[calc\(100\%-24px\)\] { max-width: calc(100% - 24px); }
+
+.max-w-\[calc\(100vw-24px\)\] { max-width: calc(-24px + 100vw); }
+
+.max-w-\[calc\(100vw-2rem\)\] { max-width: calc(-2rem + 100vw); }
+
+.max-w-\[calc\(100vw-32px\)\] { max-width: calc(-32px + 100vw); }
+
+.max-w-\[min\(440px\,calc\(100vw-32px\)\)\] { max-width: min(440px, -32px +=
+ 100vw); }
+
+.max-w-fit { max-width: fit-content; }
+
+.max-w-full { max-width: 100%; }
+
+.max-w-none { max-width: none; }
+
+.flex-1 { flex: 1 1 0%; }
+
+.flex-\[0_0_144px\] { flex: 0 0 144px; }
+
+.flex-\[0_0_168px\] { flex: 0 0 168px; }
+
+.flex-\[0_0_248px\] { flex: 0 0 248px; }
+
+.flex-\[0_0_24px\] { flex: 0 0 24px; }
+
+.flex-\[0_0_368px\] { flex: 0 0 368px; }
+
+.flex-\[0_0_40\%\] { flex: 0 0 40%; }
+
+.flex-\[0_1_220px\] { flex: 0 1 220px; }
+
+.flex-\[1_1_100\%\] { flex: 1 1 100%; }
+
+.flex-\[1_1_120px\] { flex: 1 1 120px; }
+
+.flex-\[1_1_220px\] { flex: 1 1 220px; }
+
+.flex-\[1_1_60\%\] { flex: 1 1 60%; }
+
+.flex-\[1_1_auto\], .flex-auto { flex: 1 1 auto; }
+
+.flex-initial { flex: 0 1 auto; }
+
+.flex-none { flex: 0 0 auto; }
+
+.flex-shrink, .shrink { flex-shrink: 1; }
+
+.shrink-0 { flex-shrink: 0; }
+
+.flex-grow, .grow { flex-grow: 1; }
+
+.basis-0 { flex-basis: 0px; }
+
+.table-auto { table-layout: auto; }
+
+.table-fixed { table-layout: fixed; }
+
+.border-collapse { border-collapse: collapse; }
+
+.origin-\[var\(--transform-origin\)\] { transform-origin: var(--transform-o=
+rigin); }
+
+.origin-bottom { transform-origin: center bottom; }
+
+.origin-bottom-left { transform-origin: 0px 100%; }
+
+.origin-center { transform-origin: 50% center; }
+
+.origin-top { transform-origin: center top; }
+
+.origin-top-left { transform-origin: 0px 0px; }
+
+.-translate-x-1\/2 { --tw-translate-x: -50%; transform: translate(var(--tw-=
+translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--t=
+w-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--t=
+w-scale-y)); }
+
+.-translate-y-1\/2 { --tw-translate-y: -50%; transform: translate(var(--tw-=
+translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--t=
+w-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--t=
+w-scale-y)); }
+
+.-translate-y-full { --tw-translate-y: -100%; transform: translate(var(--tw=
+-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--=
+tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--=
+tw-scale-y)); }
+
+.translate-x-0 { --tw-translate-x: 0px; transform: translate(var(--tw-trans=
+late-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-ske=
+w-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-sca=
+le-y)); }
+
+.translate-x-3\.5 { --tw-translate-x: .875rem; transform: translate(var(--t=
+w-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(-=
+-tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(-=
+-tw-scale-y)); }
+
+.translate-x-\[-10px\] { --tw-translate-x: -10px; transform: translate(var(=
+--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(va=
+r(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(va=
+r(--tw-scale-y)); }
+
+.translate-y-px { --tw-translate-y: 1px; transform: translate(var(--tw-tran=
+slate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-sk=
+ew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-sc=
+ale-y)); }
+
+.-rotate-90 { --tw-rotate: -90deg; transform: translate(var(--tw-translate-=
+x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x))=
+ skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)=
+); }
+
+.rotate-0 { --tw-rotate: 0deg; transform: translate(var(--tw-translate-x), =
+var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) ske=
+wY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.rotate-180 { --tw-rotate: 180deg; transform: translate(var(--tw-translate-=
+x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x))=
+ skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)=
+); }
+
+.rotate-90 { --tw-rotate: 90deg; transform: translate(var(--tw-translate-x)=
+, var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) s=
+kewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));=
+ }
+
+.scale-100 { --tw-scale-x: 1; --tw-scale-y: 1; transform: translate(var(--t=
+w-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(-=
+-tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(-=
+-tw-scale-y)); }
+
+.scale-110 { --tw-scale-x: 1.1; --tw-scale-y: 1.1; transform: translate(var=
+(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(v=
+ar(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(v=
+ar(--tw-scale-y)); }
+
+.scale-95 { --tw-scale-x: .95; --tw-scale-y: .95; transform: translate(var(=
+--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(va=
+r(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(va=
+r(--tw-scale-y)); }
+
+.scale-\[1\.02\] { --tw-scale-x: 1.02; --tw-scale-y: 1.02; transform: trans=
+late(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))=
+ skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) =
+scaleY(var(--tw-scale-y)); }
+
+.scale-\[1\.2\] { --tw-scale-x: 1.2; --tw-scale-y: 1.2; transform: translat=
+e(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) sk=
+ewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) sca=
+leY(var(--tw-scale-y)); }
+
+.\!transform { transform: translate(var(--tw-translate-x), var(--tw-transla=
+te-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew=
+-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)) !important; }
+
+.transform { transform: translate(var(--tw-translate-x), var(--tw-translate=
+-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y=
+)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.animate-\[cds-shimmer-text-shine_3s_cubic-bezier\(0\.77\,0\,0\.175\,1\)_in=
+finite\] { animation: 3s cubic-bezier(0.77, 0, 0.175, 1) 0s infinite normal=
+ none running cds-shimmer-text-shine; }
+
+@keyframes spin {=20
+  100% { transform: rotate(360deg); }
+}
+
+.animate-\[spin_2s_linear_infinite\] { animation: 2s linear 0s infinite nor=
+mal none running spin; }
+
+@keyframes om-fade-in {=20
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+.animate-om-fade-in { animation: 0.15s ease-out 0s 1 normal none running om=
+-fade-in; }
+
+@keyframes om-presence-pulse {=20
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.animate-om-presence-pulse { animation: 1.2s ease-in-out 0s infinite normal=
+ none running om-presence-pulse; }
+
+@keyframes om-pulse {=20
+  0%, 80%, 100% { opacity: 0.25; transform: scale(0.75); }
+  40% { opacity: 1; transform: scale(1); }
+}
+
+.animate-om-pulse { animation: 1.2s ease-in-out 0s infinite normal none run=
+ning om-pulse; }
+
+@keyframes om-scale-in {=20
+  0% { opacity: 0; transform: scale(0.96); }
+  100% { opacity: 1; transform: scale(1); }
+}
+
+.animate-om-scale-in { animation: 0.15s ease-out 0s 1 normal none running o=
+m-scale-in; }
+
+@keyframes om-spark-pulse {=20
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.45; transform: scale(0.85); }
+}
+
+.animate-om-spark-pulse { animation: 1.2s ease-in-out 0s infinite normal no=
+ne running om-spark-pulse; }
+
+@keyframes om-spin {=20
+  100% { transform: rotate(360deg); }
+}
+
+.animate-om-spin { animation: 1s linear 0s infinite normal none running om-=
+spin; }
+
+@keyframes pulse {=20
+  50% { opacity: 0.5; }
+}
+
+.animate-pulse { animation: 2s cubic-bezier(0.4, 0, 0.6, 1) 0s infinite nor=
+mal none running pulse; }
+
+.cursor-\[inherit\] { cursor: inherit; }
+
+.cursor-\[var\(--cds-cursor-interactive\)\] { cursor: var(--cds-cursor-inte=
+ractive); }
+
+.cursor-auto { cursor: auto; }
+
+.cursor-col-resize { cursor: col-resize; }
+
+.cursor-crosshair { cursor: crosshair; }
+
+.cursor-default { cursor: default; }
+
+.cursor-ew-resize { cursor: ew-resize; }
+
+.cursor-grab { cursor: grab; }
+
+.cursor-grabbing { cursor: grabbing; }
+
+.cursor-not-allowed { cursor: not-allowed; }
+
+.cursor-ns-resize { cursor: ns-resize; }
+
+.cursor-nwse-resize { cursor: nwse-resize; }
+
+.cursor-pointer { cursor: pointer; }
+
+.cursor-row-resize { cursor: row-resize; }
+
+.cursor-text { cursor: text; }
+
+.cursor-zoom-in { cursor: zoom-in; }
+
+.cursor-zoom-out { cursor: zoom-out; }
+
+.touch-none { touch-action: none; }
+
+.select-none { user-select: none; }
+
+.select-text { user-select: text; }
+
+.select-all { user-select: all; }
+
+.resize-none { resize: none; }
+
+.resize-y { resize: vertical; }
+
+.resize { resize: both; }
+
+.scroll-pb-7 { scroll-padding-bottom: 1.75rem; }
+
+.list-disc { list-style-type: disc; }
+
+.list-none { list-style-type: none; }
+
+.appearance-none { appearance: none; }
+
+.grid-cols-1 { grid-template-columns: repeat(1, minmax(0px, 1fr)); }
+
+.grid-cols-2 { grid-template-columns: repeat(2, minmax(0px, 1fr)); }
+
+.grid-cols-3 { grid-template-columns: repeat(3, minmax(0px, 1fr)); }
+
+.grid-cols-4 { grid-template-columns: repeat(4, minmax(0px, 1fr)); }
+
+.grid-cols-8 { grid-template-columns: repeat(8, minmax(0px, 1fr)); }
+
+.grid-cols-\[118px_1fr_42px_42px_42px\] { grid-template-columns: 118px 1fr =
+42px 42px 42px; }
+
+.grid-cols-\[1fr_1fr_auto\] { grid-template-columns: 1fr 1fr auto; }
+
+.grid-cols-\[1fr_250px\] { grid-template-columns: 1fr 250px; }
+
+.grid-cols-\[1fr_auto_1fr\] { grid-template-columns: 1fr auto 1fr; }
+
+.grid-cols-\[96px_auto\] { grid-template-columns: 96px auto; }
+
+.grid-cols-\[repeat\(auto-fill\,minmax\(150px\,1fr\)\)\] { grid-template-co=
+lumns: repeat(auto-fill, minmax(150px, 1fr)); }
+
+.grid-cols-\[repeat\(auto-fill\,minmax\(280px\,1fr\)\)\] { grid-template-co=
+lumns: repeat(auto-fill, minmax(280px, 1fr)); }
+
+.grid-cols-\[repeat\(auto-fill\,minmax\(68px\,1fr\)\)\] { grid-template-col=
+umns: repeat(auto-fill, minmax(68px, 1fr)); }
+
+.grid-rows-\[0fr\] { grid-template-rows: 0fr; }
+
+.grid-rows-\[1fr\] { grid-template-rows: 1fr; }
+
+.flex-row { flex-direction: row; }
+
+.flex-col { flex-direction: column; }
+
+.flex-col-reverse { flex-direction: column-reverse; }
+
+.flex-wrap { flex-wrap: wrap; }
+
+.flex-wrap-reverse { flex-wrap: wrap-reverse; }
+
+.flex-nowrap { flex-wrap: nowrap; }
+
+.place-items-center { place-items: center; }
+
+.items-start { align-items: flex-start; }
+
+.items-end { align-items: flex-end; }
+
+.items-center { align-items: center; }
+
+.items-baseline { align-items: baseline; }
+
+.items-stretch { align-items: stretch; }
+
+.justify-start { justify-content: flex-start; }
+
+.justify-end { justify-content: flex-end; }
+
+.justify-center { justify-content: center; }
+
+.justify-between { justify-content: space-between; }
+
+.gap-0 { gap: 0px; }
+
+.gap-0\.5 { gap: 0.125rem; }
+
+.gap-1 { gap: 0.25rem; }
+
+.gap-1\.5 { gap: 0.375rem; }
+
+.gap-10 { gap: 2.5rem; }
+
+.gap-12 { gap: 3rem; }
+
+.gap-2 { gap: 0.5rem; }
+
+.gap-2\.5 { gap: 0.625rem; }
+
+.gap-3 { gap: 0.75rem; }
+
+.gap-3\.5 { gap: 0.875rem; }
+
+.gap-4 { gap: 1rem; }
+
+.gap-5 { gap: 1.25rem; }
+
+.gap-6 { gap: 1.5rem; }
+
+.gap-7 { gap: 1.75rem; }
+
+.gap-\[10px\] { gap: 10px; }
+
+.gap-\[11px\] { gap: 11px; }
+
+.gap-\[14px\] { gap: 14px; }
+
+.gap-\[17px\] { gap: 17px; }
+
+.gap-\[18px\] { gap: 18px; }
+
+.gap-\[1px\] { gap: 1px; }
+
+.gap-\[24px\] { gap: 24px; }
+
+.gap-\[2px\] { gap: 2px; }
+
+.gap-\[3px\] { gap: 3px; }
+
+.gap-\[4px\] { gap: 4px; }
+
+.gap-\[5px\] { gap: 5px; }
+
+.gap-\[7px\] { gap: 7px; }
+
+.gap-\[8px\] { gap: 8px; }
+
+.gap-\[9px\] { gap: 9px; }
+
+.gap-\[inherit\] { gap: inherit; }
+
+.gap-\[var\(--cds-pad-sm\,6px\)\] { gap: var(--cds-pad-sm,6px); }
+
+.gap-lg { gap: var(--cds-gap-lg); }
+
+.gap-md { gap: var(--cds-gap-md); }
+
+.gap-px { gap: 1px; }
+
+.gap-sm { gap: var(--cds-gap-sm); }
+
+.gap-xl { gap: var(--cds-gap-xl); }
+
+.gap-xs { gap: var(--cds-gap-xs); }
+
+.gap-x-1\.5 { column-gap: 0.375rem; }
+
+.gap-x-2 { column-gap: 0.5rem; }
+
+.gap-x-2\.5 { column-gap: 0.625rem; }
+
+.gap-x-3 { column-gap: 0.75rem; }
+
+.gap-x-4 { column-gap: 1rem; }
+
+.gap-x-5 { column-gap: 1.25rem; }
+
+.gap-x-7 { column-gap: 1.75rem; }
+
+.gap-x-md { column-gap: var(--cds-gap-md); }
+
+.gap-y-1 { row-gap: 0.25rem; }
+
+.gap-y-1\.5 { row-gap: 0.375rem; }
+
+.gap-y-2 { row-gap: 0.5rem; }
+
+.gap-y-3 { row-gap: 0.75rem; }
+
+.gap-y-\[18px\] { row-gap: 18px; }
+
+.gap-y-px { row-gap: 1px; }
+
+.gap-y-sm { row-gap: var(--cds-gap-sm); }
+
+.divide-y > :not([hidden]) ~ :not([hidden]) { --tw-divide-y-reverse: 0; bor=
+der-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse))); border-bot=
+tom-width: calc(1px * var(--tw-divide-y-reverse)); }
+
+.self-start { align-self: flex-start; }
+
+.self-center { align-self: center; }
+
+.self-stretch { align-self: stretch; }
+
+.justify-self-start { justify-self: start; }
+
+.justify-self-end { justify-self: end; }
+
+.overflow-auto { overflow: auto; }
+
+.overflow-hidden { overflow: hidden; }
+
+.overflow-visible { overflow: visible; }
+
+.overflow-x-auto { overflow-x: auto; }
+
+.overflow-y-auto { overflow-y: auto; }
+
+.overflow-x-hidden { overflow-x: hidden; }
+
+.overflow-y-hidden { overflow-y: hidden; }
+
+.truncate { text-overflow: ellipsis; white-space: nowrap; overflow: hidden;=
+ }
+
+.text-ellipsis { text-overflow: ellipsis; }
+
+.whitespace-normal { white-space: normal; }
+
+.whitespace-nowrap { white-space: nowrap; }
+
+.whitespace-pre { white-space: pre; }
+
+.whitespace-pre-line { white-space: pre-line; }
+
+.whitespace-pre-wrap { white-space: pre-wrap; }
+
+.text-wrap { text-wrap: wrap; }
+
+.text-pretty { text-wrap: pretty; }
+
+.break-normal { overflow-wrap: normal; word-break: normal; }
+
+.break-words { overflow-wrap: break-word; }
+
+.break-all { word-break: break-all; }
+
+.\!rounded-\[calc\(var\(--fr\)-\(var\(--fh\)-var\(--fhn\)\)\/2\)\] { border=
+-radius: calc(var(--fr) - (var(--fh) - var(--fhn)) / 2) !important; }
+
+.rounded { border-radius: var(--cds-radius); }
+
+.rounded-2xl { border-radius: 1rem; }
+
+.rounded-\[0_5px_5px_0\] { border-radius: 0px 5px 5px 0px; }
+
+.rounded-\[100px\] { border-radius: 100px; }
+
+.rounded-\[10px\] { border-radius: 10px; }
+
+.rounded-\[13px\] { border-radius: 13px; }
+
+.rounded-\[14px\] { border-radius: 14px; }
+
+.rounded-\[16px\] { border-radius: 16px; }
+
+.rounded-\[18px\] { border-radius: 18px; }
+
+.rounded-\[1px\] { border-radius: 1px; }
+
+.rounded-\[20px\] { border-radius: 20px; }
+
+.rounded-\[24px\] { border-radius: 24px; }
+
+.rounded-\[2px\] { border-radius: 2px; }
+
+.rounded-\[3px\] { border-radius: 3px; }
+
+.rounded-\[4px\] { border-radius: 4px; }
+
+.rounded-\[50\%_50\%_50\%_0\] { border-radius: 50% 50% 50% 0px; }
+
+.rounded-\[5px\] { border-radius: 5px; }
+
+.rounded-\[6px\] { border-radius: 6px; }
+
+.rounded-\[7px\] { border-radius: 7px; }
+
+.rounded-\[99px\] { border-radius: 99px; }
+
+.rounded-\[9px\] { border-radius: 9px; }
+
+.rounded-\[calc\(var\(--cds-h-control-nested\)\/4-2px\)\] { border-radius: =
+calc(var(--cds-h-control-nested) / 4 - 2px); }
+
+.rounded-\[calc\(var\(--cds-radius\)-1px\)\] { border-radius: calc(var(--cd=
+s-radius) - 1px); }
+
+.rounded-\[calc\(var\(--cds-radius\)-2px\)\] { border-radius: calc(var(--cd=
+s-radius) - 2px); }
+
+.rounded-\[inherit\] { border-radius: inherit; }
+
+.rounded-\[var\(--cds-checkbox-radius\)\] { border-radius: var(--cds-checkb=
+ox-radius); }
+
+.rounded-card { border-radius: calc(var(--cds-radius) + 4px); }
+
+.rounded-chip { border-radius: calc(var(--cds-h-control-nested) / 4); }
+
+.rounded-full { border-radius: 9999px; }
+
+.rounded-lg { border-radius: 0.5rem; }
+
+.rounded-md { border-radius: 0.375rem; }
+
+.rounded-none { border-radius: 0px; }
+
+.rounded-xl { border-radius: 0.75rem; }
+
+.rounded-b-\[10px\] { border-bottom-right-radius: 10px; border-bottom-left-=
+radius: 10px; }
+
+.rounded-b-\[1px\] { border-bottom-right-radius: 1px; border-bottom-left-ra=
+dius: 1px; }
+
+.rounded-b-\[4px\] { border-bottom-right-radius: 4px; border-bottom-left-ra=
+dius: 4px; }
+
+.rounded-b-\[inherit\] { border-bottom-right-radius: inherit; border-bottom=
+-left-radius: inherit; }
+
+.rounded-b-xl { border-bottom-right-radius: 0.75rem; border-bottom-left-rad=
+ius: 0.75rem; }
+
+.rounded-e-\[inherit\] { border-start-end-radius: inherit; border-end-end-r=
+adius: inherit; }
+
+.rounded-l-none { border-top-left-radius: 0px; border-bottom-left-radius: 0=
+px; }
+
+.rounded-r-none { border-top-right-radius: 0px; border-bottom-right-radius:=
+ 0px; }
+
+.rounded-t { border-top-left-radius: var(--cds-radius); border-top-right-ra=
+dius: var(--cds-radius); }
+
+.rounded-t-\[10px\] { border-top-left-radius: 10px; border-top-right-radius=
+: 10px; }
+
+.rounded-t-\[4px\] { border-top-left-radius: 4px; border-top-right-radius: =
+4px; }
+
+.rounded-t-\[inherit\] { border-top-left-radius: inherit; border-top-right-=
+radius: inherit; }
+
+.rounded-t-lg { border-top-left-radius: 0.5rem; border-top-right-radius: 0.=
+5rem; }
+
+.rounded-t-md { border-top-left-radius: 0.375rem; border-top-right-radius: =
+0.375rem; }
+
+.\!border-0 { border-width: 0px !important; }
+
+.border { border-width: 1px; }
+
+.border-0 { border-width: 0px; }
+
+.border-2 { border-width: 2px; }
+
+.border-\[0\.5px\] { border-width: 0.5px; }
+
+.border-\[1\.5px\] { border-width: 1.5px; }
+
+.border-\[5px\] { border-width: 5px; }
+
+.border-\[8px\] { border-width: 8px; }
+
+.border-\[length\:var\(--cds-ring-inner\)\] { border-width: var(--cds-ring-=
+inner); }
+
+.\!border-b-0 { border-bottom-width: 0px !important; }
+
+.border-b { border-bottom-width: 1px; }
+
+.border-b-0 { border-bottom-width: 0px; }
+
+.border-b-2 { border-bottom-width: 2px; }
+
+.border-b-\[0\.5px\] { border-bottom-width: 0.5px; }
+
+.border-b-\[length\:var\(--cds-ring-inner\)\] { border-bottom-width: var(--=
+cds-ring-inner); }
+
+.border-l { border-left-width: 1px; }
+
+.border-l-\[2\.5px\] { border-left-width: 2.5px; }
+
+.border-l-\[3px\] { border-left-width: 3px; }
+
+.border-r { border-right-width: 1px; }
+
+.border-t { border-top-width: 1px; }
+
+.border-t-0 { border-top-width: 0px; }
+
+.border-t-\[0\.5px\] { border-top-width: 0.5px; }
+
+.border-solid { border-style: solid; }
+
+.border-dashed { border-style: dashed; }
+
+.border-none { border-style: none; }
+
+.\!border-transparent { border-color: rgba(0, 0, 0, 0) !important; }
+
+.border-\[color-mix\(in_srgb\,var\(--om-accent-error\)_40\%\,var\(--om-bord=
+er-default\)\)\] { border-color: color-mix(in srgb,var(--om-accent-error) 4=
+0%,var(--om-border-default)); }
+
+.border-\[color-mix\(in_srgb\,var\(--om-accent-primary\)_30\%\,transparent\=
+)\] { border-color: color-mix(in srgb,var(--om-accent-primary) 30%,transpar=
+ent); }
+
+.border-\[color-mix\(in_srgb\,var\(--om-accent-success\)_40\%\,var\(--om-bo=
+rder-default\)\)\] { border-color: color-mix(in srgb,var(--om-accent-succes=
+s) 40%,var(--om-border-default)); }
+
+.border-\[color-mix\(in_srgb\,var\(--om-accent-warning\)_40\%\,var\(--om-bo=
+rder-default\)\)\] { border-color: color-mix(in srgb,var(--om-accent-warnin=
+g) 40%,var(--om-border-default)); }
+
+.border-\[rgba\(0\,0\,0\,0\.08\)\] { border-color: rgba(0, 0, 0, 0.08); }
+
+.border-\[rgba\(0\,0\,0\,0\.12\)\] { border-color: rgba(0, 0, 0, 0.12); }
+
+.border-\[rgba\(0\,0\,0\,0\.15\)\] { border-color: rgba(0, 0, 0, 0.15); }
+
+.border-\[rgba\(15\,12\,8\,0\.04\)\] { border-color: rgba(15, 12, 8, 0.04);=
+ }
+
+.border-\[rgba\(15\,12\,8\,0\.06\)\] { border-color: rgba(15, 12, 8, 0.06);=
+ }
+
+.border-\[rgba\(15\,12\,8\,0\.08\)\] { border-color: rgba(15, 12, 8, 0.08);=
+ }
+
+.border-\[rgba\(15\,12\,8\,0\.1\)\] { border-color: rgba(15, 12, 8, 0.1); }
+
+.border-\[rgba\(15\,12\,8\,0\.14\)\] { border-color: rgba(15, 12, 8, 0.14);=
+ }
+
+.border-\[rgba\(15\,12\,8\,0\.5\)\] { border-color: rgba(15, 12, 8, 0.5); }
+
+.border-\[rgba\(217\,119\,87\,0\.35\)\] { border-color: rgba(217, 119, 87, =
+0.35); }
+
+.border-\[rgba\(255\,255\,255\,0\.06\)\] { border-color: rgba(255, 255, 255=
+, 0.06); }
+
+.border-\[rgba\(255\,255\,255\,0\.08\)\] { border-color: rgba(255, 255, 255=
+, 0.08); }
+
+.border-\[rgba\(255\,255\,255\,0\.3\)\] { border-color: rgba(255, 255, 255,=
+ 0.3); }
+
+.border-\[var\(--cds-border\)\] { border-color: var(--cds-border); }
+
+.border-\[var\(--cds-border-accent\)\] { border-color: var(--cds-border-acc=
+ent); }
+
+.border-\[var\(--cds-fill-accent\)\] { border-color: var(--cds-fill-accent)=
+; }
+
+.border-\[var\(--cds-ring-color\)\] { border-color: var(--cds-ring-color); =
+}
+
+.border-\[var\(--om-border-default\)\] { border-color: var(--om-border-defa=
+ult); }
+
+.border-\[var\(--tpl-selected-border\)\] { border-color: var(--tpl-selected=
+-border); }
+
+.border-accent { border-color: var(--cds-border-accent); }
+
+.border-alpha-1 { border-color: var(--cds-alpha-1); }
+
+.border-alpha-2 { border-color: var(--cds-alpha-2); }
+
+.border-danger { border-color: var(--cds-border-danger); }
+
+.border-om-accent-black { border-color: var(--om-accent-black); }
+
+.border-om-accent-blue { border-color: var(--om-accent-blue); }
+
+.border-om-accent-error { border-color: var(--om-accent-error); }
+
+.border-om-accent-primary { border-color: var(--om-accent-primary); }
+
+.border-om-accent-secondary { border-color: var(--om-accent-secondary); }
+
+.border-om-accent-warning { border-color: var(--om-accent-warning); }
+
+.border-om-border-card { border-color: var(--om-border-card); }
+
+.border-om-border-default { border-color: var(--om-border-default); }
+
+.border-om-border-modal { border-color: var(--om-border-modal); }
+
+.border-om-border-strong { border-color: var(--om-border-strong); }
+
+.border-om-border-subtle { border-color: var(--om-border-subtle); }
+
+.border-om-presenter-border { border-color: var(--om-presenter-border); }
+
+.border-om-presenter-control-border { border-color: var(--om-presenter-cont=
+rol-border); }
+
+.border-om-text-inverse { border-color: var(--om-text-inverse); }
+
+.border-om-text-primary { border-color: var(--om-text-primary); }
+
+.border-pro { border-color: var(--cds-border-pro); }
+
+.border-strong { border-color: var(--cds-border-strong); }
+
+.border-stronger { border-color: var(--cds-border-stronger); }
+
+.border-success { border-color: var(--cds-border-success); }
+
+.border-transparent { border-color: rgba(0, 0, 0, 0); }
+
+.border-warning { border-color: var(--cds-border-warning); }
+
+.border-white { --tw-border-opacity: 1; border-color: rgb(255 255 255/var(-=
+-tw-border-opacity,1)); }
+
+.border-b-\[var\(--cds-border\)\] { border-bottom-color: var(--cds-border);=
+ }
+
+.border-b-om-accent-black { border-bottom-color: var(--om-accent-black); }
+
+.border-l-\[\#e3ddd1\] { --tw-border-opacity: 1; border-left-color: rgb(227=
+ 221 209/var(--tw-border-opacity,1)); }
+
+.border-l-om-accent-blue { border-left-color: var(--om-accent-blue); }
+
+.border-l-om-accent-error { border-left-color: var(--om-accent-error); }
+
+.border-l-om-accent-primary { border-left-color: var(--om-accent-primary); =
+}
+
+.border-l-om-accent-secondary { border-left-color: var(--om-accent-secondar=
+y); }
+
+.border-l-om-border-default { border-left-color: var(--om-border-default); =
+}
+
+.border-t-\[\#e3ddd1\] { --tw-border-opacity: 1; border-top-color: rgb(227 =
+221 209/var(--tw-border-opacity,1)); }
+
+.border-t-om-accent-black { border-top-color: var(--om-accent-black); }
+
+.border-t-om-text-primary { border-top-color: var(--om-text-primary); }
+
+.border-t-transparent { border-top-color: rgba(0, 0, 0, 0); }
+
+.border-t-white { --tw-border-opacity: 1; border-top-color: rgb(255 255 255=
+/var(--tw-border-opacity,1)); }
+
+.bg-\[\#000\] { --tw-bg-opacity: 1; background-color: rgb(0 0 0/var(--tw-bg=
+-opacity,1)); }
+
+.bg-\[\#1a1a1a\] { --tw-bg-opacity: 1; background-color: rgb(26 26 26/var(-=
+-tw-bg-opacity,1)); }
+
+.bg-\[\#1f1d19\] { --tw-bg-opacity: 1; background-color: rgb(31 29 25/var(-=
+-tw-bg-opacity,1)); }
+
+.bg-\[\#2C2C2A\] { --tw-bg-opacity: 1; background-color: rgb(44 44 42/var(-=
+-tw-bg-opacity,1)); }
+
+.bg-\[\#2a2722\] { --tw-bg-opacity: 1; background-color: rgb(42 39 34/var(-=
+-tw-bg-opacity,1)); }
+
+.bg-\[\#2f75ff\] { --tw-bg-opacity: 1; background-color: rgb(47 117 255/var=
+(--tw-bg-opacity,1)); }
+
+.bg-\[\#F5F4ED\] { --tw-bg-opacity: 1; background-color: rgb(245 244 237/va=
+r(--tw-bg-opacity,1)); }
+
+.bg-\[\#f0eee9\] { --tw-bg-opacity: 1; background-color: rgb(240 238 233/va=
+r(--tw-bg-opacity,1)); }
+
+.bg-\[\#fafaf7\] { --tw-bg-opacity: 1; background-color: rgb(250 250 247/va=
+r(--tw-bg-opacity,1)); }
+
+.bg-\[\#fff\], .bg-\[\#ffffff\] { --tw-bg-opacity: 1; background-color: rgb=
+(255 255 255/var(--tw-bg-opacity,1)); }
+
+.bg-\[\.\.\.\] { }
+
+.bg-\[color-mix\(in_srgb\,var\(--om-accent-blue\)_12\%\,transparent\)\] { b=
+ackground-color: color-mix(in srgb,var(--om-accent-blue) 12%,transparent); =
+}
+
+.bg-\[color-mix\(in_srgb\,var\(--om-accent-blue\)_8\%\,var\(--om-bg-surface=
+\)\)\] { background-color: color-mix(in srgb,var(--om-accent-blue) 8%,var(-=
+-om-bg-surface)); }
+
+.bg-\[color-mix\(in_srgb\,var\(--om-accent-error\)_8\%\,var\(--om-bg-surfac=
+e\)\)\] { background-color: color-mix(in srgb,var(--om-accent-error) 8%,var=
+(--om-bg-surface)); }
+
+.bg-\[color-mix\(in_srgb\,var\(--om-accent-success\)_8\%\,var\(--om-bg-surf=
+ace\)\)\] { background-color: color-mix(in srgb,var(--om-accent-success) 8%=
+,var(--om-bg-surface)); }
+
+.bg-\[color-mix\(in_srgb\,var\(--om-accent-warning\)_14\%\,transparent\)\] =
+{ background-color: color-mix(in srgb,var(--om-accent-warning) 14%,transpar=
+ent); }
+
+.bg-\[color-mix\(in_srgb\,var\(--om-accent-warning\)_18\%\,transparent\)\] =
+{ background-color: color-mix(in srgb,var(--om-accent-warning) 18%,transpar=
+ent); }
+
+.bg-\[color-mix\(in_srgb\,var\(--om-accent-warning\)_8\%\,var\(--om-bg-surf=
+ace\)\)\] { background-color: color-mix(in srgb,var(--om-accent-warning) 8%=
+,var(--om-bg-surface)); }
+
+.bg-\[color-mix\(in_srgb\,var\(--om-bg-app\)_94\%\,transparent\)\] { backgr=
+ound-color: color-mix(in srgb,var(--om-bg-app) 94%,transparent); }
+
+.bg-\[color-mix\(in_srgb\,var\(--om-bg-elevated\)_78\%\,transparent\)\] { b=
+ackground-color: color-mix(in srgb,var(--om-bg-elevated) 78%,transparent); =
+}
+
+.bg-\[color-mix\(in_srgb\,var\(--om-bg-surface\)_45\%\,transparent\)\] { ba=
+ckground-color: color-mix(in srgb,var(--om-bg-surface) 45%,transparent); }
+
+.bg-\[color\:var\(--chat-floor\)\] { background-color: var(--chat-floor); }
+
+.bg-\[rgba\(0\,0\,0\,0\)\] { background-color: rgba(0, 0, 0, 0); }
+
+.bg-\[rgba\(0\,0\,0\,0\.1\)\] { background-color: rgba(0, 0, 0, 0.1); }
+
+.bg-\[rgba\(0\,0\,0\,0\.35\)\] { background-color: rgba(0, 0, 0, 0.35); }
+
+.bg-\[rgba\(0\,0\,0\,0\.6\)\] { background-color: rgba(0, 0, 0, 0.6); }
+
+.bg-\[rgba\(0\,0\,0\,0\.7\)\] { background-color: rgba(0, 0, 0, 0.7); }
+
+.bg-\[rgba\(15\,12\,8\,0\.06\)\] { background-color: rgba(15, 12, 8, 0.06);=
+ }
+
+.bg-\[rgba\(15\,12\,8\,0\.14\)\] { background-color: rgba(15, 12, 8, 0.14);=
+ }
+
+.bg-\[rgba\(15\,12\,8\,0\.36\)\] { background-color: rgba(15, 12, 8, 0.36);=
+ }
+
+.bg-\[rgba\(15\,12\,8\,0\.5\)\] { background-color: rgba(15, 12, 8, 0.5); }
+
+.bg-\[rgba\(20\,20\,20\,0\.15\)\] { background-color: rgba(20, 20, 20, 0.15=
+); }
+
+.bg-\[rgba\(201\,168\,45\,0\.12\)\] { background-color: rgba(201, 168, 45, =
+0.12); }
+
+.bg-\[rgba\(217\,119\,87\,0\.04\)\] { background-color: rgba(217, 119, 87, =
+0.04); }
+
+.bg-\[rgba\(217\,119\,87\,0\.08\)\] { background-color: rgba(217, 119, 87, =
+0.08); }
+
+.bg-\[rgba\(250\,249\,245\,0\.7\)\] { background-color: rgba(250, 249, 245,=
+ 0.7); }
+
+.bg-\[rgba\(250\,249\,245\,0\.94\)\] { background-color: rgba(250, 249, 245=
+, 0.94); }
+
+.bg-\[rgba\(255\,255\,255\,0\.02\)\] { background-color: rgba(255, 255, 255=
+, 0.02); }
+
+.bg-\[rgba\(255\,255\,255\,0\.22\)\] { background-color: rgba(255, 255, 255=
+, 0.22); }
+
+.bg-\[rgba\(255\,255\,255\,0\.3\)\] { background-color: rgba(255, 255, 255,=
+ 0.3); }
+
+.bg-\[rgba\(255\,255\,255\,0\.4\)\] { background-color: rgba(255, 255, 255,=
+ 0.4); }
+
+.bg-\[rgba\(255\,255\,255\,0\.5\)\] { background-color: rgba(255, 255, 255,=
+ 0.5); }
+
+.bg-\[rgba\(255\,255\,255\,0\.85\)\] { background-color: rgba(255, 255, 255=
+, 0.85); }
+
+.bg-\[rgba\(255\,255\,255\,0\.95\)\] { background-color: rgba(255, 255, 255=
+, 0.95); }
+
+.bg-\[rgba\(42\,120\,214\,0\.05\)\] { background-color: rgba(42, 120, 214, =
+0.05); }
+
+.bg-\[rgba\(42\,120\,214\,0\.07\)\] { background-color: rgba(42, 120, 214, =
+0.07); }
+
+.bg-\[rgba\(42\,120\,214\,0\.08\)\] { background-color: rgba(42, 120, 214, =
+0.08); }
+
+.bg-\[var\(--cds-bg-accent\)\] { background-color: var(--cds-bg-accent); }
+
+.bg-\[var\(--cds-clay\)\] { background-color: var(--cds-clay); }
+
+.bg-\[var\(--cds-fill-ghost-hover\)\] { background-color: var(--cds-fill-gh=
+ost-hover); }
+
+.bg-\[var\(--cds-on-accent\)\] { background-color: var(--cds-on-accent); }
+
+.bg-\[var\(--cds-on-brand\)\] { background-color: var(--cds-on-brand); }
+
+.bg-\[var\(--cds-on-danger\)\] { background-color: var(--cds-on-danger); }
+
+.bg-\[var\(--cds-on-primary\)\] { background-color: var(--cds-on-primary); =
+}
+
+.bg-\[var\(--cds-page-bg\)\] { background-color: var(--cds-page-bg); }
+
+.bg-\[var\(--cds-segmented-control-thumb\)\] { background-color: var(--cds-=
+segmented-control-thumb); }
+
+.bg-\[var\(--cds-segmented-control-track\)\] { background-color: var(--cds-=
+segmented-control-track); }
+
+.bg-\[var\(--cds-skeleton-base\)\] { background-color: var(--cds-skeleton-b=
+ase); }
+
+.bg-\[var\(--cds-surface-2\)\] { background-color: var(--cds-surface-2); }
+
+.bg-\[var\(--cds-surface-popover\)\] { background-color: var(--cds-surface-=
+popover); }
+
+.bg-\[var\(--cds-switch-knob\)\] { background-color: var(--cds-switch-knob)=
+; }
+
+.bg-\[var\(--cds-switch-track\)\] { background-color: var(--cds-switch-trac=
+k); }
+
+.bg-\[var\(--om-accent-blue-bg\)\] { background-color: var(--om-accent-blue=
+-bg); }
+
+.bg-\[var\(--om-=E2=80=A6\)\] { background-color: var(--om-=E2=80=A6); }
+
+.bg-accent { background-color: var(--cds-bg-accent); }
+
+.bg-accent-chip { background-color: var(--cds-bg-accent-chip); }
+
+.bg-backdrop { background-color: var(--cds-backdrop); }
+
+.bg-black { background-color: var(--cds-black); }
+
+.bg-border { background-color: var(--cds-border); }
+
+.bg-current { background-color: currentcolor; }
+
+.bg-danger { background-color: var(--cds-bg-danger); }
+
+.bg-danger-chip { background-color: var(--cds-bg-danger-chip); }
+
+.bg-fill-accent { background-color: var(--cds-fill-accent); }
+
+.bg-fill-brand { background-color: var(--cds-fill-brand); }
+
+.bg-fill-control { background-color: var(--cds-fill-control); }
+
+.bg-fill-danger { background-color: var(--cds-fill-danger); }
+
+.bg-fill-field { background-color: var(--cds-fill-field); }
+
+.bg-fill-ghost-hover { background-color: var(--cds-fill-ghost-hover); }
+
+.bg-fill-primary { background-color: var(--cds-fill-primary); }
+
+.bg-fill-pro { background-color: var(--cds-fill-pro); }
+
+.bg-fill-secondary { background-color: var(--cds-fill-secondary); }
+
+.bg-fill-warning { background-color: var(--cds-fill-warning); }
+
+.bg-green-500 { background-color: var(--cds-green-500); }
+
+.bg-neutral { background-color: var(--cds-bg-neutral); }
+
+.bg-neutral-chip { background-color: var(--cds-bg-neutral-chip); }
+
+.bg-neutral-chip-hover { background-color: var(--cds-bg-neutral-chip-hover)=
+; }
+
+.bg-neutral-hover { background-color: var(--cds-bg-neutral-hover); }
+
+.bg-om-accent-black { background-color: var(--om-accent-black); }
+
+.bg-om-accent-black-active { background-color: var(--om-accent-black-active=
+); }
+
+.bg-om-accent-blue { background-color: var(--om-accent-blue); }
+
+.bg-om-accent-blue-bg { background-color: var(--om-accent-blue-bg); }
+
+.bg-om-accent-error { background-color: var(--om-accent-error); }
+
+.bg-om-accent-primary { background-color: var(--om-accent-primary); }
+
+.bg-om-accent-primary-active { background-color: var(--om-accent-primary-ac=
+tive); }
+
+.bg-om-accent-primary-bg { background-color: var(--om-accent-primary-bg); }
+
+.bg-om-accent-pro-bg { background-color: var(--om-accent-pro-bg); }
+
+.bg-om-accent-secondary { background-color: var(--om-accent-secondary); }
+
+.bg-om-accent-secondary-active { background-color: var(--om-accent-secondar=
+y-active); }
+
+.bg-om-accent-success { background-color: var(--om-accent-success); }
+
+.bg-om-accent-warning { background-color: var(--om-accent-warning); }
+
+.bg-om-bg-active { background-color: var(--om-bg-active); }
+
+.bg-om-bg-app { background-color: var(--om-bg-app); }
+
+.bg-om-bg-elevated { background-color: var(--om-bg-elevated); }
+
+.bg-om-bg-error-tint { background-color: var(--om-bg-error-tint); }
+
+.bg-om-bg-hover { background-color: var(--om-bg-hover); }
+
+.bg-om-bg-intro-splash { background-color: var(--om-bg-intro-splash); }
+
+.bg-om-bg-muted { background-color: var(--om-bg-muted); }
+
+.bg-om-bg-panel { background-color: var(--om-bg-panel); }
+
+.bg-om-bg-scrim { background-color: var(--om-bg-scrim); }
+
+.bg-om-bg-secondary-tab-bar { background-color: var(--om-bg-secondary-tab-b=
+ar); }
+
+.bg-om-bg-selected { background-color: var(--om-bg-selected); }
+
+.bg-om-bg-stripe { background-color: var(--om-bg-stripe); }
+
+.bg-om-bg-surface { background-color: var(--om-bg-surface); }
+
+.bg-om-border-default { background-color: var(--om-border-default); }
+
+.bg-om-border-subtle { background-color: var(--om-border-subtle); }
+
+.bg-om-presenter-bg { background-color: var(--om-presenter-bg); }
+
+.bg-om-presenter-control-bg { background-color: var(--om-presenter-control-=
+bg); }
+
+.bg-om-presenter-divider { background-color: var(--om-presenter-divider); }
+
+.bg-om-presenter-slide-bg { background-color: var(--om-presenter-slide-bg);=
+ }
+
+.bg-pink { background-color: var(--cds-bg-pink); }
+
+.bg-pink-chip { background-color: var(--cds-bg-pink-chip); }
+
+.bg-pro { background-color: var(--cds-bg-pro); }
+
+.bg-pro-chip { background-color: var(--cds-bg-pro-chip); }
+
+.bg-success { background-color: var(--cds-bg-success); }
+
+.bg-success-chip { background-color: var(--cds-bg-success-chip); }
+
+.bg-surface-0 { background-color: var(--cds-surface-0); }
+
+.bg-surface-1 { background-color: var(--cds-surface-1); }
+
+.bg-surface-2 { background-color: var(--cds-surface-2); }
+
+.bg-surface-3 { background-color: var(--cds-surface-3); }
+
+.bg-surface-popover { background-color: var(--cds-surface-popover); }
+
+.bg-transparent { background-color: rgba(0, 0, 0, 0); }
+
+.bg-warning { background-color: var(--cds-bg-warning); }
+
+.bg-warning-chip { background-color: var(--cds-bg-warning-chip); }
+
+.bg-white { --tw-bg-opacity: 1; background-color: rgb(255 255 255/var(--tw-=
+bg-opacity,1)); }
+
+.bg-white\/20 { background-color: rgba(255, 255, 255, 0.2); }
+
+.\!bg-none { background-image: none !important; }
+
+.bg-\[linear-gradient\(180deg\,var\(--om-accent-blue\)\,var\(--om-accent-bl=
+ue-hover\)\)\] { background-image: linear-gradient(180deg,var(--om-accent-b=
+lue),var(--om-accent-blue-hover)); }
+
+.bg-\[linear-gradient\(to_bottom\,var\(--om-bg-surface\)_50\%\,var\(--om-bg=
+-panel\)_100\%\)\] { background-image: linear-gradient(to bottom,var(--om-b=
+g-surface) 50%,var(--om-bg-panel) 100%); }
+
+.bg-\[linear-gradient\(to_left\,var\(--om-bg-app\)\,transparent\)\] { backg=
+round-image: linear-gradient(to left,var(--om-bg-app),transparent); }
+
+.bg-\[linear-gradient\(to_right\,\#f00_0\%\,\#ff0_17\%\,\#0f0_33\%\,\#0ff_5=
+0\%\,\#00f_67\%\,\#f0f_83\%\,\#f00_100\%\)\] { background-image: linear-gra=
+dient(90deg, red 0%, rgb(255, 255, 0) 17%, rgb(0, 255, 0) 33%, rgb(0, 255, =
+255) 50%, rgb(0, 0, 255) 67%, rgb(255, 0, 255) 83%, red 100%); }
+
+.bg-\[linear-gradient\(to_right\,var\(--om-bg-app\)\,transparent\)\] { back=
+ground-image: linear-gradient(to right,var(--om-bg-app),transparent); }
+
+.bg-\[linear-gradient\(to_top\,var\(--cds-surface-popover\)\,color-mix\(in_=
+oklab\,var\(--cds-surface-popover\)_40\%\,transparent\)_10px\,transparent\)=
+\] { background-image: linear-gradient(to top,var(--cds-surface-popover),co=
+lor-mix(in oklab,var(--cds-surface-popover) 40%,transparent) 10px,transpare=
+nt); }
+
+.bg-\[linear-gradient\(var\(--cds-alpha-1\)\,var\(--cds-alpha-1\)\)\] { bac=
+kground-image: linear-gradient(var(--cds-alpha-1),var(--cds-alpha-1)); }
+
+.bg-\[radial-gradient\(ellipse_120\%_90\%_at_40\%_30\%\,\#1a1a1a_0\%\,\#0d0=
+d0d_50\%\,\#000_100\%\)\] { background-image: radial-gradient(120% 90% at 4=
+0% 30%, rgb(26, 26, 26) 0%, rgb(13, 13, 13) 50%, rgb(0, 0, 0) 100%); }
+
+.bg-gradient-to-b { background-image: linear-gradient(to bottom, var(--tw-g=
+radient-stops)); }
+
+.bg-gradient-to-t { background-image: linear-gradient(to top, var(--tw-grad=
+ient-stops)); }
+
+.bg-none { background-image: none; }
+
+.from-\[rgba\(255\,255\,255\,0\.3\)\] { --tw-gradient-from: #ffffff4d var(-=
+-tw-gradient-from-position); --tw-gradient-to: #fff0 var(--tw-gradient-to-p=
+osition); --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-t=
+o); }
+
+.from-\[var\(--cds-surface-popover\)\] { --tw-gradient-from: var(--cds-surf=
+ace-popover) var(--tw-gradient-from-position); --tw-gradient-to: #fff0 var(=
+--tw-gradient-to-position); --tw-gradient-stops: var(--tw-gradient-from), v=
+ar(--tw-gradient-to); }
+
+.from-white { --tw-gradient-from: #fff var(--tw-gradient-from-position); --=
+tw-gradient-to: #fff0 var(--tw-gradient-to-position); --tw-gradient-stops: =
+var(--tw-gradient-from), var(--tw-gradient-to); }
+
+.to-om-bg-app { --tw-gradient-to: var(--om-bg-app) var(--tw-gradient-to-pos=
+ition); }
+
+.to-transparent { --tw-gradient-to: transparent var(--tw-gradient-to-positi=
+on); }
+
+.bg-cover { background-size: cover; }
+
+.bg-clip-padding { background-clip: padding-box; }
+
+.bg-clip-text { background-clip: text; }
+
+.bg-\[right_8px_center\] { background-position: right 8px center; }
+
+.bg-bottom { background-position: center bottom; }
+
+.bg-right-top { background-position: 100% 0px; }
+
+.bg-top { background-position: center top; }
+
+.bg-no-repeat { background-repeat: no-repeat; }
+
+.fill-\[var\(--cds-surface-popover\)\] { fill: var(--cds-surface-popover); =
+}
+
+.fill-accent { fill: var(--cds-fill-accent); }
+
+.fill-brand { fill: var(--cds-fill-brand); }
+
+.fill-danger { fill: var(--cds-fill-danger); }
+
+.fill-pictogram-highlight-cactus { fill: var(--cds-pictogram-highlight-cact=
+us); }
+
+.fill-pictogram-highlight-default { fill: var(--cds-pictogram-highlight-def=
+ault); }
+
+.fill-pictogram-highlight-heather { fill: var(--cds-pictogram-highlight-hea=
+ther); }
+
+.fill-pictogram-highlight-peach { fill: var(--cds-pictogram-highlight-peach=
+); }
+
+.fill-primary { fill: var(--cds-fill-primary); }
+
+.fill-pro { fill: var(--cds-fill-pro); }
+
+.fill-secondary { fill: var(--cds-fill-secondary); }
+
+.fill-success { fill: var(--cds-fill-success); }
+
+.fill-warning { fill: var(--cds-fill-warning); }
+
+.object-contain { object-fit: contain; }
+
+.object-cover { object-fit: cover; }
+
+.object-center { object-position: center center; }
+
+.\!p-0 { padding: 0px !important; }
+
+.p-0 { padding: 0px; }
+
+.p-0\.5 { padding: 0.125rem; }
+
+.p-1 { padding: 0.25rem; }
+
+.p-1\.5 { padding: 0.375rem; }
+
+.p-2 { padding: 0.5rem; }
+
+.p-2\.5 { padding: 0.625rem; }
+
+.p-3 { padding: 0.75rem; }
+
+.p-3\.5 { padding: 0.875rem; }
+
+.p-4 { padding: 1rem; }
+
+.p-5 { padding: 1.25rem; }
+
+.p-6 { padding: 1.5rem; }
+
+.p-8 { padding: 2rem; }
+
+.p-\[10px_10px_10px_14px\] { padding: 10px 10px 10px 14px; }
+
+.p-\[12px_14px\] { padding: 12px 14px; }
+
+.p-\[14px_28px\] { padding: 14px 28px; }
+
+.p-\[17px_7px_15px\] { padding: 17px 7px 15px; }
+
+.p-\[18px\] { padding: 18px; }
+
+.p-\[18px_8px_16px\] { padding: 18px 8px 16px; }
+
+.p-\[20px\] { padding: 20px; }
+
+.p-\[28px_20px\] { padding: 28px 20px; }
+
+.p-\[2px\] { padding: 2px; }
+
+.p-\[3px\] { padding: 3px; }
+
+.p-\[3px_3px_6px\] { padding: 3px 3px 6px; }
+
+.p-\[5px_8px_5px_5px\] { padding: 5px 8px 5px 5px; }
+
+.p-\[6px_10px\] { padding: 6px 10px; }
+
+.p-\[7px_10px\] { padding: 7px 10px; }
+
+.p-lg { padding: var(--cds-pad-lg); }
+
+.p-md { padding: var(--cds-pad-md); }
+
+.p-px { padding: 1px; }
+
+.p-xl { padding: var(--cds-pad-xl); }
+
+.px-0 { padding-left: 0px; padding-right: 0px; }
+
+.px-0\.5 { padding-left: 0.125rem; padding-right: 0.125rem; }
+
+.px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
+
+.px-1\.5 { padding-left: 0.375rem; padding-right: 0.375rem; }
+
+.px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+
+.px-11 { padding-left: 2.75rem; padding-right: 2.75rem; }
+
+.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+
+.px-2\.5 { padding-left: 0.625rem; padding-right: 0.625rem; }
+
+.px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
+
+.px-3\.5 { padding-left: 0.875rem; padding-right: 0.875rem; }
+
+.px-4 { padding-left: 1rem; padding-right: 1rem; }
+
+.px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+
+.px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+
+.px-7 { padding-left: 1.75rem; padding-right: 1.75rem; }
+
+.px-8 { padding-left: 2rem; padding-right: 2rem; }
+
+.px-\[10px\] { padding-left: 10px; padding-right: 10px; }
+
+.px-\[11px\] { padding-left: 11px; padding-right: 11px; }
+
+.px-\[13px\] { padding-left: 13px; padding-right: 13px; }
+
+.px-\[14px\] { padding-left: 14px; padding-right: 14px; }
+
+.px-\[18px\] { padding-left: 18px; padding-right: 18px; }
+
+.px-\[2px\] { padding-left: 2px; padding-right: 2px; }
+
+.px-\[3px\] { padding-left: 3px; padding-right: 3px; }
+
+.px-\[44px\] { padding-left: 44px; padding-right: 44px; }
+
+.px-\[4px\] { padding-left: 4px; padding-right: 4px; }
+
+.px-\[5px\] { padding-left: 5px; padding-right: 5px; }
+
+.px-\[7px\] { padding-left: 7px; padding-right: 7px; }
+
+.px-\[9px\] { padding-left: 9px; padding-right: 9px; }
+
+.px-\[calc\(var\(--cds-pad-md\)\+4px\)\] { padding-left: calc(var(--cds-pad=
+-md) + 4px); padding-right: calc(var(--cds-pad-md) + 4px); }
+
+.px-lg { padding-left: var(--cds-pad-lg); padding-right: var(--cds-pad-lg);=
+ }
+
+.px-md { padding-left: var(--cds-pad-md); padding-right: var(--cds-pad-md);=
+ }
+
+.px-px { padding-left: 1px; padding-right: 1px; }
+
+.px-sm { padding-left: var(--cds-pad-sm); padding-right: var(--cds-pad-sm);=
+ }
+
+.py-0 { padding-top: 0px; padding-bottom: 0px; }
+
+.py-0\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
+
+.py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+
+.py-1\.5 { padding-top: 0.375rem; padding-bottom: 0.375rem; }
+
+.py-10 { padding-top: 2.5rem; padding-bottom: 2.5rem; }
+
+.py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+
+.py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
+
+.py-2\.5 { padding-top: 0.625rem; padding-bottom: 0.625rem; }
+
+.py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+
+.py-3\.5 { padding-top: 0.875rem; padding-bottom: 0.875rem; }
+
+.py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+
+.py-5 { padding-top: 1.25rem; padding-bottom: 1.25rem; }
+
+.py-6 { padding-top: 1.5rem; padding-bottom: 1.5rem; }
+
+.py-7 { padding-top: 1.75rem; padding-bottom: 1.75rem; }
+
+.py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+
+.py-\[1\.5px\] { padding-top: 1.5px; padding-bottom: 1.5px; }
+
+.py-\[11px\] { padding-top: 11px; padding-bottom: 11px; }
+
+.py-\[13px\] { padding-top: 13px; padding-bottom: 13px; }
+
+.py-\[15px\] { padding-top: 15px; padding-bottom: 15px; }
+
+.py-\[1px\] { padding-top: 1px; padding-bottom: 1px; }
+
+.py-\[2\.5px\] { padding-top: 2.5px; padding-bottom: 2.5px; }
+
+.py-\[3px\] { padding-top: 3px; padding-bottom: 3px; }
+
+.py-\[4px\] { padding-top: 4px; padding-bottom: 4px; }
+
+.py-\[5px\] { padding-top: 5px; padding-bottom: 5px; }
+
+.py-\[7px\] { padding-top: 7px; padding-bottom: 7px; }
+
+.py-\[9px\] { padding-top: 9px; padding-bottom: 9px; }
+
+.py-\[calc\(\(var\(--cds-h-control\)-var\(--cds-leading-body\)\)\/2\)\] { p=
+adding-top: calc((var(--cds-h-control) - var(--cds-leading-body)) / 2); pad=
+ding-bottom: calc((var(--cds-h-control) - var(--cds-leading-body)) / 2); }
+
+.py-md { padding-top: var(--cds-pad-md); padding-bottom: var(--cds-pad-md);=
+ }
+
+.py-px { padding-top: 1px; padding-bottom: 1px; }
+
+.py-sm { padding-top: var(--cds-pad-sm); padding-bottom: var(--cds-pad-sm);=
+ }
+
+.pb-0 { padding-bottom: 0px; }
+
+.pb-0\.5 { padding-bottom: 0.125rem; }
+
+.pb-1 { padding-bottom: 0.25rem; }
+
+.pb-1\.5 { padding-bottom: 0.375rem; }
+
+.pb-2 { padding-bottom: 0.5rem; }
+
+.pb-2\.5 { padding-bottom: 0.625rem; }
+
+.pb-20 { padding-bottom: 5rem; }
+
+.pb-3 { padding-bottom: 0.75rem; }
+
+.pb-3\.5 { padding-bottom: 0.875rem; }
+
+.pb-4 { padding-bottom: 1rem; }
+
+.pb-5 { padding-bottom: 1.25rem; }
+
+.pb-6 { padding-bottom: 1.5rem; }
+
+.pb-8 { padding-bottom: 2rem; }
+
+.pb-9 { padding-bottom: 2.25rem; }
+
+.pb-\[14px\] { padding-bottom: 14px; }
+
+.pb-\[18px\] { padding-bottom: 18px; }
+
+.pb-\[22px\] { padding-bottom: 22px; }
+
+.pb-\[38px\] { padding-bottom: 38px; }
+
+.pb-\[44px\] { padding-bottom: 44px; }
+
+.pb-\[5px\] { padding-bottom: 5px; }
+
+.pb-\[7px\] { padding-bottom: 7px; }
+
+.pb-\[90px\] { padding-bottom: 90px; }
+
+.pb-\[calc\(\(var\(--cds-h-control\)-var\(--cds-font-size-body\)-var\(--cds=
+-leading-footnote\)\+var\(--cds-font-size-footnote\)\)\/2\)\] { padding-bot=
+tom: calc((var(--cds-h-control) - var(--cds-font-size-body) - var(--cds-lea=
+ding-footnote) + var(--cds-font-size-footnote)) / 2); }
+
+.pb-px { padding-bottom: 1px; }
+
+.pb-sm { padding-bottom: var(--cds-pad-sm); }
+
+.pl-0 { padding-left: 0px; }
+
+.pl-0\.5 { padding-left: 0.125rem; }
+
+.pl-1 { padding-left: 0.25rem; }
+
+.pl-1\.5 { padding-left: 0.375rem; }
+
+.pl-2 { padding-left: 0.5rem; }
+
+.pl-2\.5 { padding-left: 0.625rem; }
+
+.pl-3 { padding-left: 0.75rem; }
+
+.pl-3\.5 { padding-left: 0.875rem; }
+
+.pl-4 { padding-left: 1rem; }
+
+.pl-5 { padding-left: 1.25rem; }
+
+.pl-6 { padding-left: 1.5rem; }
+
+.pl-\[22px\] { padding-left: 22px; }
+
+.pl-\[30px\] { padding-left: 30px; }
+
+.pl-\[34px\] { padding-left: 34px; }
+
+.pl-\[38px\] { padding-left: 38px; }
+
+.pl-\[calc\(4px\+1em\)\] { padding-left: calc(1em + 4px); }
+
+.pl-\[var\(--chat-pad-l\)\] { padding-left: var(--chat-pad-l); }
+
+.pl-md { padding-left: var(--cds-pad-md); }
+
+.pl-sm { padding-left: var(--cds-pad-sm); }
+
+.pr-0 { padding-right: 0px; }
+
+.pr-0\.5 { padding-right: 0.125rem; }
+
+.pr-1 { padding-right: 0.25rem; }
+
+.pr-1\.5 { padding-right: 0.375rem; }
+
+.pr-10 { padding-right: 2.5rem; }
+
+.pr-11 { padding-right: 2.75rem; }
+
+.pr-14 { padding-right: 3.5rem; }
+
+.pr-2 { padding-right: 0.5rem; }
+
+.pr-2\.5 { padding-right: 0.625rem; }
+
+.pr-3 { padding-right: 0.75rem; }
+
+.pr-3\.5 { padding-right: 0.875rem; }
+
+.pr-4 { padding-right: 1rem; }
+
+.pr-5 { padding-right: 1.25rem; }
+
+.pr-6 { padding-right: 1.5rem; }
+
+.pr-\[14px\] { padding-right: 14px; }
+
+.pr-\[18px\] { padding-right: 18px; }
+
+.pr-\[22px\] { padding-right: 22px; }
+
+.pr-\[26px\] { padding-right: 26px; }
+
+.pr-\[44px\] { padding-right: 44px; }
+
+.pr-\[7px\] { padding-right: 7px; }
+
+.pr-\[9px\] { padding-right: 9px; }
+
+.pr-\[var\(--chat-pad-r\)\] { padding-right: var(--chat-pad-r); }
+
+.pr-md { padding-right: var(--cds-pad-md); }
+
+.pr-sm { padding-right: var(--cds-pad-sm); }
+
+.pt-0 { padding-top: 0px; }
+
+.pt-0\.5 { padding-top: 0.125rem; }
+
+.pt-1 { padding-top: 0.25rem; }
+
+.pt-1\.5 { padding-top: 0.375rem; }
+
+.pt-2 { padding-top: 0.5rem; }
+
+.pt-2\.5 { padding-top: 0.625rem; }
+
+.pt-3 { padding-top: 0.75rem; }
+
+.pt-3\.5 { padding-top: 0.875rem; }
+
+.pt-4 { padding-top: 1rem; }
+
+.pt-5 { padding-top: 1.25rem; }
+
+.pt-6 { padding-top: 1.5rem; }
+
+.pt-8 { padding-top: 2rem; }
+
+.pt-\[11px\] { padding-top: 11px; }
+
+.pt-\[14px\] { padding-top: 14px; }
+
+.pt-\[18px\] { padding-top: 18px; }
+
+.pt-\[1em\] { padding-top: 1em; }
+
+.pt-\[22px\] { padding-top: 22px; }
+
+.pt-\[30px\] { padding-top: 30px; }
+
+.pt-\[34px\] { padding-top: 34px; }
+
+.pt-\[3px\] { padding-top: 3px; }
+
+.pt-\[5px\] { padding-top: 5px; }
+
+.pt-\[60px\] { padding-top: 60px; }
+
+.pt-\[7px\] { padding-top: 7px; }
+
+.pt-sm { padding-top: var(--cds-pad-sm); }
+
+.text-left { text-align: left; }
+
+.text-center { text-align: center; }
+
+.text-right { text-align: right; }
+
+.align-baseline { vertical-align: baseline; }
+
+.align-top { vertical-align: top; }
+
+.align-middle { vertical-align: middle; }
+
+.align-text-bottom { vertical-align: text-bottom; }
+
+.align-\[-2px\] { vertical-align: -2px; }
+
+.font-\[\'JetBrains_Mono\'\,\'SF_Mono\'\,Menlo\,Monaco\,monospace\] { font-=
+family: "JetBrains Mono", "SF Mono", Menlo, Monaco, monospace; }
+
+.font-\[\'SF_Mono\'\,Consolas\,monospace\] { font-family: "SF Mono", Consol=
+as, monospace; }
+
+.font-\[inherit\] { font-family: inherit; }
+
+.font-mono { font-family: var(--cds-font-mono); }
+
+.font-om-serif { font-family: "Anthropic Serif", Georgia, serif; }
+
+.font-sans { font-family: var(--cds-font-sans); }
+
+.font-voice { font-family: var(--cds-font-voice); }
+
+.text-\[0\.6rem\] { font-size: 0.6rem; }
+
+.text-\[0\.93em\] { font-size: 0.93em; }
+
+.text-\[10\.5px\] { font-size: 10.5px; }
+
+.text-\[10px\] { font-size: 10px; }
+
+.text-\[11\.5px\] { font-size: 11.5px; }
+
+.text-\[11px\] { font-size: 11px; }
+
+.text-\[11px\]\/\[14px\] { font-size: 11px; line-height: 14px; }
+
+.text-\[12\.5px\] { font-size: 12.5px; }
+
+.text-\[12px\] { font-size: 12px; }
+
+.text-\[13\.5px\] { font-size: 13.5px; }
+
+.text-\[13px\] { font-size: 13px; }
+
+.text-\[13px\]\/\[18px\] { font-size: 13px; line-height: 18px; }
+
+.text-\[14\.5px\] { font-size: 14.5px; }
+
+.text-\[15px\] { font-size: 15px; }
+
+.text-\[16px\] { font-size: 16px; }
+
+.text-\[17px\] { font-size: 17px; }
+
+.text-\[18px\] { font-size: 18px; }
+
+.text-\[20px\] { font-size: 20px; }
+
+.text-\[21px\] { font-size: 21px; }
+
+.text-\[22px\] { font-size: 22px; }
+
+.text-\[24px\] { font-size: 24px; }
+
+.text-\[28px\] { font-size: 28px; }
+
+.text-\[36px\] { font-size: 36px; }
+
+.text-\[8px\] { font-size: 8px; }
+
+.text-\[9\.5px\] { font-size: 9.5px; }
+
+.text-\[9px\] { font-size: 9px; }
+
+.text-\[length\:inherit\] { font-size: inherit; }
+
+.text-base { font-size: 1rem; line-height: 1.5rem; }
+
+.text-body { font-size: var(--cds-font-size-body); line-height: var(--cds-l=
+eading-body); }
+
+.text-caption { font-size: var(--cds-font-size-caption); line-height: var(-=
+-cds-leading-caption); }
+
+.text-footnote { font-size: var(--cds-font-size-footnote); line-height: var=
+(--cds-leading-footnote); }
+
+.text-heading { font-size: var(--cds-font-size-heading); line-height: var(-=
+-cds-leading-heading); }
+
+.text-sm { font-size: 0.875rem; line-height: 1.25rem; }
+
+.text-title { font-size: var(--cds-font-size-title); line-height: var(--cds=
+-leading-title); }
+
+.text-xs { font-size: 0.75rem; line-height: 1rem; }
+
+.font-\[330\] { font-weight: 330; }
+
+.font-\[350\] { font-weight: 350; }
+
+.font-\[370\] { font-weight: 370; }
+
+.font-\[380\] { font-weight: 380; }
+
+.font-\[420\] { font-weight: 420; }
+
+.font-\[430\] { font-weight: 430; }
+
+.font-\[450\] { font-weight: 450; }
+
+.font-\[550\] { font-weight: 550; }
+
+.font-\[650\] { font-weight: 650; }
+
+.font-bold { font-weight: 700; }
+
+.font-light { font-weight: 300; }
+
+.font-medium { font-weight: 500; }
+
+.font-normal { font-weight: 400; }
+
+.font-semibold { font-weight: 600; }
+
+.uppercase { text-transform: uppercase; }
+
+.lowercase { text-transform: lowercase; }
+
+.capitalize { text-transform: capitalize; }
+
+.normal-case { text-transform: none; }
+
+.italic { font-style: italic; }
+
+.not-italic { font-style: normal; }
+
+.ordinal { --tw-ordinal: ordinal; font-variant-numeric: var(--tw-ordinal) v=
+ar(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) va=
+r(--tw-numeric-fraction); }
+
+.tabular-nums { --tw-numeric-spacing: tabular-nums; font-variant-numeric: v=
+ar(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-n=
+umeric-spacing) var(--tw-numeric-fraction); }
+
+.leading-4 { line-height: 1rem; }
+
+.leading-5 { line-height: 1.25rem; }
+
+.leading-\[1\.15\] { line-height: 1.15; }
+
+.leading-\[1\.1\] { line-height: 1.1; }
+
+.leading-\[1\.25\] { line-height: 1.25; }
+
+.leading-\[1\.2\] { line-height: 1.2; }
+
+.leading-\[1\.35\] { line-height: 1.35; }
+
+.leading-\[1\.3\] { line-height: 1.3; }
+
+.leading-\[1\.45\] { line-height: 1.45; }
+
+.leading-\[1\.4\] { line-height: 1.4; }
+
+.leading-\[1\.55\] { line-height: 1.55; }
+
+.leading-\[1\.5\] { line-height: 1.5; }
+
+.leading-\[1\.65\] { line-height: 1.65; }
+
+.leading-\[1\.6\] { line-height: 1.6; }
+
+.leading-\[1\.7\] { line-height: 1.7; }
+
+.leading-\[1\.95\] { line-height: 1.95; }
+
+.leading-\[10px\] { line-height: 10px; }
+
+.leading-\[13px\] { line-height: 13px; }
+
+.leading-\[17px\] { line-height: 17px; }
+
+.leading-none { line-height: 1; }
+
+.leading-normal { line-height: 1.5; }
+
+.leading-snug { line-height: 1.375; }
+
+.leading-tight { line-height: 1.25; }
+
+.tracking-\[-0\.005em\] { letter-spacing: -0.005em; }
+
+.tracking-\[-0\.1px\] { letter-spacing: -0.1px; }
+
+.tracking-\[-0\.2px\] { letter-spacing: -0.2px; }
+
+.tracking-\[-0\.3px\] { letter-spacing: -0.3px; }
+
+.tracking-\[-0\.5px\] { letter-spacing: -0.5px; }
+
+.tracking-\[0\.01em\] { letter-spacing: 0.01em; }
+
+.tracking-\[0\.02em\] { letter-spacing: 0.02em; }
+
+.tracking-\[0\.03em\] { letter-spacing: 0.03em; }
+
+.tracking-\[0\.04em\] { letter-spacing: 0.04em; }
+
+.tracking-\[0\.05em\] { letter-spacing: 0.05em; }
+
+.tracking-\[0\.1em\] { letter-spacing: 0.1em; }
+
+.tracking-\[0\.1px\] { letter-spacing: 0.1px; }
+
+.tracking-\[0\.2px\] { letter-spacing: 0.2px; }
+
+.tracking-\[0\.3px\] { letter-spacing: 0.3px; }
+
+.tracking-\[0\.4px\] { letter-spacing: 0.4px; }
+
+.tracking-\[0\.5px\] { letter-spacing: 0.5px; }
+
+.tracking-\[0\.6px\] { letter-spacing: 0.6px; }
+
+.tracking-\[0\.8px\] { letter-spacing: 0.8px; }
+
+.tracking-\[0\] { letter-spacing: 0px; }
+
+.tracking-normal { letter-spacing: 0px; }
+
+.\!text-on-accent { color: var(--cds-on-accent) !important; }
+
+.text-\[\#6ea2ff\] { --tw-text-opacity: 1; color: rgb(110 162 255/var(--tw-=
+text-opacity,1)); }
+
+.text-\[\#BF6A3A\] { --tw-text-opacity: 1; color: rgb(191 106 58/var(--tw-t=
+ext-opacity,1)); }
+
+.text-\[\#D97757\] { --tw-text-opacity: 1; color: rgb(217 119 87/var(--tw-t=
+ext-opacity,1)); }
+
+.text-\[\#FAF9F5\] { --tw-text-opacity: 1; color: rgb(250 249 245/var(--tw-=
+text-opacity,1)); }
+
+.text-\[\#bcd1ca\] { --tw-text-opacity: 1; color: rgb(188 209 202/var(--tw-=
+text-opacity,1)); }
+
+.text-\[\#cc785c\] { --tw-text-opacity: 1; color: rgb(204 120 92/var(--tw-t=
+ext-opacity,1)); }
+
+.text-\[color-mix\(in_srgb\,var\(--om-accent-blue\)\,var\(--om-text-primary=
+\)_30\%\)\] { color: color-mix(in srgb,var(--om-accent-blue),var(--om-text-=
+primary) 30%); }
+
+.text-\[color-mix\(in_srgb\,var\(--om-accent-primary\)\,var\(--om-text-prim=
+ary\)_25\%\)\] { color: color-mix(in srgb,var(--om-accent-primary),var(--om=
+-text-primary) 25%); }
+
+.text-\[color-mix\(in_srgb\,var\(--om-accent-warning\)\,var\(--om-text-prim=
+ary\)_45\%\)\] { color: color-mix(in srgb,var(--om-accent-warning),var(--om=
+-text-primary) 45%); }
+
+.text-\[rgba\(15\,12\,8\,0\.36\)\] { color: rgba(15, 12, 8, 0.36); }
+
+.text-\[rgba\(15\,12\,8\,0\.5\)\] { color: rgba(15, 12, 8, 0.5); }
+
+.text-\[rgba\(15\,12\,8\,0\.7\)\] { color: rgba(15, 12, 8, 0.7); }
+
+.text-\[rgba\(15\,12\,8\,=E2=80=A6\)\] { }
+
+.text-\[rgba\(255\,255\,255\,0\.4\)\] { color: rgba(255, 255, 255, 0.4); }
+
+.text-\[rgba\(255\,255\,255\,0\.45\)\] { color: rgba(255, 255, 255, 0.45); =
+}
+
+.text-\[rgba\(255\,255\,255\,0\.5\)\] { color: rgba(255, 255, 255, 0.5); }
+
+.text-\[rgba\(255\,255\,255\,0\.6\)\] { color: rgba(255, 255, 255, 0.6); }
+
+.text-\[rgba\(255\,255\,255\,0\.92\)\] { color: rgba(255, 255, 255, 0.92); =
+}
+
+.text-\[var\(--cds-fill-accent\)\] { color: var(--cds-fill-accent); }
+
+.text-\[var\(--cds-on-brand\)\] { color: var(--cds-on-brand); }
+
+.text-\[var\(--cds-text-accent\)\] { color: var(--cds-text-accent); }
+
+.text-\[var\(--cds-text-danger\)\] { color: var(--cds-text-danger); }
+
+.text-\[var\(--cds-text-muted\)\] { color: var(--cds-text-muted); }
+
+.text-\[var\(--cds-text-primary\)\] { color: var(--cds-text-primary); }
+
+.text-\[var\(--cds-text-secondary\)\] { color: var(--cds-text-secondary); }
+
+.text-\[var\(--om-accent-blue\)\] { color: var(--om-accent-blue); }
+
+.text-\[var\(--sticker-text\)\] { color: var(--sticker-text); }
+
+.text-\[var\(--sticker-text-muted\)\] { color: var(--sticker-text-muted); }
+
+.text-accent { color: var(--cds-text-accent); }
+
+.text-danger { color: var(--cds-text-danger); }
+
+.text-disabled { color: var(--cds-text-disabled); }
+
+.text-gray-0 { color: var(--cds-gray-0); }
+
+.text-inherit { color: inherit; }
+
+.text-muted { color: var(--cds-text-muted); }
+
+.text-om-accent-blue { color: var(--om-accent-blue); }
+
+.text-om-accent-error { color: var(--om-accent-error); }
+
+.text-om-accent-primary { color: var(--om-accent-primary); }
+
+.text-om-accent-pro { color: var(--om-accent-pro); }
+
+.text-om-accent-secondary-active { color: var(--om-accent-secondary-active)=
+; }
+
+.text-om-accent-secondary-hover { color: var(--om-accent-secondary-hover); =
+}
+
+.text-om-accent-success { color: var(--om-accent-success); }
+
+.text-om-accent-verifier { color: var(--om-accent-verifier); }
+
+.text-om-accent-warning { color: var(--om-accent-warning); }
+
+.text-om-bg-surface { color: var(--om-bg-surface); }
+
+.text-om-presenter-label { color: var(--om-presenter-label); }
+
+.text-om-presenter-muted { color: var(--om-presenter-muted); }
+
+.text-om-presenter-text { color: var(--om-presenter-text); }
+
+.text-om-text-disabled { color: var(--om-text-disabled); }
+
+.text-om-text-inverse { color: var(--om-text-inverse); }
+
+.text-om-text-link { color: var(--om-text-link); }
+
+.text-om-text-primary { color: var(--om-text-primary); }
+
+.text-om-text-secondary { color: var(--om-text-secondary); }
+
+.text-om-text-tertiary { color: var(--om-text-tertiary); }
+
+.text-on-accent { color: var(--cds-on-accent); }
+
+.text-on-brand { color: var(--cds-on-brand); }
+
+.text-on-danger { color: var(--cds-on-danger); }
+
+.text-on-primary { color: var(--cds-on-primary); }
+
+.text-on-pro { color: var(--cds-on-pro); }
+
+.text-pink { color: var(--cds-text-pink); }
+
+.text-primary { color: var(--cds-text-primary); }
+
+.text-pro { color: var(--cds-text-pro); }
+
+.text-secondary { color: var(--cds-text-secondary); }
+
+.text-success { color: var(--cds-text-success); }
+
+.text-transparent { color: rgba(0, 0, 0, 0); }
+
+.text-warning { color: var(--cds-text-warning); }
+
+.text-white { --tw-text-opacity: 1; color: rgb(255 255 255/var(--tw-text-op=
+acity,1)); }
+
+.text-yellow-750 { color: var(--cds-yellow-750); }
+
+.underline { text-decoration-line: underline; }
+
+.overline { text-decoration-line: overline; }
+
+.line-through { text-decoration-line: line-through; }
+
+.no-underline { text-decoration-line: none; }
+
+.decoration-\[color-mix\(in_srgb\,currentColor\,transparent_60\%\)\] { text=
+-decoration-color: color-mix(in srgb, currentcolor 40%, transparent); }
+
+.decoration-\[rgba\(20\,20\,19\,0\.2\)\] { text-decoration-color: rgba(20, =
+20, 19, 0.2); }
+
+.decoration-current { text-decoration-color: currentcolor; }
+
+.decoration-dotted { text-decoration-style: dotted; }
+
+.underline-offset-2 { text-underline-offset: 2px; }
+
+.underline-offset-\[3px\] { text-underline-offset: 3px; }
+
+.antialiased { -webkit-font-smoothing: antialiased; }
+
+.subpixel-antialiased { -webkit-font-smoothing: auto; }
+
+.accent-black { accent-color: var(--cds-black); }
+
+.accent-om-accent-primary { accent-color: var(--om-accent-primary); }
+
+.opacity-0 { opacity: 0; }
+
+.opacity-100 { opacity: 1; }
+
+.opacity-25 { opacity: 0.25; }
+
+.opacity-40 { opacity: 0.4; }
+
+.opacity-50 { opacity: 0.5; }
+
+.opacity-60 { opacity: 0.6; }
+
+.opacity-70 { opacity: 0.7; }
+
+.opacity-90 { opacity: 0.9; }
+
+.opacity-\[0\.45\] { opacity: 0.45; }
+
+.opacity-\[0\.55\] { opacity: 0.55; }
+
+.opacity-\[0\.65\] { opacity: 0.65; }
+
+.opacity-\[0\.85\] { opacity: 0.85; }
+
+.opacity-\[0\.92\] { opacity: 0.92; }
+
+.bg-blend-soft-light { background-blend-mode: soft-light; }
+
+.mix-blend-darken { mix-blend-mode: darken; }
+
+.\!shadow { --tw-shadow: 0 1px 3px 0 #0000001a, 0 1px 2px -1px #0000001a !i=
+mportant; --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2p=
+x -1px var(--tw-shadow-color) !important; box-shadow: var(--tw-ring-offset-=
+shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow) !impor=
+tant; }
+
+.shadow { --tw-shadow: 0 1px 3px 0 #0000001a, 0 1px 2px -1px #0000001a; --t=
+w-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--=
+tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(-=
+-tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[-1px_0_0_rgba\(0\,0\,0\,0\.1\)\] { --tw-shadow: -1px 0 0 #0000001=
+a; --tw-shadow-colored: -1px 0 0 var(--tw-shadow-color); box-shadow: var(--=
+tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw=
+-shadow); }
+
+.shadow-\[-4px_0_12px_rgba\(40\,30\,20\,0\.08\)\] { --tw-shadow: -4px 0 12p=
+x #281e1414; --tw-shadow-colored: -4px 0 12px var(--tw-shadow-color); box-s=
+hadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #00=
+00), var(--tw-shadow); }
+
+.shadow-\[0_-1px_0_rgba\(0\,0\,0\,0\.1\)\] { --tw-shadow: 0 -1px 0 #0000001=
+a; --tw-shadow-colored: 0 -1px 0 var(--tw-shadow-color); box-shadow: var(--=
+tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw=
+-shadow); }
+
+.shadow-\[0_0_0_0\.5px_var\(--om-border-default\)\,0_1px_2px_rgba\(0\,0\,0\=
+,0\.06\)\] { --tw-shadow: 0 0 0 .5px var(--om-border-default),0 1px 2px #00=
+00000f; --tw-shadow-colored: 0 0 0 .5px var(--tw-shadow-color), 0 1px 2px v=
+ar(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), =
+var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_0_0_1\.5px_var\(--om-text-primary\)\,0_2px_6px_rgba\(0\,0\,0\,0=
+\.15\)\] { --tw-shadow: 0 0 0 1.5px var(--om-text-primary),0 2px 6px #00000=
+026; --tw-shadow-colored: 0 0 0 1.5px var(--tw-shadow-color), 0 2px 6px var=
+(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), va=
+r(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_0_0_1px_rgba\(0\,0\,0\,0\.3\)\] { --tw-shadow: 0 0 0 1px #00000=
+04d; --tw-shadow-colored: 0 0 0 1px var(--tw-shadow-color); box-shadow: var=
+(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(-=
+-tw-shadow); }
+
+.shadow-\[0_0_0_3px_rgba\(47\,117\,255\,0\.22\)\,0_1px_3px_rgba\(30\,90\,22=
+0\,0\.35\)\,inset_0_1px_0_rgba\(255\,255\,255\,0\.2\)\] { --tw-shadow: 0 0 =
+0 3px #2f75ff38,0 1px 3px #1e5adc59,inset 0 1px 0 #fff3; --tw-shadow-colore=
+d: 0 0 0 3px var(--tw-shadow-color), 0 1px 3px var(--tw-shadow-color), inse=
+t 0 1px 0 var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0=
+ 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_0_0_3px_var\(--cds-bg-accent\)\] { --tw-shadow: 0 0 0 3px var(-=
+-cds-bg-accent); --tw-shadow-colored: 0 0 0 3px var(--tw-shadow-color); box=
+-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #=
+0000), var(--tw-shadow); }
+
+.shadow-\[0_0_0_3px_var\(--om-accent-blue-bg\)\] { --tw-shadow: 0 0 0 3px v=
+ar(--om-accent-blue-bg); --tw-shadow-colored: 0 0 0 3px var(--tw-shadow-col=
+or); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shad=
+ow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_0_1px_rgba\(0\,0\,0\,0\.2\)\] { --tw-shadow: 0 0 1px #0003; --t=
+w-shadow-colored: 0 0 1px var(--tw-shadow-color); box-shadow: var(--tw-ring=
+-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow=
+); }
+
+.shadow-\[0_12px_32px_rgba\(0\,0\,0\,0\.18\)\] { --tw-shadow: 0 12px 32px #=
+0000002e; --tw-shadow-colored: 0 12px 32px var(--tw-shadow-color); box-shad=
+ow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000)=
+, var(--tw-shadow); }
+
+.shadow-\[0_1px_0_rgba\(255\,255\,255\,0\.5\)_inset\,0_12px_40px_rgba\(0\,0=
+\,0\,0\.18\)\] { --tw-shadow: 0 1px 0 #ffffff80 inset,0 12px 40px #0000002e=
+; --tw-shadow-colored: inset 0 1px 0 var(--tw-shadow-color), 0 12px 40px va=
+r(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), v=
+ar(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_1px_2px_rgba\(0\,0\,0\,0\.04\)\] { --tw-shadow: 0 1px 2px #0000=
+000a; --tw-shadow-colored: 0 1px 2px var(--tw-shadow-color); box-shadow: va=
+r(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(=
+--tw-shadow); }
+
+.shadow-\[0_1px_2px_rgba\(0\,0\,0\,0\.08\)\,inset_0_1px_0_rgba\(255\,255\,2=
+55\,0\.04\)\] { --tw-shadow: 0 1px 2px #00000014,inset 0 1px 0 #ffffff0a; -=
+-tw-shadow-colored: 0 1px 2px var(--tw-shadow-color), inset 0 1px 0 var(--t=
+w-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--=
+tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_1px_2px_rgba\(0\,0\,0\,0\.12\)\] { --tw-shadow: 0 1px 2px #0000=
+001f; --tw-shadow-colored: 0 1px 2px var(--tw-shadow-color); box-shadow: va=
+r(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(=
+--tw-shadow); }
+
+.shadow-\[0_1px_2px_rgba\(15\,12\,8\,0\.08\)\] { --tw-shadow: 0 1px 2px #0f=
+0c0814; --tw-shadow-colored: 0 1px 2px var(--tw-shadow-color); box-shadow: =
+var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), va=
+r(--tw-shadow); }
+
+.shadow-\[0_1px_2px_rgba\(20\,20\,19\,0\.04\)\] { --tw-shadow: 0 1px 2px #1=
+414130a; --tw-shadow-colored: 0 1px 2px var(--tw-shadow-color); box-shadow:=
+ var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), v=
+ar(--tw-shadow); }
+
+.shadow-\[0_1px_2px_rgba\(20\,20\,19\,0\.08\)\,0_0_0_1px_var\(--om-border-s=
+ubtle\)\] { --tw-shadow: 0 1px 2px #14141314,0 0 0 1px var(--om-border-subt=
+le); --tw-shadow-colored: 0 1px 2px var(--tw-shadow-color), 0 0 0 1px var(-=
+-tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(=
+--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_1px_2px_rgba\(20\,20\,19\,0\.08\)\] { --tw-shadow: 0 1px 2px #1=
+4141314; --tw-shadow-colored: 0 1px 2px var(--tw-shadow-color); box-shadow:=
+ var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), v=
+ar(--tw-shadow); }
+
+.shadow-\[0_1px_2px_rgba\(90\,139\,187\,0\.3\)\,inset_0_1px_0_rgba\(255\,25=
+5\,255\,0\.15\)\] { --tw-shadow: 0 1px 2px #5a8bbb4d,inset 0 1px 0 #ffffff2=
+6; --tw-shadow-colored: 0 1px 2px var(--tw-shadow-color), inset 0 1px 0 var=
+(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), va=
+r(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_1px_3px_rgba\(166\,50\,68\,0\.3\)\,0_2px_6px_rgba\(166\,50\,68\=
+,0\.18\)\,inset_0_1px_0_rgba\(255\,255\,255\,0\.12\)\] { --tw-shadow: 0 1px=
+ 3px #a632444d,0 2px 6px #a632442e,inset 0 1px 0 #ffffff1f; --tw-shadow-col=
+ored: 0 1px 3px var(--tw-shadow-color), 0 2px 6px var(--tw-shadow-color), i=
+nset 0 1px 0 var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shado=
+w,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_1px_3px_rgba\(180\,90\,30\,0\.35\)\,0_2px_6px_rgba\(180\,90\,30=
+\,0\.2\)\,inset_0_1px_0_rgba\(255\,255\,255\,0\.15\)\] { --tw-shadow: 0 1px=
+ 3px #b45a1e59,0 2px 6px #b45a1e33,inset 0 1px 0 #ffffff26; --tw-shadow-col=
+ored: 0 1px 3px var(--tw-shadow-color), 0 2px 6px var(--tw-shadow-color), i=
+nset 0 1px 0 var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shado=
+w,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_1px_3px_rgba\(20\,20\,19\,0\.06\)\,0_1px_2px_rgba\(20\,20\,19\,=
+0\.04\)\] { --tw-shadow: 0 1px 3px #1414130f,0 1px 2px #1414130a; --tw-shad=
+ow-colored: 0 1px 3px var(--tw-shadow-color), 0 1px 2px var(--tw-shadow-col=
+or); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shad=
+ow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_2px_6px_rgba\(0\,0\,0\,0\.25\)\] { --tw-shadow: 0 2px 6px #0000=
+0040; --tw-shadow-colored: 0 2px 6px var(--tw-shadow-color); box-shadow: va=
+r(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(=
+--tw-shadow); }
+
+.shadow-\[0_2px_8px_rgba\(0\,0\,0\,0\.1\)\] { --tw-shadow: 0 2px 8px #00000=
+01a; --tw-shadow-colored: 0 2px 8px var(--tw-shadow-color); box-shadow: var=
+(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(-=
+-tw-shadow); }
+
+.shadow-\[0_2px_8px_rgba\(0\,0\,0\,0\.18\)\,0_1px_3px_rgba\(0\,0\,0\,0\.12\=
+)\] { --tw-shadow: 0 2px 8px #0000002e,0 1px 3px #0000001f; --tw-shadow-col=
+ored: 0 2px 8px var(--tw-shadow-color), 0 1px 3px var(--tw-shadow-color); b=
+ox-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0=
+ #0000), var(--tw-shadow); }
+
+.shadow-\[0_4px_12px_rgba\(0\,0\,0\,0\.15\)\] { --tw-shadow: 0 4px 12px #00=
+000026; --tw-shadow-colored: 0 4px 12px var(--tw-shadow-color); box-shadow:=
+ var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), v=
+ar(--tw-shadow); }
+
+.shadow-\[0_4px_14px_rgba\(37\,105\,191\,0\.35\)\,0_0_0_1px_rgba\(255\,255\=
+,255\,0\.3\)_inset\] { --tw-shadow: 0 4px 14px #2569bf59,0 0 0 1px #ffffff4=
+d inset; --tw-shadow-colored: 0 4px 14px var(--tw-shadow-color), inset 0 0 =
+0 1px var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #=
+0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_4px_14px_rgba\(47\,117\,255\,0\.35\)\,0_0_0_1px_rgba\(255\,255\=
+,255\,0\.35\)_inset\] { --tw-shadow: 0 4px 14px #2f75ff59,0 0 0 1px #ffffff=
+59 inset; --tw-shadow-colored: 0 4px 14px var(--tw-shadow-color), inset 0 0=
+ 0 1px var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 =
+#0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_4px_16px_rgba\(0\,0\,0\,0\.1\)\,0_1px_4px_rgba\(0\,0\,0\,0\.06\=
+)\] { --tw-shadow: 0 4px 16px #0000001a,0 1px 4px #0000000f; --tw-shadow-co=
+lored: 0 4px 16px var(--tw-shadow-color), 0 1px 4px var(--tw-shadow-color);=
+ box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0=
+ 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_6px_18px_-10px_rgba\(15\,12\,8\,0\.22\)\] { --tw-shadow: 0 6px =
+18px -10px #0f0c0838; --tw-shadow-colored: 0 6px 18px -10px var(--tw-shadow=
+-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-=
+shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[inset_0_-1px_0_rgba\(15\,12\,8\,0\.05\)\] { --tw-shadow: inset 0 =
+-1px 0 #0f0c080d; --tw-shadow-colored: inset 0 -1px 0 var(--tw-shadow-color=
+); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow=
+,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[inset_0_-2px_0_var\(--om-text-primary\)\] { --tw-shadow: inset 0 =
+-2px 0 var(--om-text-primary); --tw-shadow-colored: inset 0 -2px 0 var(--tw=
+-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--t=
+w-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[inset_0_0_0_1px_rgb\(255_255_255\/0\.3\)\] { --tw-shadow: inset 0=
+ 0 0 1px #ffffff4d; --tw-shadow-colored: inset 0 0 0 1px var(--tw-shadow-co=
+lor); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-sha=
+dow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[inset_0_0_0_1px_var\(--om-accent-blue-hover\)\] { --tw-shadow: in=
+set 0 0 0 1px var(--om-accent-blue-hover); --tw-shadow-colored: inset 0 0 0=
+ 1px var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0=
+000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[inset_0_0_0_1px_var\(--om-border-strong\)\] { --tw-shadow: inset =
+0 0 0 1px var(--om-border-strong); --tw-shadow-colored: inset 0 0 0 1px var=
+(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), va=
+r(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[inset_0_0_0_2px_\#6A9BCC\] { --tw-shadow: inset 0 0 0 2px #6a9bcc=
+; --tw-shadow-colored: inset 0 0 0 2px var(--tw-shadow-color); box-shadow: =
+var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), va=
+r(--tw-shadow); }
+
+.shadow-card-ring { --tw-shadow: inset 0 0 0 var(--cds-ring-inner) var(--cd=
+s-ring-color), 0 0 0 var(--cds-ring-outer) var(--cds-ring-color); --tw-shad=
+ow-colored: inset 0 0 0 var(--tw-shadow-color), 0 0 0 var(--tw-shadow-color=
+); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow=
+,0 0 #0000), var(--tw-shadow); }
+
+.shadow-field { --tw-shadow: inset 0 0 0 1px var(--cds-fill-secondary-ring)=
+, 0 1px 2px 0 #0000000d; --tw-shadow-colored: inset 0 0 0 1px var(--tw-shad=
+ow-color), 0 1px 2px 0 var(--tw-shadow-color); box-shadow: var(--tw-ring-of=
+fset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); =
+}
+
+.shadow-field-drop { --tw-shadow: 0 1px 2px 0 #0000000d; --tw-shadow-colore=
+d: 0 1px 2px 0 var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-sha=
+dow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-field-ring { --tw-shadow: inset 0 0 0 1px var(--cds-fill-secondary-=
+ring); --tw-shadow-colored: inset 0 0 0 1px var(--tw-shadow-color); box-sha=
+dow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000=
+), var(--tw-shadow); }
+
+.shadow-focus { --tw-shadow: var(--cds-focus-shadow); --tw-shadow-colored: =
+var(--cds-focus-shadow); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000)=
+, var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-lg { --tw-shadow: var(--cds-shadow-lg); --tw-shadow-colored: var(--=
+cds-shadow-lg); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--t=
+w-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-md { --tw-shadow: var(--cds-shadow-md); --tw-shadow-colored: var(--=
+cds-shadow-md); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--t=
+w-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-none { --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; box-=
+shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0=
+000), var(--tw-shadow); }
+
+.shadow-om-card { --tw-shadow: var(--om-shadow-card); --tw-shadow-colored: =
+var(--om-shadow-card); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), =
+var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-om-diffuse { --tw-shadow: var(--om-shadow-diffuse); --tw-shadow-col=
+ored: var(--om-shadow-diffuse); box-shadow: var(--tw-ring-offset-shadow,0 0=
+ #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-om-inset { --tw-shadow: var(--om-shadow-inset); --tw-shadow-colored=
+: var(--om-shadow-inset); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000=
+), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-om-lg { --tw-shadow: var(--om-shadow-lg); --tw-shadow-colored: var(=
+--om-shadow-lg); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--=
+tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-om-md { --tw-shadow: var(--om-shadow-md); --tw-shadow-colored: var(=
+--om-shadow-md); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--=
+tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-om-modal { --tw-shadow: var(--om-shadow-modal); --tw-shadow-colored=
+: var(--om-shadow-modal); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000=
+), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-om-sm { --tw-shadow: var(--om-shadow-sm); --tw-shadow-colored: var(=
+--om-shadow-sm); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--=
+tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-om-xs { --tw-shadow: var(--om-shadow-xs); --tw-shadow-colored: var(=
+--om-shadow-xs); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--=
+tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-panel { --tw-shadow: inset 0 0 0 var(--cds-ring-inner) var(--cds-ri=
+ng-color), 0 0 0 var(--cds-ring-outer) var(--cds-ring-color), var(--cds-sha=
+dow-popover); --tw-shadow-colored: inset 0 0 0 var(--tw-shadow-color), 0 0 =
+0 var(--tw-shadow-color), var(--cds-shadow-popover); box-shadow: var(--tw-r=
+ing-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-sha=
+dow); }
+
+.shadow-panel-lg { --tw-shadow: inset 0 0 0 var(--cds-ring-inner) var(--cds=
+-ring-color), 0 0 0 var(--cds-ring-outer) var(--cds-ring-color), var(--cds-=
+shadow-lg); --tw-shadow-colored: inset 0 0 0 var(--tw-shadow-color), 0 0 0 =
+var(--tw-shadow-color), var(--cds-shadow-lg); box-shadow: var(--tw-ring-off=
+set-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-panel-md { --tw-shadow: inset 0 0 0 var(--cds-ring-inner) var(--cds=
+-ring-color), 0 0 0 var(--cds-ring-outer) var(--cds-ring-color), var(--cds-=
+shadow-md); --tw-shadow-colored: inset 0 0 0 var(--tw-shadow-color), 0 0 0 =
+var(--tw-shadow-color), var(--cds-shadow-md); box-shadow: var(--tw-ring-off=
+set-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-panel-sm { --tw-shadow: inset 0 0 0 var(--cds-ring-inner) var(--cds=
+-ring-color), 0 0 0 var(--cds-ring-outer) var(--cds-ring-color), var(--cds-=
+shadow-sm); --tw-shadow-colored: inset 0 0 0 var(--tw-shadow-color), 0 0 0 =
+var(--tw-shadow-color), var(--cds-shadow-sm); box-shadow: var(--tw-ring-off=
+set-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-popover { --tw-shadow: var(--cds-shadow-popover); --tw-shadow-color=
+ed: var(--cds-shadow-popover); box-shadow: var(--tw-ring-offset-shadow,0 0 =
+#0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-ring-danger { --tw-shadow: inset 0 0 0 1px var(--cds-border-danger)=
+; --tw-shadow-colored: inset 0 0 0 1px var(--tw-shadow-color); box-shadow: =
+var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), va=
+r(--tw-shadow); }
+
+.shadow-ring-warning { --tw-shadow: inset 0 0 0 1px var(--cds-border-warnin=
+g); --tw-shadow-colored: inset 0 0 0 1px var(--tw-shadow-color); box-shadow=
+: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), =
+var(--tw-shadow); }
+
+.shadow-sm { --tw-shadow: var(--cds-shadow-sm); --tw-shadow-colored: var(--=
+cds-shadow-sm); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--t=
+w-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.shadow-\[0_0_0_3px_var\(--om-accent-primary-bg\)\,var\(--om-shadow-xs\)\] =
+{ --tw-shadow-color: 0 0 0 3px var(--om-accent-primary-bg),var(--om-shadow-=
+xs); --tw-shadow: var(--tw-shadow-colored); }
+
+.outline-none { outline-offset: 2px; outline: rgba(0, 0, 0, 0) solid 2px; }
+
+.\!outline { outline-style: solid !important; }
+
+.outline { outline-style: solid; }
+
+.outline-dashed { outline-style: dashed; }
+
+.outline-1 { outline-width: 1px; }
+
+.outline-2 { outline-width: 2px; }
+
+.outline-\[1\.5px\] { outline-width: 1.5px; }
+
+.outline-offset-1 { outline-offset: 1px; }
+
+.outline-offset-\[-1\.5px\] { outline-offset: -1.5px; }
+
+.outline-offset-\[-4px\] { outline-offset: -4px; }
+
+.\!outline { outline-color: var(--cds-border) !important; }
+
+.outline { outline-color: var(--cds-border); }
+
+.outline-om-accent-blue { outline-color: var(--om-accent-blue); }
+
+.outline-om-accent-primary { outline-color: var(--om-accent-primary); }
+
+.ring { --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-o=
+ffset-width) var(--tw-ring-offset-color); --tw-ring-shadow: var(--tw-ring-i=
+nset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color); b=
+ox-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-sh=
+adow,0 0 #0000); }
+
+.ring-danger { --tw-ring-color: var(--cds-border-danger); }
+
+.ring-success { --tw-ring-color: var(--cds-border-success); }
+
+.ring-warning { --tw-ring-color: var(--cds-border-warning); }
+
+.blur { --tw-blur: blur(8px); filter: var(--tw-blur) var(--tw-brightness) v=
+ar(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert)=
+ var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow); }
+
+.blur-\[12px\] { --tw-blur: blur(12px); filter: var(--tw-blur) var(--tw-bri=
+ghtness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--=
+tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow); }
+
+.brightness-0 { --tw-brightness: brightness(0); filter: var(--tw-blur) var(=
+--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate=
+) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)=
+; }
+
+.drop-shadow { --tw-drop-shadow: drop-shadow(0 1px 2px #0000001a) drop-shad=
+ow(0 1px 1px #0000000f); filter: var(--tw-blur) var(--tw-brightness) var(--=
+tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(=
+--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow); }
+
+.drop-shadow-\[0_1px_1px_rgba\(0\,0\,0\,0\.3\)\] { --tw-drop-shadow: drop-s=
+hadow(0 1px 1px #0000004d); filter: var(--tw-blur) var(--tw-brightness) var=
+(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) v=
+ar(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow); }
+
+.invert { --tw-invert: invert(100%); filter: var(--tw-blur) var(--tw-bright=
+ness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-=
+invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow); }
+
+.filter { filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) va=
+r(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) =
+var(--tw-sepia) var(--tw-drop-shadow); }
+
+.backdrop-blur-\[1px\] { --tw-backdrop-blur: blur(1px); backdrop-filter: va=
+r(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contr=
+ast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-ba=
+ckdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(-=
+-tw-backdrop-sepia); }
+
+.backdrop-blur-\[24px\] { --tw-backdrop-blur: blur(24px); backdrop-filter: =
+var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-con=
+trast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-=
+backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var=
+(--tw-backdrop-sepia); }
+
+.backdrop-blur-\[2px\] { --tw-backdrop-blur: blur(2px); backdrop-filter: va=
+r(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contr=
+ast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-ba=
+ckdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(-=
+-tw-backdrop-sepia); }
+
+.backdrop-blur-\[6px\] { --tw-backdrop-blur: blur(6px); backdrop-filter: va=
+r(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contr=
+ast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-ba=
+ckdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(-=
+-tw-backdrop-sepia); }
+
+.backdrop-blur-sm { --tw-backdrop-blur: blur(4px); backdrop-filter: var(--t=
+w-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) =
+var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdro=
+p-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-b=
+ackdrop-sepia); }
+
+.backdrop-saturate-\[1\.6\] { --tw-backdrop-saturate: saturate(1.6); backdr=
+op-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-b=
+ackdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate=
+) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-sa=
+turate) var(--tw-backdrop-sepia); }
+
+.backdrop-filter { backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdr=
+op-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var=
+(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opac=
+ity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia); }
+
+.transition { transition-property: color, background-color, border-color, t=
+ext-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,=
+ -webkit-backdrop-filter, backdrop-filter; transition-duration: 0.15s; tran=
+sition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+
+.transition-\[background\,color\] { transition-property: background, color;=
+ transition-duration: 0.15s; transition-timing-function: cubic-bezier(0.4, =
+0, 0.2, 1); }
+
+.transition-\[background-color\] { transition-property: background-color; t=
+ransition-duration: 0.15s; transition-timing-function: cubic-bezier(0.4, 0,=
+ 0.2, 1); }
+
+.transition-\[border-color\,background\] { transition-property: border-colo=
+r, background; transition-duration: 0.15s; transition-timing-function: cubi=
+c-bezier(0.4, 0, 0.2, 1); }
+
+.transition-\[border-color\,box-shadow\,transform\] { transition-property: =
+border-color, box-shadow, transform; transition-duration: 0.15s; transition=
+-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+
+.transition-\[border-color\,box-shadow\] { transition-property: border-colo=
+r, box-shadow; transition-duration: 0.15s; transition-timing-function: cubi=
+c-bezier(0.4, 0, 0.2, 1); }
+
+.transition-\[border-color\] { transition-property: border-color; transitio=
+n-duration: 0.15s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1)=
+; }
+
+.transition-\[box-shadow\,transform\] { transition-property: box-shadow, tr=
+ansform; transition-duration: 0.15s; transition-timing-function: cubic-bezi=
+er(0.4, 0, 0.2, 1); }
+
+.transition-\[box-shadow\] { transition-property: box-shadow; transition-du=
+ration: 0.15s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+
+.transition-\[height\] { transition-property: height; transition-duration: =
+0.15s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+
+.transition-\[left\,width\] { transition-property: left, width; transition-=
+duration: 0.15s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); =
+}
+
+.transition-\[opacity\,scale\] { transition-property: opacity, scale; trans=
+ition-duration: 0.15s; transition-timing-function: cubic-bezier(0.4, 0, 0.2=
+, 1); }
+
+.transition-\[opacity\,transform\] { transition-property: opacity, transfor=
+m; transition-duration: 0.15s; transition-timing-function: cubic-bezier(0.4=
+, 0, 0.2, 1); }
+
+.transition-\[transform\,box-shadow\] { transition-property: transform, box=
+-shadow; transition-duration: 0.15s; transition-timing-function: cubic-bezi=
+er(0.4, 0, 0.2, 1); }
+
+.transition-\[transform\,opacity\] { transition-property: transform, opacit=
+y; transition-duration: 0.15s; transition-timing-function: cubic-bezier(0.4=
+, 0, 0.2, 1); }
+
+.transition-\[width\] { transition-property: width; transition-duration: 0.=
+15s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+
+.transition-all { transition-property: all; transition-duration: 0.15s; tra=
+nsition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+
+.transition-colors { transition-property: color, background-color, border-c=
+olor, text-decoration-color, fill, stroke; transition-duration: 0.15s; tran=
+sition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+
+.transition-none { transition-property: none; }
+
+.transition-opacity { transition-property: opacity; transition-duration: 0.=
+15s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+
+.transition-shadow { transition-property: box-shadow; transition-duration: =
+0.15s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+
+.transition-transform { transition-property: transform; transition-duration=
+: 0.15s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+
+.delay-0 { transition-delay: 0s; }
+
+.delay-1000 { transition-delay: 1s; }
+
+.duration-0 { transition-duration: 0s; }
+
+.duration-100 { transition-duration: 0.1s; }
+
+.duration-150 { transition-duration: 0.15s; }
+
+.duration-200 { transition-duration: 0.2s; }
+
+.duration-300 { transition-duration: 0.3s; }
+
+.duration-\[120ms\] { transition-duration: 0.12s; }
+
+.duration-\[180ms\] { transition-duration: 0.18s; }
+
+.duration-\[220ms\] { transition-duration: 0.22s; }
+
+.duration-\[250ms\] { transition-duration: 0.25s; }
+
+.duration-\[400ms\] { transition-duration: 0.4s; }
+
+.duration-\[80ms\] { transition-duration: 80ms; }
+
+.duration-base { transition-duration: var(--cds-dur-base); }
+
+.duration-fast { transition-duration: var(--cds-dur-fast); }
+
+.duration-snap { transition-duration: var(--cds-dur-snap); }
+
+.ease-\[cubic-bezier\(\.3\,\.7\,\.4\,1\)\] { transition-timing-function: cu=
+bic-bezier(0.3, 0.7, 0.4, 1); }
+
+.ease-\[cubic-bezier\(0\.2\,0\.8\,0\.2\,1\)\] { transition-timing-function:=
+ cubic-bezier(0.2, 0.8, 0.2, 1); }
+
+.ease-\[cubic-bezier\(0\.34\,1\.56\,0\.64\,1\)\] { transition-timing-functi=
+on: cubic-bezier(0.34, 1.56, 0.64, 1); }
+
+.ease-\[ease\] { transition-timing-function: ease; }
+
+.ease-out { transition-timing-function: var(--cds-ease-out); }
+
+.ease-overshoot { transition-timing-function: var(--cds-ease-overshoot); }
+
+.ease-snap { transition-timing-function: var(--cds-ease-snap); }
+
+.will-change-\[transform\,opacity\,filter\] { will-change: transform, opaci=
+ty, filter; }
+
+.text-caption-medium { font-size: var(--cds-font-size-caption); line-height=
+: var(--cds-leading-caption); font-weight: 500; }
+
+.text-heading-semibold { font-size: var(--cds-font-size-heading); line-heig=
+ht: var(--cds-leading-heading); font-weight: 600; }
+
+.text-title-semibold { font-size: var(--cds-font-size-title); line-height: =
+var(--cds-leading-title); font-weight: 600; }
+
+.draggable-none { app-region: no-drag; }
+
+.\[--cds-fill-ghost-hover\:rgb\(255_255_255\/0\.15\)\] { --cds-fill-ghost-h=
+over: #ffffff26; }
+
+.\[--cds-focus-shadow\:inset_0_0_0_1px_var\(--cds-page-bg\)\,0_0_0_1px_var\=
+(--cds-on-accent\)\,0_0_6px_1px_color-mix\(in_srgb\,var\(--cds-on-accent\)_=
+35\%\,transparent\)\] { --cds-focus-shadow: inset 0 0 0 1px var(--cds-page-=
+bg),0 0 0 1px var(--cds-on-accent),0 0 6px 1px color-mix(in srgb,var(--cds-=
+on-accent) 35%,transparent); }
+
+.\[--cds-h-control\:28px\] { --cds-h-control: 28px; }
+
+.\[--cds-page-bg\:var\(--cds-fill-accent\)\] { --cds-page-bg: var(--cds-fil=
+l-accent); }
+
+.\[--cds-popup-max-h\:100vh\] { --cds-popup-max-h: 100vh; }
+
+.\[--cds-stack-overlap\:calc\(var\(--cds-avatar-lg\)\*0\.25\)\] { --cds-sta=
+ck-overlap: calc(var(--cds-avatar-lg) * .25); }
+
+.\[--cds-stack-overlap\:calc\(var\(--cds-avatar-md\)\*0\.25\)\] { --cds-sta=
+ck-overlap: calc(var(--cds-avatar-md) * .25); }
+
+.\[--cds-stack-overlap\:calc\(var\(--cds-avatar-sm\)\*0\.25\)\] { --cds-sta=
+ck-overlap: calc(var(--cds-avatar-sm) * .25); }
+
+.\[--fh\:var\(--cds-h-control\)\] { --fh: var(--cds-h-control); }
+
+.\[--fhn\:var\(--cds-h-control-nested\)\] { --fhn: var(--cds-h-control-nest=
+ed); }
+
+.\[--fr\:var\(--cds-radius\)\] { --fr: var(--cds-radius); }
+
+.\[--ts\:calc\(1_-_var\(--toast-index\)_\*_0\.04\)\] { --ts: calc(1 - var(-=
+-toast-index) * .04); }
+
+.\[--ty\:calc\(var\(--toast-index\)_\*_14px\)\] { --ty: calc(var(--toast-in=
+dex) * 14px); }
+
+.\[-moz-appearance\:textfield\] { }
+
+.\[-webkit-app-region\:drag\] { app-region: drag; }
+
+.\[-webkit-app-region\:no-drag\] { app-region: no-drag; }
+
+.\[-webkit-appearance\:none\] { appearance: none; }
+
+.\[-webkit-box-decoration-break\:clone\] { -webkit-box-decoration-break: cl=
+one; }
+
+.\[-webkit-box-orient\:vertical\] { -webkit-box-orient: vertical; }
+
+.\[-webkit-line-clamp\:2\] { -webkit-line-clamp: 2; }
+
+.\[all\:unset\] { all: unset; }
+
+.\[animation-delay\:0\.15s\] { animation-delay: 0.15s; }
+
+.\[animation-delay\:0\.3s\] { animation-delay: 0.3s; }
+
+.\[animation-duration\:0\.18s\] { animation-duration: 0.18s; }
+
+.\[animation-duration\:0\.2s\] { animation-duration: 0.2s; }
+
+.\[animation-duration\:0\.6s\] { animation-duration: 0.6s; }
+
+.\[animation-duration\:0\.7s\] { animation-duration: 0.7s; }
+
+.\[animation-duration\:180ms\] { animation-duration: 0.18s; }
+
+.\[animation-timing-function\:ease\] { animation-timing-function: ease; }
+
+.\[backface-visibility\:hidden\] { backface-visibility: hidden; }
+
+.\[background-image\:linear-gradient\(0deg\,var\(--cds-bg-danger\)\,var\(--=
+cds-bg-danger\)\)\] { background-image: linear-gradient(0deg,var(--cds-bg-d=
+anger),var(--cds-bg-danger)); }
+
+.\[background-image\:linear-gradient\(0deg\,var\(--cds-bg-warning\)\,var\(-=
+-cds-bg-warning\)\)\] { background-image: linear-gradient(0deg,var(--cds-bg=
+-warning),var(--cds-bg-warning)); }
+
+.\[background-image\:linear-gradient\(120deg\,var\(--cds-text-primary\)_25\=
+%\,color-mix\(in_srgb\,var\(--cds-text-primary\)_30\%\,white\)_50\%\,var\(-=
+-cds-text-primary\)_75\%\)\] { background-image: linear-gradient(120deg,var=
+(--cds-text-primary) 25%,color-mix(in srgb,var(--cds-text-primary) 30%,whit=
+e) 50%,var(--cds-text-primary) 75%); }
+
+.\[background-image\:linear-gradient\(120deg\,var\(--cds-text-secondary\)_2=
+5\%\,color-mix\(in_srgb\,var\(--cds-text-secondary\)_30\%\,white\)_50\%\,va=
+r\(--cds-text-secondary\)_75\%\)\] { background-image: linear-gradient(120d=
+eg,var(--cds-text-secondary) 25%,color-mix(in srgb,var(--cds-text-secondary=
+) 30%,white) 50%,var(--cds-text-secondary) 75%); }
+
+.\[background-image\:linear-gradient\(rgba\(42\,120\,214\,0\.07\)\,rgba\(42=
+\,120\,214\,0\.07\)\)\] { background-image: linear-gradient(rgba(42, 120, 2=
+14, 0.07), rgba(42, 120, 214, 0.07)); }
+
+.\[background-position\:150\%_0\%\] { background-position: 150% 0px; }
+
+.\[background-size\:200\%_100\%\] { background-size: 200% 100%; }
+
+.\[background-size\:calc\(100\%-2\*var\(--dt-flush-bleed\)\)_1px\] { backgr=
+ound-size: calc(100% - 2 * var(--dt-flush-bleed)) 1px; }
+
+.\[background\:color-mix\(in_srgb\,var\(--om-accent-error\)_85\%\,black\)\]=
+ { background: color-mix(in srgb,var(--om-accent-error) 85%,black); }
+
+.\[background\:linear-gradient\(to_bottom\,var\(--om-bg-surface\)\,var\(--o=
+m-bg-app\)\)\] { background: linear-gradient(to bottom,var(--om-bg-surface)=
+,var(--om-bg-app)); }
+
+.\[box-decoration-break\:clone\] { -webkit-box-decoration-break: clone; box=
+-decoration-break: clone; }
+
+.\[box-shadow\:0_0_0_2px_var\(--cds-border-strong\)\] { box-shadow: 0 0 0 2=
+px var(--cds-border-strong); }
+
+.\[box-shadow\:0_0_0_2px_var\(--cds-page-bg\)\] { box-shadow: 0 0 0 2px var=
+(--cds-page-bg); }
+
+.\[box-shadow\:0_1px_2px_rgba\(0\,0\,0\,0\.04\)\] { box-shadow: rgba(0, 0, =
+0, 0.04) 0px 1px 2px; }
+
+.\[box-shadow\:0_20px_60px_rgba\(0\,0\,0\,0\.18\)\,0_2px_8px_rgba\(0\,0\,0\=
+,0\.08\)\] { box-shadow: rgba(0, 0, 0, 0.18) 0px 20px 60px, rgba(0, 0, 0, 0=
+.08) 0px 2px 8px; }
+
+.\[box-shadow\:inset_0_-1px_0_var\(--om-border-subtle\)\] { box-shadow: ins=
+et 0 -1px 0 var(--om-border-subtle); }
+
+.\[box-shadow\:inset_0_0_0_1px_var\(--cds-border\)\,0_1px_2px_0_rgb\(0_0_0\=
+/0\.05\)\] { box-shadow: inset 0 0 0 1px var(--cds-border),0 1px 2px 0 #000=
+0000d; }
+
+.\[box-shadow\:inset_0_0_0_1px_var\(--cds-border\)\] { box-shadow: inset 0 =
+0 0 1px var(--cds-border); }
+
+.\[box-shadow\:var\(--cds-focus-shadow\)\] { box-shadow: var(--cds-focus-sh=
+adow); }
+
+.\[box-shadow\:var\(--cds-shadow-lg\)\] { box-shadow: var(--cds-shadow-lg);=
+ }
+
+.\[box-shadow\:var\(--cds-shadow-md\)\] { box-shadow: var(--cds-shadow-md);=
+ }
+
+.\[box-shadow\:var\(--cds-shadow-sm\)\] { box-shadow: var(--cds-shadow-sm);=
+ }
+
+.\[box-shadow\:var\(--om-shadow-lg\)\,0_20px_40px_rgba\(0\,0\,0\,0\.12\)\] =
+{ box-shadow: var(--om-shadow-lg),0 20px 40px #0000001f; }
+
+.\[clip-path\:var\(--burst-clip\)\] { clip-path: var(--burst-clip); }
+
+.\[color-scheme\:normal\] { color-scheme: normal; }
+
+.\[color\:var\(--cds-text-primary\)\] { color: var(--cds-text-primary); }
+
+.\[contain\:layout_style\] { contain: layout style; }
+
+.\[contain\:strict\] { contain: strict; }
+
+.\[container-type\:inline-size\] { container-type: inline-size; }
+
+.\[cursor\:var\(--cds-cursor-interactive\)\] { cursor: var(--cds-cursor-int=
+eractive); }
+
+.\[direction\:rtl\] { direction: rtl; }
+
+.\[display\:-webkit-box\] { display: -webkit-box; }
+
+.\[field-sizing\:content\] { field-sizing: content; }
+
+.\[filter\:drop-shadow\(0_8px_24px_var\(--cds-shadow-color\)\)_drop-shadow\=
+(0_2px_6px_var\(--cds-shadow-color\)\)\] { filter: drop-shadow(0 8px 24px v=
+ar(--cds-shadow-color)) drop-shadow(0 2px 6px var(--cds-shadow-color)); }
+
+.\[font-family\:\'SF_Mono\'\,\'Consolas\'\,\'Monaco\'\,monospace\] { font-f=
+amily: "SF Mono", Consolas, Monaco, monospace; }
+
+.\[font-family\:\'SF_Mono\'\,Consolas\,monospace\] { font-family: "SF Mono"=
+, Consolas, monospace; }
+
+.\[font-family\:inherit\] { font-family: inherit; }
+
+.\[font-family\:ui-monospace\,\'SF_Mono\'\,Menlo\,monospace\] { font-family=
+: ui-monospace, "SF Mono", Menlo, monospace; }
+
+.\[font-family\:ui-monospace\,\'SF_Mono\'\,monospace\] { font-family: ui-mo=
+nospace, "SF Mono", monospace; }
+
+.\[font-family\:ui-monospace\,Menlo\,monospace\] { font-family: ui-monospac=
+e, Menlo, monospace; }
+
+.\[font-family\:ui-monospace\,SFMono-Regular\,Menlo\,monospace\] { font-fam=
+ily: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+.\[font-family\:ui-monospace\,SF_Mono\,monospace\] { font-family: ui-monosp=
+ace, "SF Mono", monospace; }
+
+.\[font-family\:ui-sans-serif\,system-ui\,-apple-system\,sans-serif\] { fon=
+t-family: ui-sans-serif, system-ui, -apple-system, sans-serif; }
+
+.\[font-family\:var\(--cds-font-mono\)\] { font-family: var(--cds-font-mono=
+); }
+
+.\[font-family\:var\(--font-sans\,sans-serif\)\] { font-family: var(--font-=
+sans,sans-serif); }
+
+.\[font-size\:inherit\] { font-size: inherit; }
+
+.\[font-variant-numeric\:normal\] { font-variant-numeric: normal; }
+
+.\[font-variant-numeric\:tabular-nums\] { font-variant-numeric: tabular-num=
+s; }
+
+.\[font-variant-numeric\:tabular-nums_lining-nums\] { font-variant-numeric:=
+ tabular-nums lining-nums; }
+
+.\[font-variation-settings\:\'wght\'_330\,\'opsz\'_22\] { font-variation-se=
+ttings: "wght" 330, "opsz" 22; }
+
+.\[font-variation-settings\:\'wght\'_330\,\'opsz\'_36\] { font-variation-se=
+ttings: "wght" 330, "opsz" 36; }
+
+.\[font-variation-settings\:\'wght\'_350\,\'opsz\'_28\] { font-variation-se=
+ttings: "wght" 350, "opsz" 28; }
+
+.\[font\:inherit\] { font: inherit; }
+
+.\[id\:\.\.\.\] { }
+
+.\[id\:m0001\] { }
+
+.\[id\:m0002\] { }
+
+.\[id\:m0003\] { }
+
+.\[id\:m0006\] { }
+
+.\[id\:m0007\] { }
+
+.\[id\:m0009\] { }
+
+.\[id\:m0011\] { }
+
+.\[id\:m0027\] { }
+
+.\[id\:m0028\] { }
+
+.\[id\:m0036\] { }
+
+.\[id\:m0100\] { }
+
+.\[id\:mNNNN\] { }
+
+.\[justify-content\:safe_center\] { justify-content: safe center; }
+
+.\[line-height\:inherit\] { line-height: inherit; }
+
+.\[mask-image\:linear-gradient\(to_bottom\,transparent_0\,black_12px\,black=
+_calc\(100\%-12px\)\,transparent\)\] { mask-image: linear-gradient(rgba(0, =
+0, 0, 0) 0px, rgb(0, 0, 0) 12px, rgb(0, 0, 0) calc(100% - 12px), rgba(0, 0,=
+ 0, 0)); }
+
+.\[mask-image\:linear-gradient\(to_right\,\#000_calc\(100\%-24px\)\,transpa=
+rent\)\] { mask-image: linear-gradient(90deg, rgb(0, 0, 0) calc(100% - 24px=
+), rgba(0, 0, 0, 0)); }
+
+.\[mask-image\:linear-gradient\(to_right\,transparent\,black_var\(--fade-le=
+ft\,0px\)\,black_calc\(100\%-var\(--fade-right\,0px\)\)\,transparent\)\] { =
+mask-image: linear-gradient(to right,transparent,black var(--fade-left,0px)=
+,black calc(100% - var(--fade-right,0px)),transparent); }
+
+.\[overflow-wrap\:anywhere\] { overflow-wrap: anywhere; }
+
+.\[overflow-wrap\:break-word\] { overflow-wrap: break-word; }
+
+.\[overflow-wrap\:normal\] { overflow-wrap: normal; }
+
+.\[overscroll-behavior-x\:contain\] { overscroll-behavior-x: contain; }
+
+.\[overscroll-behavior\:contain\] { overscroll-behavior: contain; }
+
+.\[scrollbar-gutter\:stable\] { scrollbar-gutter: stable; }
+
+.\[scrollbar-width\:none\] { scrollbar-width: none; }
+
+.\[tab-size\:2\] { tab-size: 2; }
+
+.\[text-align-last\:right\] { text-align-last: right; }
+
+.\[text-decoration-skip-ink\:none\] { text-decoration-skip-ink: none; }
+
+.\[text-decoration-thickness\:0\.5px\] { text-decoration-thickness: 0.5px; =
+}
+
+.\[text-decoration\:none\] { text-decoration: none; }
+
+.\[text-shadow\:-1px_0_rgba\(255\,255\,255\,0\.6\)\,1px_0_rgba\(255\,255\,2=
+55\,0\.6\)\,0_-1px_rgba\(255\,255\,255\,0\.6\)\,0_1px_rgba\(255\,255\,255\,=
+0\.6\)\] { text-shadow: rgba(255, 255, 255, 0.6) -1px 0px, rgba(255, 255, 2=
+55, 0.6) 1px 0px, rgba(255, 255, 255, 0.6) 0px -1px, rgba(255, 255, 255, 0.=
+6) 0px 1px; }
+
+.\[text-shadow\:0_0_12px_rgba\(47\,117\,255\,0\.9\)\] { text-shadow: rgba(4=
+7, 117, 255, 0.9) 0px 0px 12px; }
+
+.\[text-underline-position\:from-font\] { text-underline-position: from-fon=
+t; }
+
+.\[text-wrap\:balance\] { text-wrap: balance; }
+
+.\[text-wrap\:pretty\] { text-wrap: pretty; }
+
+.\[transform-style\:preserve-3d\] { transform-style: preserve-3d; }
+
+.\[transform\:translate\(0\,0\)\] { transform: translate(0px); }
+
+.\[transform\:translateY\(var\(--ty\)\)_scale\(var\(--ts\)\)\] { transform:=
+ translateY(var(--ty)) scale(var(--ts)); }
+
+.\[transform\:translateZ\(1px\)\] { transform: translateZ(1px); }
+
+.\[transform\:translateZ\(2px\)\] { transform: translateZ(2px); }
+
+.\[transition-delay\:0s\] { transition-delay: 0s; }
+
+.\[transition-delay\:1s\] { transition-delay: 1s; }
+
+.\[transition\:all_0\.12s_ease\] { transition: 0.12s; }
+
+.\[transition\:background_0\.12s\] { transition: background 0.12s; }
+
+.\[transition\:background_0\.15s_ease\,box-shadow_0\.15s_ease\] { transitio=
+n: background 0.15s, box-shadow 0.15s; }
+
+.\[transition\:background_var\(--cds-dur-snap\)\,border-color_var\(--cds-du=
+r-snap\)\,box-shadow_var\(--cds-dur-snap\)\] { transition: background var(-=
+-cds-dur-snap),border-color var(--cds-dur-snap),box-shadow var(--cds-dur-sn=
+ap); }
+
+.\[transition\:background_var\(--cds-dur-snap\)\,border-color_var\(--cds-du=
+r-snap\)\] { transition: background var(--cds-dur-snap),border-color var(--=
+cds-dur-snap); }
+
+.\[transition\:background_var\(--cds-dur-snap\)\] { transition: background =
+var(--cds-dur-snap); }
+
+.\[transition\:background_var\(--cds-dur-snap\)_var\(--cds-ease-out\)\] { t=
+ransition: background var(--cds-dur-snap) var(--cds-ease-out); }
+
+.\[transition\:border-color_0\.12s\,background_0\.12s\] { transition: borde=
+r-color 0.12s, background 0.12s; }
+
+.\[transition\:border-color_0\.12s\,box-shadow_0\.12s\,transform_0\.12s\] {=
+ transition: border-color 0.12s, box-shadow 0.12s, transform 0.12s; }
+
+.\[transition\:border-color_0\.12s_ease\,box-shadow_0\.12s_ease\] { transit=
+ion: border-color 0.12s, box-shadow 0.12s; }
+
+.\[transition\:border-color_100ms_ease\,box-shadow_100ms_ease\] { transitio=
+n: border-color 0.1s, box-shadow 0.1s; }
+
+.\[transition\:grid-template-rows_0\.2s_ease-out\] { transition: grid-templ=
+ate-rows 0.2s ease-out; }
+
+.\[transition\:grid-template-rows_var\(--ms\)_cubic-bezier\(0\.2\,0\,0\,1\)=
+\] { transition: grid-template-rows var(--ms) cubic-bezier(.2,0,0,1); }
+
+.\[transition\:opacity_0\.12s_ease\] { transition: opacity 0.12s; }
+
+.\[transition\:opacity_0\.1s\] { transition: opacity 0.1s; }
+
+.\[transition\:transform_0\.12s_ease\,box-shadow_0\.12s_ease\] { transition=
+: transform 0.12s, box-shadow 0.12s; }
+
+.\[transition\:transform_0\.15s_ease\,opacity_0\.15s_ease\,visibility_0s_li=
+near_0\.15s\] { transition: transform 0.15s, opacity 0.15s, visibility line=
+ar 0.15s; }
+
+.\[transition\:transform_0\.15s_ease\,opacity_0\.15s_ease\,visibility_0s_li=
+near_0s\] { transition: transform 0.15s, opacity 0.15s, visibility linear; =
+}
+
+.\[transition\:transform_var\(--cds-dur-snap\)_var\(--cds-ease-out\)\] { tr=
+ansition: transform var(--cds-dur-snap) var(--cds-ease-out); }
+
+.\[transition\:width_0\.3s_ease-out\] { transition: width 0.3s ease-out; }
+
+.\[word-break\:break-word\] { word-break: break-word; }
+
+.cds-root[data-cds-portal] { --cds-z-modal: 1900; --cds-z-popover: 3600; --=
+cds-z-tooltip: 3600; --cds-z-toast: 9000; }
+
+.marker\:text-om-text-tertiary ::marker { color: var(--om-text-tertiary); }
+
+.marker\:text-om-text-tertiary::marker { color: var(--om-text-tertiary); }
+
+.placeholder\:text-right::placeholder { text-align: right; }
+
+.placeholder\:font-\[inherit\]::placeholder { font-family: inherit; }
+
+.placeholder\:italic::placeholder { font-style: italic; }
+
+.placeholder\:text-\[var\(--cds-text-muted\)\]::placeholder { color: var(--=
+cds-text-muted); }
+
+.placeholder\:text-muted::placeholder { color: var(--cds-text-muted); }
+
+.placeholder\:text-om-presenter-placeholder::placeholder { color: var(--om-=
+presenter-placeholder); }
+
+.placeholder\:text-om-text-tertiary::placeholder { color: var(--om-text-ter=
+tiary); }
+
+.placeholder\:opacity-100::placeholder { opacity: 1; }
+
+.placeholder\:opacity-80::placeholder { opacity: 0.8; }
+
+.placeholder\:\[transition\:opacity_0\.32s_ease\]::placeholder { transition=
+: opacity 0.32s; }
+
+.before\:pointer-events-none::before { content: var(--tw-content); pointer-=
+events: none; }
+
+.before\:absolute::before { content: var(--tw-content); position: absolute;=
+ }
+
+.before\:-inset-1\.5::before { content: var(--tw-content); inset: -0.375rem=
+; }
+
+.before\:inset-\[-10px\]::before { content: var(--tw-content); inset: -10px=
+; }
+
+.before\:left-0::before { content: var(--tw-content); left: 0px; }
+
+.before\:right-0::before { content: var(--tw-content); right: 0px; }
+
+.before\:top-0::before { content: var(--tw-content); top: 0px; }
+
+.before\:z-\[1\]::before { content: var(--tw-content); z-index: 1; }
+
+.before\:order-1::before { content: var(--tw-content); order: 1; }
+
+.before\:h-2::before { content: var(--tw-content); height: 0.5rem; }
+
+.before\:h-5::before { content: var(--tw-content); height: 1.25rem; }
+
+.before\:h-\[3px\]::before { content: var(--tw-content); height: 3px; }
+
+.before\:w-2::before { content: var(--tw-content); width: 0.5rem; }
+
+.before\:flex-1::before { content: var(--tw-content); flex: 1 1 0%; }
+
+.before\:flex-none::before { content: var(--tw-content); flex: 0 0 auto; }
+
+.before\:rounded-\[2px\]::before { content: var(--tw-content); border-radiu=
+s: 2px; }
+
+.before\:bg-\[var\(--row-dot\)\]::before { content: var(--tw-content); back=
+ground-color: var(--row-dot); }
+
+.before\:bg-\[linear-gradient\(to_bottom\,var\(--chat-floor\)_2\%\,transpar=
+ent_100\%\)\]::before { content: var(--tw-content); background-image: linea=
+r-gradient(to bottom,var(--chat-floor) 2%,transparent 100%); }
+
+.before\:bg-\[linear-gradient\(to_right\,var\(--bar-color\)_0_var\(--pct\)\=
+,var\(--om-border-subtle\)_var\(--pct\)\)\]::before { content: var(--tw-con=
+tent); background-image: linear-gradient(to right,var(--bar-color) 0 var(--=
+pct),var(--om-border-subtle) var(--pct)); }
+
+.before\:content-\[\'\'\]::before { --tw-content: ""; content: var(--tw-con=
+tent); }
+
+.before\:content-\[\'=E2=80=9C\'\]::before { --tw-content: "=E2=80=9C"; con=
+tent: var(--tw-content); }
+
+.after\:pointer-events-none::after { content: var(--tw-content); pointer-ev=
+ents: none; }
+
+.after\:invisible::after { content: var(--tw-content); visibility: hidden; =
+}
+
+.after\:absolute::after { content: var(--tw-content); position: absolute; }
+
+.after\:inset-0::after { content: var(--tw-content); inset: 0px; }
+
+.after\:inset-y-0::after { content: var(--tw-content); top: 0px; bottom: 0p=
+x; }
+
+.after\:-end-2::after { content: var(--tw-content); inset-inline-end: -0.5r=
+em; }
+
+.after\:bottom-\[3px\]::after { content: var(--tw-content); bottom: 3px; }
+
+.after\:right-\[3px\]::after { content: var(--tw-content); right: 3px; }
+
+.after\:start-0::after { content: var(--tw-content); inset-inline-start: 0p=
+x; }
+
+.after\:block::after { content: var(--tw-content); display: block; }
+
+.after\:hidden::after { content: var(--tw-content); display: none; }
+
+.after\:h-0::after { content: var(--tw-content); height: 0px; }
+
+.after\:h-0\.5::after { content: var(--tw-content); height: 0.125rem; }
+
+.after\:h-2::after { content: var(--tw-content); height: 0.5rem; }
+
+.after\:w-2::after { content: var(--tw-content); width: 0.5rem; }
+
+.after\:w-7::after { content: var(--tw-content); width: 1.75rem; }
+
+.after\:animate-\[cds-shimmer_2s_linear_infinite\]::after { content: var(--=
+tw-content); animation: 2s linear 0s infinite normal none running cds-shimm=
+er; }
+
+.after\:overflow-hidden::after { content: var(--tw-content); overflow: hidd=
+en; }
+
+.after\:rounded::after { content: var(--tw-content); border-radius: var(--c=
+ds-radius); }
+
+.after\:rounded-\[1px\]::after { content: var(--tw-content); border-radius:=
+ 1px; }
+
+.after\:rounded-\[inherit\]::after { content: var(--tw-content); border-rad=
+ius: inherit; }
+
+.after\:rounded-full::after { content: var(--tw-content); border-radius: 99=
+99px; }
+
+.after\:rounded-br-\[2px\]::after { content: var(--tw-content); border-bott=
+om-right-radius: 2px; }
+
+.after\:border-b-2::after { content: var(--tw-content); border-bottom-width=
+: 2px; }
+
+.after\:border-r-2::after { content: var(--tw-content); border-right-width:=
+ 2px; }
+
+.after\:border-om-border-strong::after { content: var(--tw-content); border=
+-color: var(--om-border-strong); }
+
+.after\:bg-om-accent-primary::after { content: var(--tw-content); backgroun=
+d-color: var(--om-accent-primary); }
+
+.after\:bg-om-border-default::after { content: var(--tw-content); backgroun=
+d-color: var(--om-border-default); }
+
+.after\:bg-\[linear-gradient\(90deg\,transparent\,var\(--cds-skeleton-sheen=
+\)\,transparent\)\]::after { content: var(--tw-content); background-image: =
+linear-gradient(90deg,transparent,var(--cds-skeleton-sheen),transparent); }
+
+.after\:font-\[550\]::after { content: var(--tw-content); font-weight: 550;=
+ }
+
+.after\:content-\[\'\'\]::after { --tw-content: ""; content: var(--tw-conte=
+nt); }
+
+.after\:content-\[\'=E2=80=9D\'\]::after { --tw-content: "=E2=80=9D"; conte=
+nt: var(--tw-content); }
+
+.after\:content-\[attr\(data-text\)\]::after { --tw-content: attr(data-text=
+); content: var(--tw-content); }
+
+.after\:\[box-shadow\:inset_0_0_0_1px_var\(--cds-fill-secondary-ring\)\]::a=
+fter { content: var(--tw-content); box-shadow: inset 0 0 0 1px var(--cds-fi=
+ll-secondary-ring); }
+
+.first\:mt-0:first-child { margin-top: 0px; }
+
+.first\:rounded-l:first-child { border-top-left-radius: var(--cds-radius); =
+border-bottom-left-radius: var(--cds-radius); }
+
+.first\:border-t:first-child { border-top-width: 1px; }
+
+.first\:\!pl-\[var\(--dt-flush-bleed\)\]:first-child { padding-left: var(--=
+dt-flush-bleed) !important; }
+
+.first\:pt-0:first-child { padding-top: 0px; }
+
+.last\:mb-0:last-child { margin-bottom: 0px; }
+
+.last\:rounded-r:last-child { border-top-right-radius: var(--cds-radius); b=
+order-bottom-right-radius: var(--cds-radius); }
+
+.last\:border-b-0:last-child { border-bottom-width: 0px; }
+
+.last\:\!pr-\[var\(--dt-flush-bleed\)\]:last-child { padding-right: var(--d=
+t-flush-bleed) !important; }
+
+.first-of-type\:mt-1:first-of-type { margin-top: 0.25rem; }
+
+.last-of-type\:mb-0:last-of-type { margin-bottom: 0px; }
+
+.read-only\:cursor-default:read-only { cursor: default; }
+
+.read-only\:caret-transparent:read-only { caret-color: rgba(0, 0, 0, 0); }
+
+.read-only\:\[caret-color\:transparent\]:read-only { caret-color: rgba(0, 0=
+, 0, 0); }
+
+.empty\:hidden:empty { display: none; }
+
+.focus-within\:pointer-events-auto:focus-within { pointer-events: auto; }
+
+.focus-within\:border-om-border-focus:focus-within { border-color: var(--om=
+-border-focus); }
+
+.focus-within\:border-om-border-strong:focus-within { border-color: var(--o=
+m-border-strong); }
+
+.focus-within\:bg-om-bg-elevated:focus-within { background-color: var(--om-=
+bg-elevated); }
+
+.focus-within\:bg-om-bg-surface:focus-within { background-color: var(--om-b=
+g-surface); }
+
+.focus-within\:opacity-100:focus-within { opacity: 1; }
+
+.focus-within\:shadow-\[0_0_0_2px_var\(--om-bg-selected\)\]:focus-within { =
+--tw-shadow: 0 0 0 2px var(--om-bg-selected); --tw-shadow-colored: 0 0 0 2p=
+x var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000=
+), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.focus-within\:shadow-\[inset_0_0_0_1px_var\(--om-border-default\)\,var\(--=
+om-shadow-sm\)\]:focus-within { --tw-shadow-color: inset 0 0 0 1px var(--om=
+-border-default),var(--om-shadow-sm); --tw-shadow: var(--tw-shadow-colored)=
+; }
+
+.focus-within\:outline-none:focus-within { outline-offset: 2px; outline: rg=
+ba(0, 0, 0, 0) solid 2px; }
+
+.focus-within\:\[box-shadow\:var\(--cds-focus-shadow\)\]:focus-within { box=
+-shadow: var(--cds-focus-shadow); }
+
+.hover\:-translate-y-px:hover { --tw-translate-y: -1px; transform: translat=
+e(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) sk=
+ewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) sca=
+leY(var(--tw-scale-y)); }
+
+.hover\:scale-\[1\.01\]:hover { --tw-scale-x: 1.01; --tw-scale-y: 1.01; tra=
+nsform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(=
+--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--=
+tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.hover\:scale-\[1\.02\]:hover { --tw-scale-x: 1.02; --tw-scale-y: 1.02; tra=
+nsform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(=
+--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--=
+tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.hover\:scale-\[1\.15\]:hover { --tw-scale-x: 1.15; --tw-scale-y: 1.15; tra=
+nsform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(=
+--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--=
+tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.hover\:scale-\[1\.2\]:hover { --tw-scale-x: 1.2; --tw-scale-y: 1.2; transf=
+orm: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--t=
+w-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-=
+scale-x)) scaleY(var(--tw-scale-y)); }
+
+.hover\:border-\[var\(--cds-border-strong\)\]:hover { border-color: var(--c=
+ds-border-strong); }
+
+.hover\:border-om-accent-blue:hover { border-color: var(--om-accent-blue); =
+}
+
+.hover\:border-om-accent-blue-hover:hover { border-color: var(--om-accent-b=
+lue-hover); }
+
+.hover\:border-om-accent-primary:hover { border-color: var(--om-accent-prim=
+ary); }
+
+.hover\:border-om-accent-secondary:hover { border-color: var(--om-accent-se=
+condary); }
+
+.hover\:border-om-border-default:hover { border-color: var(--om-border-defa=
+ult); }
+
+.hover\:border-om-border-focus:hover { border-color: var(--om-border-focus)=
+; }
+
+.hover\:border-om-border-strong:hover { border-color: var(--om-border-stron=
+g); }
+
+.hover\:border-om-presenter-slide-hover-border:hover { border-color: var(--=
+om-presenter-slide-hover-border); }
+
+.hover\:border-om-text-primary:hover { border-color: var(--om-text-primary)=
+; }
+
+.hover\:border-transparent:hover { border-color: rgba(0, 0, 0, 0); }
+
+.hover\:border-l-om-accent-error:hover { border-left-color: var(--om-accent=
+-error); }
+
+.hover\:bg-\[\#2968f0\]:hover { --tw-bg-opacity: 1; background-color: rgb(4=
+1 104 240/var(--tw-bg-opacity,1)); }
+
+.hover\:bg-\[\#3A3A38\]:hover { --tw-bg-opacity: 1; background-color: rgb(5=
+8 58 56/var(--tw-bg-opacity,1)); }
+
+.hover\:bg-\[rgba\(0\,0\,0\,0\.1\)\]:hover { background-color: rgba(0, 0, 0=
+, 0.1); }
+
+.hover\:bg-\[rgba\(0\,0\,0\,0\.35\)\]:hover { background-color: rgba(0, 0, =
+0, 0.35); }
+
+.hover\:bg-\[rgba\(15\,12\,8\,0\.04\)\]:hover { background-color: rgba(15, =
+12, 8, 0.04); }
+
+.hover\:bg-\[rgba\(201\,168\,45\,0\.15\)\]:hover { background-color: rgba(2=
+01, 168, 45, 0.15); }
+
+.hover\:bg-\[var\(--cds-clay-emphasized\)\]:hover { background-color: var(-=
+-cds-clay-emphasized); }
+
+.hover\:bg-\[var\(--cds-fill-ghost-hover\)\]:hover { background-color: var(=
+--cds-fill-ghost-hover); }
+
+.hover\:bg-\[var\(--cds-switch-track-hover\)\]:hover { background-color: va=
+r(--cds-switch-track-hover); }
+
+.hover\:bg-\[var\(--sticker-hover-bg\)\]:hover { background-color: var(--st=
+icker-hover-bg); }
+
+.hover\:bg-alpha-1:hover { background-color: var(--cds-alpha-1); }
+
+.hover\:bg-fill-ghost-hover:hover { background-color: var(--cds-fill-ghost-=
+hover); }
+
+.hover\:bg-neutral-hover:hover { background-color: var(--cds-bg-neutral-hov=
+er); }
+
+.hover\:bg-om-accent-black-active:hover { background-color: var(--om-accent=
+-black-active); }
+
+.hover\:bg-om-accent-black-hover:hover { background-color: var(--om-accent-=
+black-hover); }
+
+.hover\:bg-om-accent-blue:hover { background-color: var(--om-accent-blue); =
+}
+
+.hover\:bg-om-accent-blue-bg:hover { background-color: var(--om-accent-blue=
+-bg); }
+
+.hover\:bg-om-accent-blue-hover:hover { background-color: var(--om-accent-b=
+lue-hover); }
+
+.hover\:bg-om-accent-primary-active:hover { background-color: var(--om-acce=
+nt-primary-active); }
+
+.hover\:bg-om-accent-primary-hover:hover { background-color: var(--om-accen=
+t-primary-hover); }
+
+.hover\:bg-om-accent-secondary-active:hover { background-color: var(--om-ac=
+cent-secondary-active); }
+
+.hover\:bg-om-accent-secondary-hover:hover { background-color: var(--om-acc=
+ent-secondary-hover); }
+
+.hover\:bg-om-bg-active:hover { background-color: var(--om-bg-active); }
+
+.hover\:bg-om-bg-hover:hover { background-color: var(--om-bg-hover); }
+
+.hover\:bg-om-bg-muted:hover { background-color: var(--om-bg-muted); }
+
+.hover\:bg-om-bg-panel:hover { background-color: var(--om-bg-panel); }
+
+.hover\:bg-om-bg-selected:hover { background-color: var(--om-bg-selected); =
+}
+
+.hover\:bg-om-bg-stripe:hover { background-color: var(--om-bg-stripe); }
+
+.hover\:bg-om-bg-surface:hover { background-color: var(--om-bg-surface); }
+
+.hover\:bg-om-presenter-control-hover:hover { background-color: var(--om-pr=
+esenter-control-hover); }
+
+.hover\:bg-om-presenter-divider-hover:hover { background-color: var(--om-pr=
+esenter-divider-hover); }
+
+.hover\:bg-surface-1:hover { background-color: var(--cds-surface-1); }
+
+.hover\:bg-surface-3:hover { background-color: var(--cds-surface-3); }
+
+.hover\:bg-transparent:hover { background-color: rgba(0, 0, 0, 0); }
+
+.hover\:bg-none:hover { background-image: none; }
+
+.hover\:text-\[var\(--cds-text-primary\)\]:hover { color: var(--cds-text-pr=
+imary); }
+
+.hover\:text-\[var\(--sticker-text\)\]:hover { color: var(--sticker-text); =
+}
+
+.hover\:text-om-accent-error:hover { color: var(--om-accent-error); }
+
+.hover\:text-om-text-primary:hover { color: var(--om-text-primary); }
+
+.hover\:text-om-text-secondary:hover { color: var(--om-text-secondary); }
+
+.hover\:text-primary:hover { color: var(--cds-text-primary); }
+
+.hover\:underline:hover { text-decoration-line: underline; }
+
+.hover\:no-underline:hover { text-decoration-line: none; }
+
+.hover\:decoration-current:hover { text-decoration-color: currentcolor; }
+
+.hover\:underline-offset-\[3px\]:hover { text-underline-offset: 3px; }
+
+.hover\:\!opacity-100:hover { opacity: 1 !important; }
+
+.hover\:opacity-80:hover { opacity: 0.8; }
+
+.hover\:shadow-\[0_0_0_0\.5px_var\(--om-border-strong\)\,0_4px_10px_rgba\(0=
+\,0\,0\,0\.12\)\]:hover { --tw-shadow: 0 0 0 .5px var(--om-border-strong),0=
+ 4px 10px #0000001f; --tw-shadow-colored: 0 0 0 .5px var(--tw-shadow-color)=
+, 0 4px 10px var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shado=
+w,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.hover\:shadow-\[0_1px_3px_rgba\(20\,20\,19\,0\.06\)\,0_1px_2px_rgba\(20\,2=
+0\,19\,0\.04\)\]:hover { --tw-shadow: 0 1px 3px #1414130f,0 1px 2px #141413=
+0a; --tw-shadow-colored: 0 1px 3px var(--tw-shadow-color), 0 1px 2px var(--=
+tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(-=
+-tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.hover\:shadow-\[0_2px_5px_rgba\(20\,20\,19\,0\.12\)\,0_0_0_1px_var\(--om-b=
+order-default\)\]:hover { --tw-shadow: 0 2px 5px #1414131f,0 0 0 1px var(--=
+om-border-default); --tw-shadow-colored: 0 2px 5px var(--tw-shadow-color), =
+0 0 0 1px var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0=
+ 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.hover\:shadow-\[0_3px_10px_rgba\(0\,0\,0\,0\.3\)\]:hover { --tw-shadow: 0 =
+3px 10px #0000004d; --tw-shadow-colored: 0 3px 10px var(--tw-shadow-color);=
+ box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0=
+ 0 #0000), var(--tw-shadow); }
+
+.hover\:shadow-om-sm:hover { --tw-shadow: var(--om-shadow-sm); --tw-shadow-=
+colored: var(--om-shadow-sm); box-shadow: var(--tw-ring-offset-shadow,0 0 #=
+0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.hover\:brightness-\[1\.05\]:hover { --tw-brightness: brightness(1.05); fil=
+ter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-graysc=
+ale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepi=
+a) var(--tw-drop-shadow); }
+
+.hover\:\[background\:color-mix\(in_srgb\,var\(--om-accent-error\)_85\%\,bl=
+ack\)\]:hover { background: color-mix(in srgb,var(--om-accent-error) 85%,bl=
+ack); }
+
+.hover\:\[background\:color-mix\(in_srgb\,var\(--om-accent-error\)_92\%\,bl=
+ack\)\]:hover { background: color-mix(in srgb,var(--om-accent-error) 92%,bl=
+ack); }
+
+.hover\:\[box-shadow\:0_0_0_2px_var\(--cds-border-strong\)\]:hover { box-sh=
+adow: 0 0 0 2px var(--cds-border-strong); }
+
+.hover\:\[box-shadow\:var\(--cds-shadow-md\)\]:hover { box-shadow: var(--cd=
+s-shadow-md); }
+
+.hover\:after\:bg-om-text-tertiary:hover::after { content: var(--tw-content=
+); background-color: var(--om-text-tertiary); }
+
+.focus\:border-om-accent-error:focus { border-color: var(--om-accent-error)=
+; }
+
+.focus\:border-om-accent-primary:focus { border-color: var(--om-accent-prim=
+ary); }
+
+.focus\:border-om-border-focus:focus { border-color: var(--om-border-focus)=
+; }
+
+.focus\:border-om-border-strong:focus { border-color: var(--om-border-stron=
+g); }
+
+.focus\:bg-om-bg-surface:focus { background-color: var(--om-bg-surface); }
+
+.focus\:shadow-\[0_0_0_2px_\#6a9bcc22\]:focus { --tw-shadow: 0 0 0 2px #6a9=
+bcc22; --tw-shadow-colored: 0 0 0 2px var(--tw-shadow-color); box-shadow: v=
+ar(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var=
+(--tw-shadow); }
+
+.focus\:shadow-\[0_0_0_2px_color-mix\(in_srgb\,var\(--om-accent-blue\)_22\%=
+\,transparent\)\]:focus { --tw-shadow: 0 0 0 2px color-mix(in srgb,var(--om=
+-accent-blue) 22%,transparent); --tw-shadow-colored: 0 0 0 2px var(--tw-sha=
+dow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ri=
+ng-shadow,0 0 #0000), var(--tw-shadow); }
+
+.focus\:outline-none:focus { outline-offset: 2px; outline: rgba(0, 0, 0, 0)=
+ solid 2px; }
+
+.focus-visible\:rounded-\[2px\]:focus-visible { border-radius: 2px; }
+
+.focus-visible\:border-\[var\(--cds-fill-accent\)\]:focus-visible { border-=
+color: var(--cds-fill-accent); }
+
+.focus-visible\:border-om-accent-secondary:focus-visible { border-color: va=
+r(--om-accent-secondary); }
+
+.focus-visible\:border-om-border-focus:focus-visible { border-color: var(--=
+om-border-focus); }
+
+.focus-visible\:bg-\[var\(--cds-fill-ghost-hover\)\]:focus-visible, .focus-=
+visible\:bg-fill-ghost-hover:focus-visible { background-color: var(--cds-fi=
+ll-ghost-hover); }
+
+.focus-visible\:bg-neutral-hover:focus-visible { background-color: var(--cd=
+s-bg-neutral-hover); }
+
+.focus-visible\:bg-surface-1:focus-visible { background-color: var(--cds-su=
+rface-1); }
+
+.focus-visible\:bg-surface-popover:focus-visible { background-color: var(--=
+cds-surface-popover); }
+
+.focus-visible\:text-om-text-secondary:focus-visible { color: var(--om-text=
+-secondary); }
+
+.focus-visible\:text-primary:focus-visible { color: var(--cds-text-primary)=
+; }
+
+.focus-visible\:decoration-current:focus-visible { text-decoration-color: c=
+urrentcolor; }
+
+.focus-visible\:opacity-100:focus-visible { opacity: 1; }
+
+.focus-visible\:\!shadow-\[0_0_0_2px_rgb\(255_255_255\/0\.7\)\]:focus-visib=
+le { --tw-shadow: 0 0 0 2px #ffffffb3 !important; --tw-shadow-colored: 0 0 =
+0 2px var(--tw-shadow-color) !important; box-shadow: var(--tw-ring-offset-s=
+hadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow) !import=
+ant; }
+
+.focus-visible\:shadow-\[0_0_0_2px_\#6a9bcc22\]:focus-visible { --tw-shadow=
+: 0 0 0 2px #6a9bcc22; --tw-shadow-colored: 0 0 0 2px var(--tw-shadow-color=
+); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow=
+,0 0 #0000), var(--tw-shadow); }
+
+.focus-visible\:shadow-\[0_0_0_2px_var\(--om-bg-selected\)\]:focus-visible =
+{ --tw-shadow: 0 0 0 2px var(--om-bg-selected); --tw-shadow-colored: 0 0 0 =
+2px var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #00=
+00), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.focus-visible\:shadow-\[0_0_0_2px_var\(--om-border-focus\)\]:focus-visible=
+ { --tw-shadow: 0 0 0 2px var(--om-border-focus); --tw-shadow-colored: 0 0 =
+0 2px var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #=
+0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.focus-visible\:shadow-\[0_0_0_2px_var\(--om-text-secondary\)\]:focus-visib=
+le { --tw-shadow: 0 0 0 2px var(--om-text-secondary); --tw-shadow-colored: =
+0 0 0 2px var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0=
+ 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.focus-visible\:shadow-\[inset_0_0_0_2px_var\(--om-border-focus\)\]:focus-v=
+isible { --tw-shadow: inset 0 0 0 2px var(--om-border-focus); --tw-shadow-c=
+olored: inset 0 0 0 2px var(--tw-shadow-color); box-shadow: var(--tw-ring-o=
+ffset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow);=
+ }
+
+.focus-visible\:shadow-focus:focus-visible { --tw-shadow: var(--cds-focus-s=
+hadow); --tw-shadow-colored: var(--cds-focus-shadow); box-shadow: var(--tw-=
+ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-sh=
+adow); }
+
+.focus-visible\:shadow-none:focus-visible { --tw-shadow: 0 0 #0000; --tw-sh=
+adow-colored: 0 0 #0000; box-shadow: var(--tw-ring-offset-shadow,0 0 #0000)=
+, var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.focus-visible\:outline-none:focus-visible { outline-offset: 2px; outline: =
+rgba(0, 0, 0, 0) solid 2px; }
+
+.focus-visible\:outline:focus-visible { outline-style: solid; }
+
+.focus-visible\:outline-2:focus-visible { outline-width: 2px; }
+
+.focus-visible\:-outline-offset-1:focus-visible { outline-offset: -1px; }
+
+.focus-visible\:-outline-offset-2:focus-visible { outline-offset: -2px; }
+
+.focus-visible\:outline-offset-2:focus-visible { outline-offset: 2px; }
+
+.focus-visible\:outline-offset-\[-2px\]:focus-visible { outline-offset: -2p=
+x; }
+
+.focus-visible\:outline:focus-visible { outline-color: var(--cds-border); }
+
+.focus-visible\:outline-om-accent-primary:focus-visible { outline-color: va=
+r(--om-accent-primary); }
+
+.focus-visible\:outline-om-border-focus:focus-visible { outline-color: var(=
+--om-border-focus); }
+
+.focus-visible\:outline-transparent:focus-visible { outline-color: rgba(0, =
+0, 0, 0); }
+
+.focus-visible\:ring-2:focus-visible { --tw-ring-offset-shadow: var(--tw-ri=
+ng-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color); --=
+tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-=
+width)) var(--tw-ring-color); box-shadow: var(--tw-ring-offset-shadow), var=
+(--tw-ring-shadow), var(--tw-shadow,0 0 #0000); }
+
+.focus-visible\:ring-om-accent-blue:focus-visible { --tw-ring-color: var(--=
+om-accent-blue); }
+
+.focus-visible\:\[box-shadow\:inset_0_0_0_1px_var\(--cds-fill-accent\)\]:fo=
+cus-visible { box-shadow: inset 0 0 0 1px var(--cds-fill-accent); }
+
+.focus-visible\:\[box-shadow\:var\(--cds-focus-shadow\)\]:focus-visible { b=
+ox-shadow: var(--cds-focus-shadow); }
+
+.focus-visible\:\[outline\:2px_solid_var\(--om-accent-primary\)\]:focus-vis=
+ible { outline: 2px solid var(--om-accent-primary); }
+
+.focus-visible\:after\:shadow-focus:focus-visible::after { content: var(--t=
+w-content); --tw-shadow: var(--cds-focus-shadow); --tw-shadow-colored: var(=
+--cds-focus-shadow); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), va=
+r(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.active\:translate-y-px:active { --tw-translate-y: 1px; transform: translat=
+e(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) sk=
+ewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) sca=
+leY(var(--tw-scale-y)); }
+
+.active\:scale-\[0\.99\]:active { --tw-scale-x: .99; --tw-scale-y: .99; tra=
+nsform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(=
+--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--=
+tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.active\:cursor-grabbing:active { cursor: grabbing; }
+
+.active\:bg-\[\#1d55d8\]:active { --tw-bg-opacity: 1; background-color: rgb=
+(29 85 216/var(--tw-bg-opacity,1)); }
+
+.active\:bg-om-accent-black-active:active { background-color: var(--om-acce=
+nt-black-active); }
+
+.active\:bg-om-accent-blue-bg:active { background-color: var(--om-accent-bl=
+ue-bg); }
+
+.active\:bg-om-accent-primary-active:active { background-color: var(--om-ac=
+cent-primary-active); }
+
+.active\:bg-om-accent-secondary-active:active { background-color: var(--om-=
+accent-secondary-active); }
+
+.active\:bg-om-bg-active:active { background-color: var(--om-bg-active); }
+
+.active\:bg-om-presenter-control-active:active { background-color: var(--om=
+-presenter-control-active); }
+
+.active\:brightness-\[\.8\]:active { --tw-brightness: brightness(.8); filte=
+r: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscal=
+e) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia)=
+ var(--tw-drop-shadow); }
+
+.active\:\[background\:color-mix\(in_srgb\,var\(--om-accent-error\)_85\%\,b=
+lack\)\]:active { background: color-mix(in srgb,var(--om-accent-error) 85%,=
+black); }
+
+.hover\:enabled\:border-om-border-strong:enabled:hover { border-color: var(=
+--om-border-strong); }
+
+.enabled\:hover\:bg-om-bg-hover:hover:enabled { background-color: var(--om-=
+bg-hover); }
+
+.enabled\:hover\:text-om-accent-primary-hover:hover:enabled { color: var(--=
+om-accent-primary-hover); }
+
+.hover\:enabled\:\[background\:var\(--hover-bg\)\]:enabled:hover { backgrou=
+nd: var(--hover-bg); }
+
+.disabled\:pointer-events-none:disabled { pointer-events: none; }
+
+.disabled\:cursor-default:disabled { cursor: default; }
+
+.disabled\:cursor-not-allowed:disabled { cursor: not-allowed; }
+
+.disabled\:bg-transparent:disabled { background-color: rgba(0, 0, 0, 0); }
+
+.disabled\:text-om-text-disabled:disabled { color: var(--om-text-disabled);=
+ }
+
+.disabled\:text-om-text-tertiary:disabled { color: var(--om-text-tertiary);=
+ }
+
+.disabled\:opacity-30:disabled { opacity: 0.3; }
+
+.disabled\:opacity-40:disabled { opacity: 0.4; }
+
+.disabled\:opacity-50:disabled { opacity: 0.5; }
+
+.disabled\:opacity-60:disabled { opacity: 0.6; }
+
+.disabled\:opacity-\[0\.35\]:disabled { opacity: 0.35; }
+
+.disabled\:opacity-\[0\.45\]:disabled { opacity: 0.45; }
+
+.group\/card:focus-within .group-focus-within\/card\:pointer-events-auto, .=
+group:focus-within .group-focus-within\:pointer-events-auto { pointer-event=
+s: auto; }
+
+.group\/card:focus-within .group-focus-within\/card\:opacity-100, .group:fo=
+cus-within .group-focus-within\:opacity-100 { opacity: 1; }
+
+.group\/card:hover .group-hover\/card\:pointer-events-auto, .group:hover .g=
+roup-hover\:pointer-events-auto { pointer-events: auto; }
+
+.group:hover .group-hover\:visible { visibility: visible; }
+
+.group:hover .group-hover\:left-px { left: 1px; }
+
+.group:hover .group-hover\:flex { display: flex; }
+
+.group:hover .group-hover\:h-2\.5 { height: 0.625rem; }
+
+.group:hover .group-hover\:w-2\.5 { width: 0.625rem; }
+
+.group:hover .group-hover\:-translate-y-0\.5 { --tw-translate-y: -.125rem; =
+transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(v=
+ar(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var=
+(--tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.group:hover .group-hover\:-translate-y-px { --tw-translate-y: -1px; transf=
+orm: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--t=
+w-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-=
+scale-x)) scaleY(var(--tw-scale-y)); }
+
+.group\/row:hover .group-hover\/row\:grid-rows-\[1fr\] { grid-template-rows=
+: 1fr; }
+
+.group\/cb:hover .group-hover\/cb\:border-stronger, .group\/rd:hover .group=
+-hover\/rd\:border-stronger { border-color: var(--cds-border-stronger); }
+
+.group\/srow:hover .group-hover\/srow\:border-om-border-focus { border-colo=
+r: var(--om-border-focus); }
+
+.group:hover .group-hover\:border-om-border-default { border-color: var(--o=
+m-border-default); }
+
+.group\/btn:hover .group-hover\/btn\:bg-fill-brand-hover { background-color=
+: var(--cds-fill-brand-hover); }
+
+.group\/btn:hover .group-hover\/btn\:bg-fill-danger-hover { background-colo=
+r: var(--cds-fill-danger-hover); }
+
+.group\/btn:hover .group-hover\/btn\:bg-fill-ghost-hover { background-color=
+: var(--cds-fill-ghost-hover); }
+
+.group\/btn:hover .group-hover\/btn\:bg-fill-primary-hover { background-col=
+or: var(--cds-fill-primary-hover); }
+
+.group\/btn:hover .group-hover\/btn\:bg-fill-secondary-hover { background-c=
+olor: var(--cds-fill-secondary-hover); }
+
+.group\/btn:hover .group-hover\/btn\:bg-white\/30 { background-color: rgba(=
+255, 255, 255, 0.3); }
+
+.group:hover .group-hover\:bg-fill-ghost-hover { background-color: var(--cd=
+s-fill-ghost-hover); }
+
+.group:hover .group-hover\:text-center { text-align: center; }
+
+.group:hover .group-hover\:text-\[9px\] { font-size: 9px; }
+
+.group:hover .group-hover\:leading-\[10px\] { line-height: 10px; }
+
+.group\/cbx:hover .group-hover\/cbx\:text-secondary { color: var(--cds-text=
+-secondary); }
+
+.group:hover .group-hover\:text-om-text-inverse { color: var(--om-text-inve=
+rse); }
+
+.group\/tl:hover .group-hover\/tl\:decoration-current { text-decoration-col=
+or: currentcolor; }
+
+.group\/card:hover .group-hover\/card\:opacity-100, .group\/thumb:hover .gr=
+oup-hover\/thumb\:opacity-100, .group:hover .group-hover\:opacity-100 { opa=
+city: 1; }
+
+.group:hover .group-hover\:opacity-70 { opacity: 0.7; }
+
+.group:hover .group-hover\:shadow-om-sm { --tw-shadow: var(--om-shadow-sm);=
+ --tw-shadow-colored: var(--om-shadow-sm); box-shadow: var(--tw-ring-offset=
+-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.group\/diff:hover .group-hover\/diff\:\[background-color\:color-mix\(in_ok=
+lch\,var\(--cds-bg-pink\)\,white_8\%\)\] { background-color: color-mix(in o=
+klch,var(--cds-bg-pink),white 8%); }
+
+.group\/diff:hover .group-hover\/diff\:\[background-color\:color-mix\(in_ok=
+lch\,var\(--cds-bg-success\)\,white_8\%\)\] { background-color: color-mix(i=
+n oklch,var(--cds-bg-success),white 8%); }
+
+.group:hover .group-hover\:after\:content-\[\'=C3=97\'\]::after { --tw-cont=
+ent: "=C3=97"; content: var(--tw-content); }
+
+.group\/row:focus-visible .group-focus-visible\/row\:grid-rows-\[1fr\] { gr=
+id-template-rows: 1fr; }
+
+.group\/tl:focus-visible .group-focus-visible\/tl\:decoration-current { tex=
+t-decoration-color: currentcolor; }
+
+.group\/btn:focus-visible .group-focus-visible\/btn\:\!shadow-\[inset_0_0_0=
+_1px_rgb\(255_255_255\/0\.3\)\] { --tw-shadow: inset 0 0 0 1px #ffffff4d !i=
+mportant; --tw-shadow-colored: inset 0 0 0 1px var(--tw-shadow-color) !impo=
+rtant; box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-sh=
+adow,0 0 #0000), var(--tw-shadow) !important; }
+
+.group\/btn:focus-visible .group-focus-visible\/btn\:shadow-\[inset_0_0_0_1=
+px_var\(--cds-page-bg\)\] { --tw-shadow: inset 0 0 0 1px var(--cds-page-bg)=
+; --tw-shadow-colored: inset 0 0 0 1px var(--tw-shadow-color); box-shadow: =
+var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), va=
+r(--tw-shadow); }
+
+.group\/cb:focus-visible .group-focus-visible\/cb\:shadow-focus, .group\/rd=
+:focus-visible .group-focus-visible\/rd\:shadow-focus { --tw-shadow: var(--=
+cds-focus-shadow); --tw-shadow-colored: var(--cds-focus-shadow); box-shadow=
+: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), =
+var(--tw-shadow); }
+
+.has-\[\+tr\.group\:hover\]\:border-b-transparent:has(+ tr.group:hover) { b=
+order-bottom-color: rgba(0, 0, 0, 0); }
+
+.has-\[\+tr\[data-selected\=3Dtrue\]\]\:border-b-transparent:has(+ tr[data-=
+selected=3D"true"]) { border-bottom-color: rgba(0, 0, 0, 0); }
+
+.has-\[\:focus-visible\]\:bg-surface-popover:has(:focus-visible) { backgrou=
+nd-color: var(--cds-surface-popover); }
+
+.has-\[\:focus-visible\]\:opacity-100:has(:focus-visible) { opacity: 1; }
+
+.has-\[\[data-popup-open\]\]\:opacity-100:has([data-popup-open]) { opacity:=
+ 1; }
+
+.has-\[\:focus-visible\]\:shadow-focus:has(:focus-visible) { --tw-shadow: v=
+ar(--cds-focus-shadow); --tw-shadow-colored: var(--cds-focus-shadow); box-s=
+hadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow,0 0 #00=
+00), var(--tw-shadow); }
+
+.aria-checked\:border-accent[aria-checked=3D"true"] { border-color: var(--c=
+ds-border-accent); }
+
+.aria-checked\:hover\:bg-surface-1:hover[aria-checked=3D"true"] { backgroun=
+d-color: var(--cds-surface-1); }
+
+.aria-disabled\:cursor-default[aria-disabled=3D"true"] { cursor: default; }
+
+.aria-expanded\:border-om-border-focus[aria-expanded=3D"true"] { border-col=
+or: var(--om-border-focus); }
+
+.aria-expanded\:shadow-\[0_0_0_2px_var\(--om-bg-selected\)\][aria-expanded=
+=3D"true"] { --tw-shadow: 0 0 0 2px var(--om-bg-selected); --tw-shadow-colo=
+red: 0 0 0 2px var(--tw-shadow-color); box-shadow: var(--tw-ring-offset-sha=
+dow,0 0 #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.aria-pressed\:text-accent[aria-pressed=3D"true"] { color: var(--cds-text-a=
+ccent); }
+
+.group\/btn[aria-expanded=3D"true"] .group-aria-expanded\/btn\:bg-fill-bran=
+d-hover { background-color: var(--cds-fill-brand-hover); }
+
+.group\/btn[aria-expanded=3D"true"] .group-aria-expanded\/btn\:bg-fill-dang=
+er-hover { background-color: var(--cds-fill-danger-hover); }
+
+.group\/btn[aria-expanded=3D"true"] .group-aria-expanded\/btn\:bg-fill-ghos=
+t-hover { background-color: var(--cds-fill-ghost-hover); }
+
+.group\/btn[aria-expanded=3D"true"] .group-aria-expanded\/btn\:bg-fill-prim=
+ary-hover { background-color: var(--cds-fill-primary-hover); }
+
+.group\/btn[aria-expanded=3D"true"] .group-aria-expanded\/btn\:bg-fill-seco=
+ndary-hover { background-color: var(--cds-fill-secondary-hover); }
+
+.group\/btn[aria-expanded=3D"true"] .group-aria-expanded\/btn\:bg-white\/30=
+ { background-color: rgba(255, 255, 255, 0.3); }
+
+.group\/btn[aria-pressed=3D"true"] .group-aria-pressed\/btn\:bg-accent, .gr=
+oup\/btn:hover[aria-pressed=3D"true"] .group-hover\/btn\:group-aria-pressed=
+\/btn\:bg-accent { background-color: var(--cds-bg-accent); }
+
+.data-\[disabled\]\:pointer-events-none[data-disabled] { pointer-events: no=
+ne; }
+
+.data-\[side\=3Dbottom\]\:top-\[-10px\][data-side=3D"bottom"] { top: -10px;=
+ }
+
+.data-\[side\=3Dleft\]\:right-\[-13px\][data-side=3D"left"] { right: -13px;=
+ }
+
+.data-\[side\=3Dright\]\:left-\[-13px\][data-side=3D"right"] { left: -13px;=
+ }
+
+.data-\[side\=3Dtop\]\:bottom-\[-10px\][data-side=3D"top"] { bottom: -10px;=
+ }
+
+.data-\[ending-style\]\:hidden[data-ending-style], .data-\[unchecked\]\:hid=
+den[data-unchecked] { display: none; }
+
+.data-\[ending-style\]\:h-0[data-ending-style], .data-\[starting-style\]\:h=
+-0[data-starting-style] { height: 0px; }
+
+.data-\[checked\]\:translate-x-\[calc\(var\(--cds-switch-h\,20px\)\*0\.8\)\=
+][data-checked] { --tw-translate-x: calc(var(--cds-switch-h,20px) * .8); tr=
+ansform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var=
+(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(-=
+-tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.data-\[side\=3Dbottom\]\:rotate-180[data-side=3D"bottom"] { --tw-rotate: 1=
+80deg; transform: translate(var(--tw-translate-x), var(--tw-translate-y)) r=
+otate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) sca=
+leX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.data-\[side\=3Dleft\]\:-rotate-90[data-side=3D"left"] { --tw-rotate: -90de=
+g; transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotat=
+e(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(=
+var(--tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.data-\[side\=3Dright\]\:rotate-90[data-side=3D"right"] { --tw-rotate: 90de=
+g; transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotat=
+e(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(=
+var(--tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.data-\[ending-style\]\:scale-\[0\.97\][data-ending-style] { --tw-scale-x: =
+.97; --tw-scale-y: .97; transform: translate(var(--tw-translate-x), var(--t=
+w-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(=
+--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.data-\[ending-style\]\:scale-\[0\.98\][data-ending-style] { --tw-scale-x: =
+.98; --tw-scale-y: .98; transform: translate(var(--tw-translate-x), var(--t=
+w-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(=
+--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.data-\[starting-style\]\:scale-\[0\.97\][data-starting-style] { --tw-scale=
+-x: .97; --tw-scale-y: .97; transform: translate(var(--tw-translate-x), var=
+(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(=
+var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.data-\[starting-style\]\:scale-\[0\.98\][data-starting-style] { --tw-scale=
+-x: .98; --tw-scale-y: .98; transform: translate(var(--tw-translate-x), var=
+(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(=
+var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.data-\[disabled\]\:cursor-default[data-disabled] { cursor: default; }
+
+.data-\[active\]\:border-\[var\(--cds-text-primary\)\][data-active] { borde=
+r-color: var(--cds-text-primary); }
+
+.data-\[selected\=3Dtrue\]\:border-transparent[data-selected=3D"true"] { bo=
+rder-color: rgba(0, 0, 0, 0); }
+
+.data-\[checked\]\:bg-fill-accent[data-checked] { background-color: var(--c=
+ds-fill-accent); }
+
+.data-\[highlighted\]\:bg-fill-danger[data-highlighted] { background-color:=
+ var(--cds-fill-danger); }
+
+.data-\[highlighted\]\:bg-fill-ghost-hover[data-highlighted] { background-c=
+olor: var(--cds-fill-ghost-hover); }
+
+.data-\[highlighted\]\:bg-neutral-hover[data-highlighted] { background-colo=
+r: var(--cds-bg-neutral-hover); }
+
+.data-\[popup-open\]\:bg-fill-ghost-hover[data-popup-open] { background-col=
+or: var(--cds-fill-ghost-hover); }
+
+.data-\[selected\=3Dtrue\]\:bg-none[data-selected=3D"true"] { background-im=
+age: none; }
+
+.data-\[active\]\:font-medium[data-active] { font-weight: 500; }
+
+.data-\[active\]\:text-primary[data-active], .data-\[checked\]\:text-primar=
+y[data-checked] { color: var(--cds-text-primary); }
+
+.data-\[highlighted\]\:text-on-danger[data-highlighted] { color: var(--cds-=
+on-danger); }
+
+.data-\[highlighted\]\:text-primary[data-highlighted] { color: var(--cds-te=
+xt-primary); }
+
+.data-\[checked\]\:opacity-100[data-checked] { opacity: 1; }
+
+.data-\[disabled\]\:opacity-50[data-disabled] { opacity: 0.5; }
+
+.data-\[ending-style\]\:opacity-0[data-ending-style] { opacity: 0; }
+
+.data-\[indeterminate\]\:opacity-100[data-indeterminate] { opacity: 1; }
+
+.data-\[limited\]\:opacity-0[data-limited], .data-\[starting-style\]\:opaci=
+ty-0[data-starting-style] { opacity: 0; }
+
+.data-\[invalid\]\:shadow-field-invalid[data-invalid] { --tw-shadow: inset =
+0 0 0 1px var(--cds-fill-danger); --tw-shadow-colored: inset 0 0 0 1px var(=
+--tw-shadow-color); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var=
+(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.data-\[instant\]\:duration-0[data-instant] { transition-duration: 0s; }
+
+.data-\[ending-style\]\:\[--ts\:0\.85\][data-ending-style] { --ts: .85; }
+
+.data-\[starting-style\]\:\[--ty\:-100\%\][data-starting-style] { --ty: -10=
+0%; }
+
+.data-\[checked\]\:data-\[disabled\]\:hover\:bg-fill-accent:hover[data-disa=
+bled][data-checked] { background-color: var(--cds-fill-accent); }
+
+.data-\[checked\]\:hover\:bg-fill-accent-hover:hover[data-checked] { backgr=
+ound-color: var(--cds-fill-accent-hover); }
+
+.data-\[disabled\]\:hover\:bg-\[var\(--cds-switch-track\)\]:hover[data-disa=
+bled] { background-color: var(--cds-switch-track); }
+
+.data-\[disabled\]\:hover\:text-current:hover[data-disabled] { color: curre=
+ntcolor; }
+
+.group\/acc[data-panel-open] .group-data-\[panel-open\]\/acc\:rotate-90, .g=
+roup\/clp[data-panel-open] .group-data-\[panel-open\]\/clp\:rotate-90 { --t=
+w-rotate: 90deg; transform: translate(var(--tw-translate-x), var(--tw-trans=
+late-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-sk=
+ew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)); }
+
+.group\/cb[data-checked] .group-data-\[checked\]\/cb\:border-0, .group\/rd[=
+data-checked] .group-data-\[checked\]\/rd\:border-0, .group\/cb[data-indete=
+rminate] .group-data-\[indeterminate\]\/cb\:border-0 { border-width: 0px; }
+
+.group\/cb[data-checked] .group-data-\[checked\]\/cb\:bg-fill-accent, .grou=
+p\/rd[data-checked] .group-data-\[checked\]\/rd\:bg-fill-accent, .group\/cb=
+[data-indeterminate] .group-data-\[indeterminate\]\/cb\:bg-fill-accent { ba=
+ckground-color: var(--cds-fill-accent); }
+
+.group\/menu-danger[data-highlighted] .group-data-\[highlighted\]\/menu-dan=
+ger\:text-on-danger { color: var(--cds-on-danger); }
+
+.group\/cb[data-disabled]:hover .group-data-\[disabled\]\/cb\:group-hover\/=
+cb\:border-strong, .group\/rd[data-disabled]:hover .group-data-\[disabled\]=
+\/rd\:group-hover\/rd\:border-strong { border-color: var(--cds-border-stron=
+g); }
+
+.group\/cb[data-checked]:hover .group-data-\[checked\]\/cb\:group-hover\/cb=
+\:bg-fill-accent-hover, .group\/rd[data-checked]:hover .group-data-\[checke=
+d\]\/rd\:group-hover\/rd\:bg-fill-accent-hover, .group\/cb[data-indetermina=
+te]:hover .group-data-\[indeterminate\]\/cb\:group-hover\/cb\:bg-fill-accen=
+t-hover { background-color: var(--cds-fill-accent-hover); }
+
+:where(.group):has(:focus-visible) .group-has-\[\:focus-visible\]\:opacity-=
+100 { opacity: 1; }
+
+.comfortable\:mx-2\.5:where([data-density=3D"comfortable"], [data-density=
+=3D"comfortable"] *) { margin-left: 0.625rem; margin-right: 0.625rem; }
+
+.comfortable\:px-2\.5:where([data-density=3D"comfortable"], [data-density=
+=3D"comfortable"] *) { padding-left: 0.625rem; padding-right: 0.625rem; }
+
+.compact\:mx-2:where([data-density=3D"compact"], [data-density=3D"compact"]=
+ *) { margin-left: 0.5rem; margin-right: 0.5rem; }
+
+.compact\:px-2:where([data-density=3D"compact"], [data-density=3D"compact"]=
+ *) { padding-left: 0.5rem; padding-right: 0.5rem; }
+
+@media (width <=3D 560px) {
+  .om-max-560\:hidden { display: none; }
+  .om-max-560\:w-auto { width: auto; }
+  .om-max-560\:min-w-0 { min-width: 0px; }
+  .om-max-560\:flex-col { flex-direction: column; }
+  .om-max-560\:border-l-0 { border-left-width: 0px; }
+  .om-max-560\:border-t { border-top-width: 1px; }
+  .om-max-560\:px-3\.5 { padding-left: 0.875rem; padding-right: 0.875rem; }
+  .om-max-560\:py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+}
+
+@media (width <=3D 660px) {
+  .om-max-660\:hidden { display: none; }
+  .om-max-660\:border-r-0 { border-right-width: 0px; }
+}
+
+@media (width <=3D 700px) {
+  .om-max-700\:mx-\[-20px\] { margin-left: -20px; margin-right: -20px; }
+  .om-max-700\:my-0 { margin-top: 0px; margin-bottom: 0px; }
+  .om-max-700\:mb-2\.5 { margin-bottom: 0.625rem; }
+  .om-max-700\:mb-9 { margin-bottom: 2.25rem; }
+  .om-max-700\:mt-1 { margin-top: 0.25rem; }
+  .om-max-700\:box-border { box-sizing: border-box; }
+  .om-max-700\:hidden { display: none; }
+  .om-max-700\:transform-none { transform: none; }
+  .om-max-700\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0px, 1=
+fr)); }
+  .om-max-700\:justify-start { justify-content: flex-start; }
+  .om-max-700\:gap-2\.5 { gap: 0.625rem; }
+  .om-max-700\:gap-y-3\.5 { row-gap: 0.875rem; }
+  .om-max-700\:self-stretch { align-self: stretch; }
+  .om-max-700\:overflow-x-auto { overflow-x: auto; }
+  .om-max-700\:p-0 { padding: 0px; }
+  .om-max-700\:p-\[12px_16px\] { padding: 12px 16px; }
+  .om-max-700\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+  .om-max-700\:pb-3\.5 { padding-bottom: 0.875rem; }
+  .om-max-700\:pt-1 { padding-top: 0.25rem; }
+  .om-max-700\:text-base { font-size: 1rem; line-height: 1.5rem; }
+  .om-max-700\:\[scroll-padding-left\:20px\] { scroll-padding-left: 20px; }
+  .om-max-700\:\[scroll-snap-type\:x_mandatory\] { scroll-snap-type: x mand=
+atory; }
+  .om-max-700\:\[scrollbar-width\:none\] { scrollbar-width: none; }
+  .om-max-700\:hover\:transform-none:hover { transform: none; }
+}
+
+@media (width <=3D 720px) {
+  .om-max-720\:flex-1 { flex: 1 1 0%; }
+  .om-max-720\:flex-\[1_0_100\%\] { flex: 1 0 100%; }
+  .om-max-720\:grid-cols-1 { grid-template-columns: repeat(1, minmax(0px, 1=
+fr)); }
+  .om-max-720\:gap-3\.5 { gap: 0.875rem; }
+  .om-max-720\:px-5 { padding-left: 1.25rem; padding-right: 1.25rem; }
+}
+
+@media (pointer: coarse) {
+  .om-coarse\:pointer-events-auto { pointer-events: auto; }
+  .om-coarse\:opacity-100 { opacity: 1; }
+}
+
+@media (hover: none) {
+  .om-no-hover\:pointer-events-auto { pointer-events: auto; }
+  .om-no-hover\:opacity-100 { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .motion-reduce\:animate-none { animation: auto ease 0s 1 normal none runn=
+ing none; }
+  .motion-reduce\:bg-none { background-image: none; }
+  .motion-reduce\:text-primary { color: var(--cds-text-primary); }
+  .motion-reduce\:text-secondary { color: var(--cds-text-secondary); }
+  .motion-reduce\:transition-none { transition-property: none; }
+  .motion-reduce\:after\:hidden::after { content: var(--tw-content); displa=
+y: none; }
+}
+
+@media (width >=3D 640px) {
+  .sm\:flex-row { flex-direction: row; }
+  .sm\:items-stretch { align-items: stretch; }
+  .sm\:justify-start { justify-content: flex-start; }
+  .sm\:justify-end { justify-content: flex-end; }
+  .sm\:justify-center { justify-content: center; }
+  .sm\:justify-between { justify-content: space-between; }
+}
+
+@media (width >=3D 768px) {
+  .md\:mt-10 { margin-top: 2.5rem; }
+  .md\:mt-20 { margin-top: 5rem; }
+  .md\:block { display: block; }
+  .md\:flex { display: flex; }
+  .md\:hidden { display: none; }
+  .md\:w-1\/2 { width: 50%; }
+  .md\:basis-2\/5 { flex-basis: 40%; }
+  .md\:basis-3\/5 { flex-basis: 60%; }
+  .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0px, 1fr)); }
+  .md\:grid-cols-\[minmax\(0\,3fr\)_minmax\(0\,2fr\)\] { grid-template-colu=
+mns: minmax(0px, 3fr) minmax(0px, 2fr); }
+  .md\:rounded-e-none { border-start-end-radius: 0px; border-end-end-radius=
+: 0px; }
+  .md\:pe-xl { padding-inline-end: var(--cds-pad-xl); }
+}
+
+.dark\:\[background-image\:linear-gradient\(120deg\,var\(--cds-text-muted\)=
+_25\%\,color-mix\(in_srgb\,var\(--cds-text-muted\)_30\%\,white\)_50\%\,var\=
+(--cds-text-muted\)_75\%\)\]:where([data-mode=3D"dark"], [data-mode=3D"dark=
+"] *) { background-image: linear-gradient(120deg,var(--cds-text-muted) 25%,=
+color-mix(in srgb,var(--cds-text-muted) 30%,white) 50%,var(--cds-text-muted=
+) 75%); }
+
+.dark\:\[background-image\:linear-gradient\(120deg\,var\(--cds-text-seconda=
+ry\)_25\%\,var\(--cds-text-primary\)_50\%\,var\(--cds-text-secondary\)_75\%=
+\)\]:where([data-mode=3D"dark"], [data-mode=3D"dark"] *) { background-image=
+: linear-gradient(120deg,var(--cds-text-secondary) 25%,var(--cds-text-prima=
+ry) 50%,var(--cds-text-secondary) 75%); }
+
+@media (prefers-reduced-motion: reduce) {
+  .dark\:motion-reduce\:bg-none:where([data-mode=3D"dark"], [data-mode=3D"d=
+ark"] *) { background-image: none; }
+  .dark\:motion-reduce\:text-muted:where([data-mode=3D"dark"], [data-mode=
+=3D"dark"] *) { color: var(--cds-text-muted); }
+  .dark\:motion-reduce\:text-secondary:where([data-mode=3D"dark"], [data-mo=
+de=3D"dark"] *) { color: var(--cds-text-secondary); }
+}
+
+@media (forced-colors: active) {
+  .forced-colors\:animate-none { animation: auto ease 0s 1 normal none runn=
+ing none; }
+  .forced-colors\:bg-none { background-image: none; }
+  .forced-colors\:text-\[color\:CanvasText\] { color: canvastext; }
+}
+
+.\[\&\+\.om-flag-row\]\:mt-2\.5 + .om-flag-row { margin-top: 0.625rem; }
+
+.\[\&\+\.om-kbd\]\:ml-0\.5 + .om-kbd { margin-left: 0.125rem; }
+
+.\[\&\+\.om-panel-section\]\:border-t + .om-panel-section { border-top-widt=
+h: 1px; }
+
+.\[\&\+\.om-panel-section\]\:border-om-border-subtle + .om-panel-section { =
+border-color: var(--om-border-subtle); }
+
+.\[\&\+\.om-review-card\]\:mt-\[26px\] + .om-review-card { margin-top: 26px=
+; }
+
+.\[\&\+\.om-settings-row\]\:mt-3\.5 + .om-settings-row { margin-top: 0.875r=
+em; }
+
+.\[\&\+\.om-sysmsg-action\]\:ml-2\.5 + .om-sysmsg-action { margin-left: 0.6=
+25rem; }
+
+.\[\&\.drag\]\:bg-om-presenter-divider-hover.drag { background-color: var(-=
+-om-presenter-divider-hover); }
+
+.\[\&\.hidden\]\:block.hidden { display: block; }
+
+.\[\&\.hidden\]\:opacity-0.hidden { opacity: 0; }
+
+.\[\&\.ph-fading\]\:placeholder\:opacity-0.ph-fading::placeholder { opacity=
+: 0; }
+
+.\[\&\:\:-webkit-inner-spin-button\]\:m-0::-webkit-inner-spin-button { marg=
+in: 0px; }
+
+.\[\&\:\:-webkit-inner-spin-button\]\:appearance-none::-webkit-inner-spin-b=
+utton { appearance: none; }
+
+.\[\&\:\:-webkit-outer-spin-button\]\:m-0::-webkit-outer-spin-button { marg=
+in: 0px; }
+
+.\[\&\:\:-webkit-outer-spin-button\]\:appearance-none::-webkit-outer-spin-b=
+utton { appearance: none; }
+
+.\[\&\:\:-webkit-scrollbar-thumb\]\:rounded-\[3px\]::-webkit-scrollbar-thum=
+b { border-radius: 3px; }
+
+.\[\&\:\:-webkit-scrollbar-thumb\]\:bg-om-border-default::-webkit-scrollbar=
+-thumb { background-color: var(--om-border-default); }
+
+.\[\&\:\:-webkit-scrollbar\]\:hidden::-webkit-scrollbar { display: none; }
+
+.\[\&\:\:-webkit-scrollbar\]\:w-1\.5::-webkit-scrollbar { width: 0.375rem; =
+}
+
+.\[\&\:\:-webkit-search-cancel-button\]\:hidden::-webkit-search-cancel-butt=
+on { display: none; }
+
+.\[\&\:\:-webkit-search-decoration\]\:hidden::-webkit-search-decoration { d=
+isplay: none; }
+
+.\[\&\:\:-webkit-search-results-button\]\:hidden::-webkit-search-results-bu=
+tton { display: none; }
+
+.\[\&\:\:-webkit-search-results-decoration\]\:hidden::-webkit-search-result=
+s-decoration { display: none; }
+
+.\[\&\:disabled\:not\(\[aria-busy\]\)\]\:opacity-50:disabled:not([aria-busy=
+]) { opacity: 0.5; }
+
+.\[\&\:focus-visible_\.om-tile-thumb\]\:border-om-border-strong:focus-visib=
+le .om-tile-thumb { border-color: var(--om-border-strong); }
+
+.\[\&\:has\(\+\.reply-action\)\]\:mb-0:has(+ .reply-action) { margin-bottom=
+: 0px; }
+
+.\[\&\:has\(\+\:hover\)\>span\]\:opacity-0:has(+ :hover) > span { opacity: =
+0; }
+
+.\[\&\:has\(\+\[aria-expanded\=3Dtrue\]\)\>span\]\:opacity-0:has(+ [aria-ex=
+panded=3D"true"]) > span { opacity: 0; }
+
+.\[\&\:has\(\+\[aria-pressed\=3Dtrue\]\)\>span\]\:opacity-0:has(+ [aria-pre=
+ssed=3D"true"]) > span { opacity: 0; }
+
+.\[\&\:hover\:not\(\:disabled\)\:not\(\[aria-expanded\=3Dtrue\]\)\]\:bg-om-=
+bg-hover:hover:not(:disabled):not([aria-expanded=3D"true"]) { background-co=
+lor: var(--om-bg-hover); }
+
+.\[\&\:hover\:not\(\:disabled\)\]\:bg-\[var\(--cds-fill-ghost-hover\)\]:hov=
+er:not(:disabled) { background-color: var(--cds-fill-ghost-hover); }
+
+.\[\&\:hover\:not\(\:disabled\)\]\:bg-om-accent-primary:hover:not(:disabled=
+) { background-color: var(--om-accent-primary); }
+
+.\[\&\:hover\:not\(\:disabled\)\]\:bg-om-accent-primary-hover:hover:not(:di=
+sabled) { background-color: var(--om-accent-primary-hover); }
+
+.\[\&\:hover\:not\(\:disabled\)\]\:bg-om-bg-muted:hover:not(:disabled) { ba=
+ckground-color: var(--om-bg-muted); }
+
+.\[\&\:hover\:not\(\:disabled\)\]\:text-\[var\(--cds-text-primary\)\]:hover=
+:not(:disabled) { color: var(--cds-text-primary); }
+
+.\[\&\:hover\:not\(\:disabled\)_\.om-tile-thumb\]\:border-om-border-strong:=
+hover:not(:disabled) .om-tile-thumb { border-color: var(--om-border-strong)=
+; }
+
+.enabled\:\[\&\:hover\:not\(\:focus\)\:not\(\[data-invalid\]\)\]\:shadow-fi=
+eld-hover:hover:not(:focus):not([data-invalid]):enabled, .\[\&\:hover\:not\=
+(\:focus-within\)\:not\(\[data-invalid\]\)\]\:shadow-field-hover:hover:not(=
+:focus-within):not([data-invalid]) { --tw-shadow: inset 0 0 0 1px var(--cds=
+-border-strong); --tw-shadow-colored: inset 0 0 0 1px var(--tw-shadow-color=
+); box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--tw-ring-shadow=
+,0 0 #0000), var(--tw-shadow); }
+
+.\[\&\:hover\:not\(\[aria-expanded\=3Dtrue\]\)\]\:bg-om-bg-hover:hover:not(=
+[aria-expanded=3D"true"]) { background-color: var(--om-bg-hover); }
+
+.\[\&\:hover_iframe\]\:pointer-events-auto:hover iframe { pointer-events: a=
+uto; }
+
+.\[\&\:not\(\:empty\)\]\:w-full:not(:empty) { width: 100%; }
+
+.\[\&\:not\(\:empty\)\~\*\]\:hidden:not(:empty) ~ * { display: none; }
+
+.\[\&\:not\(\:first-child\)\]\:ml-2:not(:first-child) { margin-left: 0.5rem=
+; }
+
+.\[\&\:not\(\:first-child\)\]\:mt-1:not(:first-child) { margin-top: 0.25rem=
+; }
+
+.\[\&\:not\(\:first-child\)\]\:border-t:not(:first-child) { border-top-widt=
+h: 1px; }
+
+.\[\&\:not\(\:first-child\)\]\:border-om-border-subtle:not(:first-child) { =
+border-color: var(--om-border-subtle); }
+
+.\[\&\:not\(\:first-child\)\]\:pt-3:not(:first-child) { padding-top: 0.75re=
+m; }
+
+.\[\&\:not\(\[data-active\]\)\]\:hover\:bg-fill-ghost-hover:hover:not([data=
+-active]), .\[\&\:not\(\[data-checked\]\)\]\:hover\:bg-fill-ghost-hover:hov=
+er:not([data-checked]) { background-color: var(--cds-fill-ghost-hover); }
+
+.\[\&\>\*\]\:pointer-events-auto > * { pointer-events: auto; }
+
+.\[\&\>\*\]\:flex-1 > * { flex: 1 1 0%; }
+
+.\[\&\>\*\]\:\[grid-area\:1\/1\] > * { grid-area: 1 / 1; }
+
+.\[\&\>\.flex\]\:justify-end > .flex { justify-content: flex-end; }
+
+.\[\&\>\.om-actions\]\:self-center > .om-actions { align-self: center; }
+
+.\[\&\>\.om-collapse\]\:basis-full > .om-collapse { flex-basis: 100%; }
+
+.\[\&\>\.om-lockup-name\]\:py-px > .om-lockup-name { padding-top: 1px; padd=
+ing-bottom: 1px; }
+
+.\[\&\>\.om-lockup-name\]\:leading-\[1\.1\] > .om-lockup-name { line-height=
+: 1.1; }
+
+.\[\&\>\.om-menu-item-btn\]\:pb-0 > .om-menu-item-btn { padding-bottom: 0px=
+; }
+
+.\[\&\>\:first-child\]\:inline-flex > :first-child { display: inline-flex; =
+}
+
+.\[\&\>\:first-child\]\:items-center > :first-child { align-items: center; =
+}
+
+.\[\&\>\:first-child\]\:gap-1 > :first-child { gap: 0.25rem; }
+
+.\[\&\>\:first-child\]\:whitespace-nowrap > :first-child { white-space: now=
+rap; }
+
+.\[\&\>\[data-selected\]\+\[role\=3Doption\]\:not\(\[data-selected\]\)\]\:r=
+elative > [data-selected] + [role=3D"option"]:not([data-selected]) { positi=
+on: relative; }
+
+.\[\&\>\[data-selected\]\+\[role\=3Doption\]\:not\(\[data-selected\]\)\]\:m=
+t-2 > [data-selected] + [role=3D"option"]:not([data-selected]) { margin-top=
+: 0.5rem; }
+
+.\[\&\>\[data-selected\]\+\[role\=3Doption\]\:not\(\[data-selected\]\)\]\:b=
+efore\:absolute > [data-selected] + [role=3D"option"]:not([data-selected]):=
+:before { content: var(--tw-content); position: absolute; }
+
+.\[\&\>\[data-selected\]\+\[role\=3Doption\]\:not\(\[data-selected\]\)\]\:b=
+efore\:inset-x-0 > [data-selected] + [role=3D"option"]:not([data-selected])=
+::before { content: var(--tw-content); left: 0px; right: 0px; }
+
+.\[\&\>\[data-selected\]\+\[role\=3Doption\]\:not\(\[data-selected\]\)\]\:b=
+efore\:-top-1 > [data-selected] + [role=3D"option"]:not([data-selected])::b=
+efore { content: var(--tw-content); top: -0.25rem; }
+
+.\[\&\>\[data-selected\]\+\[role\=3Doption\]\:not\(\[data-selected\]\)\]\:b=
+efore\:border-t > [data-selected] + [role=3D"option"]:not([data-selected]):=
+:before { content: var(--tw-content); border-top-width: 1px; }
+
+.\[\&\>a\]\:ml-0 > a { margin-left: 0px; }
+
+.\[\&\>b\]\:whitespace-nowrap > b { white-space: nowrap; }
+
+.\[\&\>b\]\:text-\[11px\] > b { font-size: 11px; }
+
+.\[\&\>b\]\:text-base > b { font-size: 1rem; line-height: 1.5rem; }
+
+.\[\&\>b\]\:font-medium > b { font-weight: 500; }
+
+.\[\&\>b\]\:leading-\[1\.15\] > b { line-height: 1.15; }
+
+.\[\&\>b\]\:text-om-text-primary > b { color: var(--om-text-primary); }
+
+.\[\&\>button\]\:h-full > button { height: 100%; }
+
+.\[\&\>button\]\:justify-end > button { justify-content: flex-end; }
+
+.\[\&\>button\]\:p-0 > button { padding: 0px; }
+
+.first\:\[\&\>button\]\:\!pl-\[var\(--dt-flush-bleed\)\] > button:first-chi=
+ld { padding-left: var(--dt-flush-bleed) !important; }
+
+.last\:\[\&\>button\]\:\!pr-\[var\(--dt-flush-bleed\)\] > button:last-child=
+ { padding-right: var(--dt-flush-bleed) !important; }
+
+.\[\&\>div\:first-child\]\:mt-0 > div:first-child { margin-top: 0px; }
+
+.\[\&\>div\:first-child\]\:border-t-0 > div:first-child { border-top-width:=
+ 0px; }
+
+.\[\&\>div\:first-child\]\:pt-0 > div:first-child { padding-top: 0px; }
+
+.\[\&\>div\>button\]\:min-w-0 > div > button { min-width: 0px; }
+
+.\[\&\>div\>button\]\:max-w-none > div > button { max-width: none; }
+
+.\[\&\>div\>button\]\:shrink > div > button { flex-shrink: 1; }
+
+.\[\&\>div\>button\]\:border-transparent > div > button { border-color: rgb=
+a(0, 0, 0, 0); }
+
+.\[\&\>div\>button\]\:shadow-none > div > button { --tw-shadow: 0 0 #0000; =
+--tw-shadow-colored: 0 0 #0000; box-shadow: var(--tw-ring-offset-shadow,0 0=
+ #0000), var(--tw-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.\[\&\>div\]\:visible > div { visibility: visible; }
+
+.\[\&\>div\]\:invisible > div { visibility: hidden; }
+
+.\[\&\>div\]\:mx-0 > div { margin-left: 0px; margin-right: 0px; }
+
+.\[\&\>div\]\:h-full > div { height: 100%; }
+
+.\[\&\>div\]\:min-w-0 > div { min-width: 0px; }
+
+.\[\&\>div\]\:overflow-hidden > div { overflow: hidden; }
+
+.\[\&\>div\]\:rounded-\[2px\] > div { border-radius: 2px; }
+
+.\[\&\>div\]\:bg-om-accent-primary > div { background-color: var(--om-accen=
+t-primary); }
+
+.\[\&\>div\]\:opacity-0 > div { opacity: 0; }
+
+.\[\&\>div\]\:opacity-100 > div { opacity: 1; }
+
+.\[\&\>div\]\:\[transition\:opacity_var\(--ms\)_ease-out_var\(--fade-delay\=
+)\,visibility_0s_linear_var\(--vis-delay\)\] > div { transition: opacity va=
+r(--ms) ease-out var(--fade-delay),visibility 0s linear var(--vis-delay); }
+
+.\[\&\>div\]\:\[transition\:width_0\.3s_ease\] > div { transition: width 0.=
+3s; }
+
+.\[\&\>i\]\:text-xs > i { font-size: 0.75rem; line-height: 1rem; }
+
+.\[\&\>i\]\:text-inherit > i { color: inherit; }
+
+.\[\&\>input\]\:m-0 > input { margin: 0px; }
+
+.\[\&\>input\]\:min-w-0 > input { min-width: 0px; }
+
+.\[\&\>input\]\:flex-1 > input { flex: 1 1 0%; }
+
+.\[\&\>input\]\:border-0 > input { border-width: 0px; }
+
+.\[\&\>input\]\:bg-transparent > input { background-color: rgba(0, 0, 0, 0)=
+; }
+
+.\[\&\>input\]\:text-\[12\.5px\] > input { font-size: 12.5px; }
+
+.\[\&\>input\]\:text-\[var\(--cds-text-primary\)\] > input { color: var(--c=
+ds-text-primary); }
+
+.\[\&\>input\]\:accent-om-text-primary > input { accent-color: var(--om-tex=
+t-primary); }
+
+.\[\&\>input\]\:outline-none > input { outline-offset: 2px; outline: rgba(0=
+, 0, 0, 0) solid 2px; }
+
+.\[\&\>li\]\:mb-1 > li { margin-bottom: 0.25rem; }
+
+.\[\&\>span\:first-child\]\:min-w-\[46px\] > span:first-child { min-width: =
+46px; }
+
+.\[\&\>span\:last-child\]\:order-2 > span:last-child { order: 2; }
+
+.\[\&\>span\:last-child\]\:min-w-\[32px\] > span:last-child { min-width: 32=
+px; }
+
+.\[\&\>span\:last-child\]\:text-right > span:last-child { text-align: right=
+; }
+
+.\[\&\>span\:last-child\]\:text-om-text-primary > span:last-child { color: =
+var(--om-text-primary); }
+
+.\[\&\>span\]\:min-w-0 > span { min-width: 0px; }
+
+.\[\&\>span\]\:flex-1 > span { flex: 1 1 0%; }
+
+.\[\&\>span\]\:text-\[9\.5px\] > span { font-size: 9.5px; }
+
+.\[\&\>span\]\:text-om-text-tertiary > span { color: var(--om-text-tertiary=
+); }
+
+.\[\&\>svg\]\:block > svg { display: block; }
+
+.\[\&\>svg\]\:max-h-full > svg { max-height: 100%; }
+
+.\[\&\>svg\]\:w-full > svg { width: 100%; }
+
+.\[\&\>svg\]\:max-w-full > svg { max-width: 100%; }
+
+.\[\&\>svg\]\:fill-current > svg { fill: currentcolor; }
+
+.\[\&\>tr\:first-child\]\:border-t-0 > tr:first-child { border-top-width: 0=
+px; }
+
+.\[\&\>tr\:last-child\]\:border-b-0 > tr:last-child { border-bottom-width: =
+0px; }
+
+.\[\&\[list\]\:\:-webkit-calendar-picker-indicator\]\:\!hidden[list]::-webk=
+it-calendar-picker-indicator { display: none !important; }
+
+.\[\&_\*\]\:pointer-events-none * { pointer-events: none; }
+
+@media (hover: none) {
+  .om-no-hover\:\[\&_\.hover-only\]\:hidden .hover-only { display: none; }
+}
+
+.\[\&_\.om-json-tree\]\:max-h-none .om-json-tree { max-height: none; }
+
+.\[\&_\.touch-only\]\:hidden .touch-only { display: none; }
+
+@media (hover: none) {
+  .om-no-hover\:\[\&_\.touch-only\]\:inline .touch-only { display: inline; =
+}
+}
+
+.\[\&_\:is\(button\,a\,input\)\]\:\[-webkit-app-region\:no-drag\] :is(butto=
+n, a, input) { app-region: no-drag; }
+
+@media (width <=3D 720px) {
+  .om-max-720\:\[\&_\[data-hide-sm\]\]\:hidden [data-hide-sm] { display: no=
+ne; }
+}
+
+.\[\&_\[role\=3Dradio\]\]\:font-medium [role=3D"radio"] { font-weight: 500;=
+ }
+
+.\[\&_a\:hover\]\:opacity-80 a:hover { opacity: 0.8; }
+
+.\[\&_a\]\:cursor-pointer a { cursor: pointer; }
+
+.\[\&_a\]\:text-inherit a { color: inherit; }
+
+.\[\&_a\]\:text-om-accent-blue a { color: var(--om-accent-blue); }
+
+.\[\&_a\]\:text-om-text-link a { color: var(--om-text-link); }
+
+.\[\&_a\]\:underline a { text-decoration-line: underline; }
+
+.\[\&_a\]\:underline-offset-\[3px\] a { text-underline-offset: 3px; }
+
+.\[\&_b\+br\]\:hidden b + br { display: none; }
+
+.\[\&_b\]\:mb-0\.5 b { margin-bottom: 0.125rem; }
+
+.\[\&_b\]\:block b { display: block; }
+
+.\[\&_b\]\:text-xs b { font-size: 0.75rem; line-height: 1rem; }
+
+.\[\&_b\]\:font-semibold b { font-weight: 600; }
+
+.\[\&_b\]\:tracking-\[0\.01em\] b { letter-spacing: 0.01em; }
+
+.\[\&_b\]\:text-primary b { color: var(--cds-text-primary); }
+
+.\[\&_br\+br\]\:hidden br + br { display: none; }
+
+.\[\&_button\:focus-visible\]\:outline button:focus-visible { outline-style=
+: solid; }
+
+.\[\&_button\:focus-visible\]\:outline-2 button:focus-visible { outline-wid=
+th: 2px; }
+
+.\[\&_button\:focus-visible\]\:-outline-offset-2 button:focus-visible { out=
+line-offset: -2px; }
+
+.\[\&_button\:focus-visible\]\:outline button:focus-visible { outline-color=
+: var(--cds-border); }
+
+.\[\&_button\:focus-visible\]\:outline-om-accent-primary button:focus-visib=
+le { outline-color: var(--om-accent-primary); }
+
+.\[\&_button\]\:text-\[rgba\(255\,255\,255\,0\.7\)\] button { color: rgba(2=
+55, 255, 255, 0.7); }
+
+.\[\&_button\]\:text-om-text-tertiary button { color: var(--om-text-tertiar=
+y); }
+
+.\[\&_button_i\]\:\!-m-px button i { margin: -1px !important; }
+
+.\[\&_button_i\]\:\!text-sm button i { font-size: 0.875rem !important; line=
+-height: 1.25rem !important; }
+
+.\[\&_i\]\:animate-om-spin i { animation: 1s linear 0s infinite normal none=
+ running om-spin; }
+
+.\[\&_i\]\:\[animation-duration\:0\.8s\] i { animation-duration: 0.8s; }
+
+.\[\&_iframe\]\:pointer-events-none iframe { pointer-events: none; }
+
+.\[\&_img\]\:h-\[52px\] img { height: 52px; }
+
+.\[\&_img\]\:h-full img { height: 100%; }
+
+.\[\&_img\]\:w-\[52px\] img { width: 52px; }
+
+.\[\&_img\]\:w-full img { width: 100%; }
+
+.\[\&_img\]\:object-contain img { object-fit: contain; }
+
+.\[\&_img\]\:object-cover img { object-fit: cover; }
+
+.\[\&_input\]\:hidden input { display: none; }
+
+.\[\&_input\]\:h-\[26px\] input { height: 26px; }
+
+.\[\&_input\]\:select-text input { user-select: text; }
+
+.\[\&_input\]\:border-none input { border-style: none; }
+
+.\[\&_input\]\:bg-transparent input { background-color: rgba(0, 0, 0, 0); }
+
+.\[\&_input\]\:pb-\[3px\] input { padding-bottom: 3px; }
+
+.\[\&_input\]\:pt-\[3px\] input { padding-top: 3px; }
+
+.\[\&_input\]\:text-\[11\.5px\] input { font-size: 11.5px; }
+
+.\[\&_input\]\:shadow-none input { --tw-shadow: 0 0 #0000; --tw-shadow-colo=
+red: 0 0 #0000; box-shadow: var(--tw-ring-offset-shadow,0 0 #0000), var(--t=
+w-ring-shadow,0 0 #0000), var(--tw-shadow); }
+
+.\[\&_option\]\:\[direction\:ltr\] option { direction: ltr; }
+
+.\[\&_p\]\:m-0 p { margin: 0px; }
+
+.\[\&_pre\]\:max-h-none pre { max-height: none; }
+
+.\[\&_span\]\:text-right span { text-align: right; }
+
+.\[\&_strong\+br\]\:hidden strong + br { display: none; }
+
+.\[\&_strong\]\:mb-0\.5 strong { margin-bottom: 0.125rem; }
+
+.\[\&_strong\]\:block strong { display: block; }
+
+.\[\&_strong\]\:text-primary strong { color: var(--cds-text-primary); }
+
+.\[\&_svg\]\:block svg { display: block; }
+
+.\[\&_svg\]\:rotate-0 svg { --tw-rotate: 0deg; transform: translate(var(--t=
+w-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(-=
+-tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(-=
+-tw-scale-y)); }
+
+.\[\&_svg\]\:rotate-180 svg { --tw-rotate: 180deg; transform: translate(var=
+(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(v=
+ar(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(v=
+ar(--tw-scale-y)); }
+
+.\[\&_svg\]\:transition-transform svg { transition-property: transform; tra=
+nsition-duration: 0.15s; transition-timing-function: cubic-bezier(0.4, 0, 0=
+.2, 1); }
+
+.\[\&_svg\]\:duration-150 svg { transition-duration: 0.15s; }
+
+.\[\&_textarea\]\:select-text textarea { user-select: text; }
+
+.group:hover + .\[\.group\:hover\+\&\]\:bg-none { background-image: none; }
+
+:hover + .\[\:hover\+\&\>span\]\:opacity-0 > span { opacity: 0; }
+
+@container (width <=3D 599px) {
+  .\[\@container\(max-width\:599px\)\]\:grid-cols-2 { grid-template-columns=
+: repeat(2, minmax(0px, 1fr)); }
+}
+
+@media (resolution <=3D 1.99x) {
+  .\[\@media\(max-resolution\:1\.99dppx\)\]\:\[clip-path\:inset\(1px_0\)\] =
+{ clip-path: inset(1px 0px); }
+}
+
+@media (width <=3D 719px) {
+  .\[\@media\(max-width\:719px\)\]\:hidden { display: none; }
+  .\[\@media\(max-width\:719px\)\]\:h-\[calc\(100vh-24px\)\] { height: calc=
+(-24px + 100vh); }
+  .\[\@media\(max-width\:719px\)\]\:w-\[calc\(100vw-24px\)\] { width: calc(=
+-24px + 100vw); }
+  .\[\@media\(max-width\:719px\)\]\:w-full { width: 100%; }
+  .\[\@media\(max-width\:719px\)\]\:border-r-0 { border-right-width: 0px; }
+}
+
+@media (width <=3D 880px) {
+  .\[\@media\(max-width\:880px\)\]\:order-3 { order: 3; }
+  .\[\@media\(max-width\:880px\)\]\:order-4 { order: 4; }
+  .\[\@media\(max-width\:880px\)\]\:block { display: block; }
+  .\[\@media\(max-width\:880px\)\]\:hidden { display: none; }
+  .\[\@media\(max-width\:880px\)\]\:h-auto { height: auto; }
+  .\[\@media\(max-width\:880px\)\]\:basis-full { flex-basis: 100%; }
+  .\[\@media\(max-width\:880px\)\]\:flex-wrap { flex-wrap: wrap; }
+  .\[\@media\(max-width\:880px\)\]\:gap-y-2\.5 { row-gap: 0.625rem; }
+  .\[\@media\(max-width\:880px\)\]\:px-6 { padding-left: 1.5rem; padding-ri=
+ght: 1.5rem; }
+  .\[\@media\(max-width\:880px\)\]\:pb-3 { padding-bottom: 0.75rem; }
+  .\[\@media\(max-width\:880px\)\]\:pt-2\.5 { padding-top: 0.625rem; }
+}
+
+[aria-expanded=3D"true"] + .\[\[aria-expanded\=3Dtrue\]\+\&\>span\]\:opacit=
+y-0 > span, [aria-pressed=3D"true"] + .\[\[aria-pressed\=3Dtrue\]\+\&\>span=
+\]\:opacity-0 > span { opacity: 0; }
+
+[data-selected=3D"true"] + .\[\[data-selected\=3Dtrue\]\+\&\]\:bg-none { ba=
+ckground-image: none; }
+
+button:active .\[button\:active_\&\]\:\[transform\:scale\(var\(--press-scal=
+e\)\)_rotate\(var\(--juice-rot\)\)\] { transform: scale(var(--press-scale))=
+ rotate(var(--juice-rot)); }
+
+button:active .\[button\:active_\&\]\:\[transition-duration\:0\.07s\] { tra=
+nsition-duration: 70ms; }
+
+button:hover .\[button\:hover_\&\]\:\[transform\:scale\(var\(--hover-scale\=
+)\)_rotate\(var\(--juice-rot\)\)\] { transform: scale(var(--hover-scale)) r=
+otate(var(--juice-rot)); }
+
+thead .\[thead_\&\]\:border-b-0 { border-bottom-width: 0px; }
+
+tr[data-selected=3D"true"] .\[tr\[data-selected\=3Dtrue\]_\&\]\:bg-fill-gho=
+st-hover { background-color: var(--cds-fill-ghost-hover); }
+
+@keyframes om-loader-slide {=20
+  0% { transform: translate(-100%); }
+  100% { transform: translate(400%); }
+}
+
+.om-loader-bar::after { content: ""; background: var(--om-text-primary); bo=
+rder-radius: 2px; width: 30%; height: 100%; animation: 1.2s ease-in-out 0s =
+infinite normal none running om-loader-slide; display: block; }
+
+@keyframes om-toast-rise-in {=20
+  0% { opacity: 0; transform: translateY(16px) scale(0.98); }
+  100% { opacity: 1; transform: translateY(0px) scale(1); }
+}
+
+@keyframes om-toast-sink-out {=20
+  0% { opacity: 1; transform: translateY(0px); }
+  100% { opacity: 0; transform: translateY(12px); }
+}
+
+.om-toast-rise-in { animation: 0.32s cubic-bezier(0.34, 1.56, 0.64, 1) 0s 1=
+ normal none running om-toast-rise-in; }
+
+.om-toast-sink-out { animation: 0.18s ease-in 0s 1 normal forwards running =
+om-toast-sink-out; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/html
+Content-ID: <frame-D15871DABEC5699F194DCB76A1C64274@mhtml.blink>
+Content-Transfer-Encoding: quoted-printable
+
+<html><head><meta http-equiv=3D"Content-Type" content=3D"text/html; charset=
+=3DUTF-8"></head><body></body></html>
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/html
+Content-ID: <frame-40BECF81F0084B3424C7A0802889AFC9@mhtml.blink>
+Content-Transfer-Encoding: quoted-printable
+
+<html><head><meta http-equiv=3D"Content-Type" content=3D"text/html; charset=
+=3DUTF-8"></head><body></body></html>
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/html
+Content-ID: <frame-95B80C3396D04C3E818D04B557599D4F@mhtml.blink>
+Content-Transfer-Encoding: quoted-printable
+
+<html><head><meta http-equiv=3D"Content-Type" content=3D"text/html; charset=
+=3DUTF-8"></head><body></body></html>
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/html
+Content-ID: <frame-5E4D2A899281B05ED92A00AB84008AD6@mhtml.blink>
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://15b5e0f9-5329-43e0-8d6a-0aed95d8ce1a.claudeusercontent.com/v1/design/projects/15b5e0f9-5329-43e0-8d6a-0aed95d8ce1a/serve/Rivus%20Design%20System%20(standalone).html?srcmap=1&_omeo=https%3A%2F%2Fclaude.ai
+
+<!DOCTYPE html><html><head><meta http-equiv=3D"Content-Type" content=3D"tex=
+t/html; charset=3DUTF-8"><link rel=3D"stylesheet" type=3D"text/css" href=3D=
+"cid:css-3026d320-2ccd-45b2-8578-52c5f7e34245@mhtml.blink" /><link rel=3D"s=
+tylesheet" type=3D"text/css" href=3D"cid:css-776974b1-ed17-4d00-9fe3-0610e9=
+3ec548@mhtml.blink" /><link rel=3D"stylesheet" type=3D"text/css" href=3D"ci=
+d:css-12fecc26-cc94-4f75-bd8c-ca6da7e6677e@mhtml.blink" /><link rel=3D"styl=
+esheet" type=3D"text/css" href=3D"cid:css-a36257f3-c259-440b-a8c7-32b141fda=
+2c6@mhtml.blink" /><link rel=3D"stylesheet" type=3D"text/css" href=3D"cid:c=
+ss-ddfcec38-1c34-4cf8-ae61-8d19c3e77e18@mhtml.blink" /><link rel=3D"stylesh=
+eet" type=3D"text/css" href=3D"cid:css-864c9c22-cb8a-4d97-93d6-a99d7ab93872=
+@mhtml.blink" /><link rel=3D"stylesheet" type=3D"text/css" href=3D"cid:css-=
+aedb1fcb-ae22-4ab0-8b88-cbaab0069f8a@mhtml.blink" />
+
+<meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=3D1"=
+>
+
+<link rel=3D"preconnect" href=3D"https://fonts.googleapis.com/" data-dc-tpl=
+=3D"1"><link rel=3D"preconnect" href=3D"https://fonts.gstatic.com/" data-dc=
+-tpl=3D"2"><link href=3D"https://fonts.googleapis.com/css2?family=3DMontser=
+rat:wght@500;600;700&amp;display=3Dswap" rel=3D"stylesheet" data-dc-tpl=3D"=
+1"><link href=3D"https://fonts.googleapis.com/css2?family=3DMontserrat:wght=
+@500;600&amp;display=3Dswap" rel=3D"stylesheet" data-dc-tpl=3D"1"><link hre=
+f=3D"https://fonts.googleapis.com/css2?family=3DMontserrat:wght@400;500;600=
+&amp;display=3Dswap" rel=3D"stylesheet" data-dc-tpl=3D"1"><link href=3D"htt=
+ps://fonts.googleapis.com/css2?family=3DMontserrat:wght@600&amp;display=3Ds=
+wap" rel=3D"stylesheet" data-dc-tpl=3D"1"></head>
+<body>
+
+<div id=3D"dc-root"><div class=3D"sc-host" data-sc-name=3D"Rivus Design Sys=
+tem (standalone)"><div data-dc-tpl=3D"5" style=3D"min-height: 100vh; backgr=
+ound: rgb(246, 247, 251); font-family: Montserrat, sans-serif; color: rgb(2=
+2, 22, 31); padding: 44px 32px 80px;"><div data-dc-tpl=3D"6" style=3D"max-w=
+idth: 1080px; margin: 0px auto;">
+
+ =20
+  <div data-dc-tpl=3D"7" style=3D"display: flex; align-items: flex-end; jus=
+tify-content: space-between; gap: 24px; flex-wrap: wrap; border-bottom: 1px=
+ solid rgb(233, 234, 240); padding-bottom: 26px; margin-bottom: 38px;">
+    <div data-dc-tpl=3D"8">
+      <img data-dc-tpl=3D"9" src=3D"blob:https://15b5e0f9-5329-43e0-8d6a-0a=
+ed95d8ce1a.claudeusercontent.com/63e7bcfe-ef7a-4e19-829b-2e64a93c4f81" alt=
+=3D"Rivus" style=3D"height: 30px; display: block; margin-bottom: 16px;" wid=
+th=3D"104" height=3D"30">
+      <h1 data-dc-tpl=3D"10" style=3D"margin: 0px; font-size: 30px; font-we=
+ight: 600; letter-spacing: -0.02em;">Design System</h1>
+      <p data-dc-tpl=3D"11" style=3D"margin: 8px 0px 0px; font-size: 14px; =
+color: rgb(138, 139, 153); max-width: 540px; line-height: 1.5;">The reusabl=
+e visual language behind the Rivus business management agent =E2=80=94 toke=
+ns, type, and live components shared across every screen.</p>
+    </div>
+    <div data-dc-tpl=3D"12" style=3D"display: flex; align-items: center; ga=
+p: 8px; background: linear-gradient(135deg, rgba(30, 190, 250, 0.12), rgba(=
+110, 30, 200, 0.12)); border: 1px solid rgba(110, 30, 200, 0.16); padding: =
+7px 13px; border-radius: 999px;">
+      <span data-dc-tpl=3D"13" style=3D"width: 7px; height: 7px; border-rad=
+ius: 50%; background: rgb(31, 181, 115); box-shadow: rgba(31, 181, 115, 0.1=
+8) 0px 0px 0px 3px;"></span>
+      <span data-dc-tpl=3D"14" style=3D"font-size: 12px; font-weight: 600; =
+color: rgb(58, 42, 82);">v1 =C2=B7 Living document</span>
+    </div>
+  </div>
+
+ =20
+  <div data-dc-tpl=3D"15" style=3D"font-size: 12px; font-weight: 600; lette=
+r-spacing: 0.08em; text-transform: uppercase; color: rgb(154, 155, 176); ma=
+rgin-bottom: 18px;">Color</div>
+
+ =20
+    <div data-dc-tpl=3D"17" style=3D"margin-bottom: 26px;">
+      <div data-dc-tpl=3D"18" style=3D"font-size: 13px; font-weight: 600; c=
+olor: rgb(90, 91, 104); margin-bottom: 12px;"><span class=3D"sc-interp">Bra=
+nd</span></div>
+      <div data-dc-tpl=3D"19" style=3D"display: grid; grid-template-columns=
+: repeat(4, 1fr); gap: 14px;">
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: line=
+ar-gradient(135deg, rgb(30, 190, 250), rgb(110, 30, 200));"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Rivus gradient</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#1ebefa =E2=86=92 #6e1ec8</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+30, 190, 250);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Sky</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#1ebefa</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+110, 30, 200);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Violet</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#6e1ec8</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+16, 16, 25);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Ink</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#101019</span></div>
+            </div>
+          </div>
+       =20
+      </div>
+    </div>
+ =20
+    <div data-dc-tpl=3D"17" style=3D"margin-bottom: 26px;">
+      <div data-dc-tpl=3D"18" style=3D"font-size: 13px; font-weight: 600; c=
+olor: rgb(90, 91, 104); margin-bottom: 12px;"><span class=3D"sc-interp">Sur=
+faces</span></div>
+      <div data-dc-tpl=3D"19" style=3D"display: grid; grid-template-columns=
+: repeat(4, 1fr); gap: 14px;">
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+246, 247, 251); border-bottom: 1px solid rgb(233, 234, 240);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">App background</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#f6f7fb</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+255, 255, 255); border-bottom: 1px solid rgb(233, 234, 240);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Card</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#ffffff</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+19, 19, 31);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Briefing dark</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#13131f</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+233, 234, 240);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Hairline</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#e9eaf0</span></div>
+            </div>
+          </div>
+       =20
+      </div>
+    </div>
+ =20
+    <div data-dc-tpl=3D"17" style=3D"margin-bottom: 26px;">
+      <div data-dc-tpl=3D"18" style=3D"font-size: 13px; font-weight: 600; c=
+olor: rgb(90, 91, 104); margin-bottom: 12px;"><span class=3D"sc-interp">Sta=
+tus</span></div>
+      <div data-dc-tpl=3D"19" style=3D"display: grid; grid-template-columns=
+: repeat(4, 1fr); gap: 14px;">
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+31, 181, 115);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Success</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#1fb573</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+240, 160, 32);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Warning</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#f0a020</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+240, 88, 75);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Danger</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#f0584b</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+110, 30, 200);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Accent</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#6e1ec8</span></div>
+            </div>
+          </div>
+       =20
+      </div>
+    </div>
+ =20
+    <div data-dc-tpl=3D"17" style=3D"margin-bottom: 26px;">
+      <div data-dc-tpl=3D"18" style=3D"font-size: 13px; font-weight: 600; c=
+olor: rgb(90, 91, 104); margin-bottom: 12px;"><span class=3D"sc-interp">Tex=
+t</span></div>
+      <div data-dc-tpl=3D"19" style=3D"display: grid; grid-template-columns=
+: repeat(4, 1fr); gap: 14px;">
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+22, 22, 31);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Primary</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#16161f</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+138, 139, 153);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Sub</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#8a8b99</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+154, 155, 176);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Muted</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#9a9bb0</span></div>
+            </div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"21" style=3D"background: rgb(255, 255, 255); =
+border: 1px solid rgb(233, 234, 240); border-radius: 12px; overflow: hidden=
+;">
+            <div data-dc-tpl=3D"22" style=3D"height: 74px; background: rgb(=
+182, 184, 196);"></div>
+            <div data-dc-tpl=3D"23" style=3D"padding: 11px 13px;">
+              <div data-dc-tpl=3D"24" style=3D"font-size: 13px; font-weight=
+: 600;"><span class=3D"sc-interp">Disabled</span></div>
+              <div data-dc-tpl=3D"25" style=3D"font-size: 11.5px; color: rg=
+b(154, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace; margin-t=
+op: 2px;"><span class=3D"sc-interp">#b6b8c4</span></div>
+            </div>
+          </div>
+       =20
+      </div>
+    </div>
+ =20
+
+ =20
+  <div data-dc-tpl=3D"26" style=3D"font-size: 12px; font-weight: 600; lette=
+r-spacing: 0.08em; text-transform: uppercase; color: rgb(154, 155, 176); ma=
+rgin: 42px 0px 18px;">Typography =C2=B7 Montserrat</div>
+  <div data-dc-tpl=3D"27" style=3D"background: rgb(255, 255, 255); border: =
+1px solid rgb(233, 234, 240); border-radius: 14px; padding: 8px 24px;">
+   =20
+      <div data-dc-tpl=3D"29" style=3D"display: flex; align-items: baseline=
+; justify-content: space-between; gap: 24px; padding: 18px 0px; border-bott=
+om: 1px solid rgb(243, 244, 248);">
+        <div data-dc-tpl=3D"30" style=3D"font-size: 30px; font-weight: 600;=
+ letter-spacing: -0.02em;"><span class=3D"sc-interp">Good morning, Marcus</=
+span></div>
+        <div data-dc-tpl=3D"31" style=3D"font-size: 12px; color: rgb(154, 1=
+55, 176); font-family: &quot;Roboto Mono&quot;, monospace; white-space: now=
+rap; flex-shrink: 0;"><span class=3D"sc-interp">Display =C2=B7 30 / 600</sp=
+an></div>
+      </div>
+   =20
+      <div data-dc-tpl=3D"29" style=3D"display: flex; align-items: baseline=
+; justify-content: space-between; gap: 24px; padding: 18px 0px; border-bott=
+om: 1px solid rgb(243, 244, 248);">
+        <div data-dc-tpl=3D"30" style=3D"font-size: 20px; font-weight: 600;=
+"><span class=3D"sc-interp">Schedule</span></div>
+        <div data-dc-tpl=3D"31" style=3D"font-size: 12px; color: rgb(154, 1=
+55, 176); font-family: &quot;Roboto Mono&quot;, monospace; white-space: now=
+rap; flex-shrink: 0;"><span class=3D"sc-interp">Heading =C2=B7 20 / 600</sp=
+an></div>
+      </div>
+   =20
+      <div data-dc-tpl=3D"29" style=3D"display: flex; align-items: baseline=
+; justify-content: space-between; gap: 24px; padding: 18px 0px; border-bott=
+om: 1px solid rgb(243, 244, 248);">
+        <div data-dc-tpl=3D"30" style=3D"font-size: 15px; font-weight: 600;=
+"><span class=3D"sc-interp">Today's schedule</span></div>
+        <div data-dc-tpl=3D"31" style=3D"font-size: 12px; color: rgb(154, 1=
+55, 176); font-family: &quot;Roboto Mono&quot;, monospace; white-space: now=
+rap; flex-shrink: 0;"><span class=3D"sc-interp">Subhead =C2=B7 15 / 600</sp=
+an></div>
+      </div>
+   =20
+      <div data-dc-tpl=3D"29" style=3D"display: flex; align-items: baseline=
+; justify-content: space-between; gap: 24px; padding: 18px 0px; border-bott=
+om: 1px solid rgb(243, 244, 248);">
+        <div data-dc-tpl=3D"30" style=3D"font-size: 13.5px; font-weight: 40=
+0; color: rgb(58, 59, 72);"><span class=3D"sc-interp">Rivus handled 38 conv=
+ersations overnight.</span></div>
+        <div data-dc-tpl=3D"31" style=3D"font-size: 12px; color: rgb(154, 1=
+55, 176); font-family: &quot;Roboto Mono&quot;, monospace; white-space: now=
+rap; flex-shrink: 0;"><span class=3D"sc-interp">Body =C2=B7 13.5 / 400</spa=
+n></div>
+      </div>
+   =20
+      <div data-dc-tpl=3D"29" style=3D"display: flex; align-items: baseline=
+; justify-content: space-between; gap: 24px; padding: 18px 0px; border-bott=
+om: 1px solid rgb(243, 244, 248);">
+        <div data-dc-tpl=3D"30" style=3D"font-size: 12px; font-weight: 600;=
+ letter-spacing: 0.06em; color: rgb(138, 139, 153);"><span class=3D"sc-inte=
+rp">CONVERSATIONS TODAY</span></div>
+        <div data-dc-tpl=3D"31" style=3D"font-size: 12px; color: rgb(154, 1=
+55, 176); font-family: &quot;Roboto Mono&quot;, monospace; white-space: now=
+rap; flex-shrink: 0;"><span class=3D"sc-interp">Label =C2=B7 12 / 600 =C2=
+=B7 .06em</span></div>
+      </div>
+   =20
+      <div data-dc-tpl=3D"29" style=3D"display: flex; align-items: baseline=
+; justify-content: space-between; gap: 24px; padding: 18px 0px; border-bott=
+om: 1px solid rgb(243, 244, 248);">
+        <div data-dc-tpl=3D"30" style=3D"font-size: 11.5px; font-weight: 50=
+0; color: rgb(154, 155, 176);"><span class=3D"sc-interp">34 handled by Rivu=
+s</span></div>
+        <div data-dc-tpl=3D"31" style=3D"font-size: 12px; color: rgb(154, 1=
+55, 176); font-family: &quot;Roboto Mono&quot;, monospace; white-space: now=
+rap; flex-shrink: 0;"><span class=3D"sc-interp">Caption =C2=B7 11.5 / 500</=
+span></div>
+      </div>
+   =20
+  </div>
+
+ =20
+  <div data-dc-tpl=3D"32" style=3D"display: grid; grid-template-columns: 1.=
+4fr 1fr; gap: 18px; margin-top: 42px; align-items: start;">
+    <div data-dc-tpl=3D"33">
+      <div data-dc-tpl=3D"34" style=3D"font-size: 12px; font-weight: 600; l=
+etter-spacing: 0.08em; text-transform: uppercase; color: rgb(154, 155, 176)=
+; margin-bottom: 18px;">Signature gradient</div>
+      <div data-dc-tpl=3D"35" style=3D"background: rgb(255, 255, 255); bord=
+er: 1px solid rgb(233, 234, 240); border-radius: 14px; padding: 18px;">
+        <div data-dc-tpl=3D"36" style=3D"height: 88px; border-radius: 11px;=
+ background: linear-gradient(135deg, rgb(30, 190, 250), rgb(110, 30, 200));=
+ margin-bottom: 14px;"></div>
+        <div data-dc-tpl=3D"37" style=3D"font-size: 12.5px; color: rgb(90, =
+91, 104); font-family: &quot;Roboto Mono&quot;, monospace; line-height: 1.6=
+;">linear-gradient(135deg, #1ebefa, #6e1ec8)</div>
+        <div data-dc-tpl=3D"38" style=3D"font-size: 12.5px; color: rgb(138,=
+ 139, 153); line-height: 1.5; margin-top: 10px;">The one signature element.=
+ Reserve it for Rivus-the-agent: primary buttons, the symbol tile, AI statu=
+s, active nav. Never as a page or card background.</div>
+      </div>
+    </div>
+    <div data-dc-tpl=3D"39">
+      <div data-dc-tpl=3D"40" style=3D"font-size: 12px; font-weight: 600; l=
+etter-spacing: 0.08em; text-transform: uppercase; color: rgb(154, 155, 176)=
+; margin-bottom: 18px;">Radius</div>
+      <div data-dc-tpl=3D"41" style=3D"background: rgb(255, 255, 255); bord=
+er: 1px solid rgb(233, 234, 240); border-radius: 14px; padding: 18px; displ=
+ay: flex; flex-direction: column; gap: 14px;">
+       =20
+          <div data-dc-tpl=3D"43" style=3D"display: flex; align-items: cent=
+er; gap: 14px;">
+            <div data-dc-tpl=3D"44" style=3D"width: 46px; height: 46px; bac=
+kground: rgb(238, 240, 244); border: 1px solid rgb(224, 226, 234); flex-shr=
+ink: 0; border-radius: 8px;"></div>
+            <div data-dc-tpl=3D"45"><div data-dc-tpl=3D"46" style=3D"font-s=
+ize: 13px; font-weight: 600;"><span class=3D"sc-interp">Controls</span></di=
+v><div data-dc-tpl=3D"47" style=3D"font-size: 11.5px; color: rgb(154, 155, =
+176); font-family: &quot;Roboto Mono&quot;, monospace;"><span class=3D"sc-i=
+nterp">8px</span></div></div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"43" style=3D"display: flex; align-items: cent=
+er; gap: 14px;">
+            <div data-dc-tpl=3D"44" style=3D"width: 46px; height: 46px; bac=
+kground: rgb(238, 240, 244); border: 1px solid rgb(224, 226, 234); flex-shr=
+ink: 0; border-radius: 11px;"></div>
+            <div data-dc-tpl=3D"45"><div data-dc-tpl=3D"46" style=3D"font-s=
+ize: 13px; font-weight: 600;"><span class=3D"sc-interp">Buttons / inputs</s=
+pan></div><div data-dc-tpl=3D"47" style=3D"font-size: 11.5px; color: rgb(15=
+4, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace;"><span class=
+=3D"sc-interp">10=E2=80=9311px</span></div></div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"43" style=3D"display: flex; align-items: cent=
+er; gap: 14px;">
+            <div data-dc-tpl=3D"44" style=3D"width: 46px; height: 46px; bac=
+kground: rgb(238, 240, 244); border: 1px solid rgb(224, 226, 234); flex-shr=
+ink: 0; border-radius: 14px;"></div>
+            <div data-dc-tpl=3D"45"><div data-dc-tpl=3D"46" style=3D"font-s=
+ize: 13px; font-weight: 600;"><span class=3D"sc-interp">Cards</span></div><=
+div data-dc-tpl=3D"47" style=3D"font-size: 11.5px; color: rgb(154, 155, 176=
+); font-family: &quot;Roboto Mono&quot;, monospace;"><span class=3D"sc-inte=
+rp">14px</span></div></div>
+          </div>
+       =20
+          <div data-dc-tpl=3D"43" style=3D"display: flex; align-items: cent=
+er; gap: 14px;">
+            <div data-dc-tpl=3D"44" style=3D"width: 46px; height: 46px; bac=
+kground: rgb(238, 240, 244); border: 1px solid rgb(224, 226, 234); flex-shr=
+ink: 0; border-radius: 999px;"></div>
+            <div data-dc-tpl=3D"45"><div data-dc-tpl=3D"46" style=3D"font-s=
+ize: 13px; font-weight: 600;"><span class=3D"sc-interp">Pills</span></div><=
+div data-dc-tpl=3D"47" style=3D"font-size: 11.5px; color: rgb(154, 155, 176=
+); font-family: &quot;Roboto Mono&quot;, monospace;"><span class=3D"sc-inte=
+rp">999px</span></div></div>
+          </div>
+       =20
+      </div>
+    </div>
+  </div>
+
+ =20
+  <div data-dc-tpl=3D"48" style=3D"font-size: 12px; font-weight: 600; lette=
+r-spacing: 0.08em; text-transform: uppercase; color: rgb(154, 155, 176); ma=
+rgin: 52px 0px 18px;">Components</div>
+
+ =20
+  <div data-dc-tpl=3D"49" style=3D"background: rgb(255, 255, 255); border: =
+1px solid rgb(233, 234, 240); border-radius: 14px; padding: 20px; margin-bo=
+ttom: 18px;">
+    <div data-dc-tpl=3D"50" style=3D"display: flex; align-items: center; ju=
+stify-content: space-between; margin-bottom: 16px;">
+      <div data-dc-tpl=3D"51" style=3D"font-size: 14px; font-weight: 600;">=
+Briefing banner</div>
+      <div data-dc-tpl=3D"52" style=3D"font-size: 11.5px; color: rgb(154, 1=
+55, 176); font-family: &quot;Roboto Mono&quot;, monospace;">BriefingBanner<=
+/div>
+    </div>
+    <div class=3D"sc-host" data-sc-name=3D"BriefingBanner" data-dc-tpl=3D"5=
+3"><div data-dc-tpl=3D"2" style=3D"background: linear-gradient(120deg, rgb(=
+19, 19, 31), rgb(27, 21, 48)); border-radius: 16px; padding: 22px 24px; dis=
+play: flex; align-items: center; gap: 20px; overflow: hidden; position: rel=
+ative; font-family: Montserrat, sans-serif;">
+  <div data-dc-tpl=3D"3" style=3D"position: absolute; right: -40px; top: -6=
+0px; width: 240px; height: 240px; border-radius: 50%; background: radial-gr=
+adient(circle, rgba(110, 30, 200, 0.45), transparent 70%);"></div>
+  <div data-dc-tpl=3D"4" style=3D"position: absolute; right: 90px; top: -30=
+px; width: 180px; height: 180px; border-radius: 50%; background: radial-gra=
+dient(circle, rgba(30, 190, 250, 0.3), transparent 70%);"></div>
+  <div data-dc-tpl=3D"5" style=3D"width: 46px; height: 46px; border-radius:=
+ 12px; background: linear-gradient(135deg, rgb(30, 190, 250), rgb(110, 30, =
+200)); display: flex; align-items: center; justify-content: center; flex-sh=
+rink: 0; position: relative;">
+    <img data-dc-tpl=3D"6" src=3D"https://15b5e0f9-5329-43e0-8d6a-0aed95d8c=
+e1a.claudeusercontent.com/v1/design/projects/15b5e0f9-5329-43e0-8d6a-0aed95=
+d8ce1a/serve/assets/rivus-symbol-white.svg" alt=3D"Rivus" style=3D"width: 6=
+2%; height: 62%; object-fit: contain;" width=3D"29" height=3D"29">
+  </div>
+  <div data-dc-tpl=3D"7" style=3D"flex: 1 1 0%; position: relative; min-wid=
+th: 0px;">
+    <div data-dc-tpl=3D"8" style=3D"font-size: 11px; font-weight: 600; lett=
+er-spacing: 0.1em; text-transform: uppercase; color: rgb(154, 143, 196); ma=
+rgin-bottom: 4px;"><span class=3D"sc-interp">While you were away</span></di=
+v>
+    <div data-dc-tpl=3D"9" style=3D"font-size: 16.5px; font-weight: 500; co=
+lor: rgb(243, 241, 251); line-height: 1.45; max-width: 660px;"><span class=
+=3D"sc-interp">Rivus handled 38 conversations, booked 6 jobs, and answered =
+19 questions overnight. Two items need a human eye.</span></div>
+  </div>
+  </div></div>
+    <div data-dc-tpl=3D"54" style=3D"font-size: 12px; color: rgb(138, 139, =
+153); margin-top: 13px; line-height: 1.5;">The agent's "while you were away=
+" summary. Props: <span data-dc-tpl=3D"55" style=3D"font-family: &quot;Robo=
+to Mono&quot;, monospace; color: rgb(110, 30, 200);">eyebrow =C2=B7 message=
+ =C2=B7 ctaLabel</span></div>
+  </div>
+
+  <div data-dc-tpl=3D"56" style=3D"display: grid; grid-template-columns: 1f=
+r 1fr; gap: 18px; margin-bottom: 18px; align-items: start;">
+   =20
+    <div data-dc-tpl=3D"57" style=3D"background: rgb(255, 255, 255); border=
+: 1px solid rgb(233, 234, 240); border-radius: 14px; padding: 20px;">
+      <div data-dc-tpl=3D"58" style=3D"display: flex; align-items: center; =
+justify-content: space-between; margin-bottom: 16px;">
+        <div data-dc-tpl=3D"59" style=3D"font-size: 14px; font-weight: 600;=
+">AI status pill</div>
+        <div data-dc-tpl=3D"60" style=3D"font-size: 11.5px; color: rgb(154,=
+ 155, 176); font-family: &quot;Roboto Mono&quot;, monospace;">RivusPill</di=
+v>
+      </div>
+      <div data-dc-tpl=3D"61" style=3D"display: flex; flex-wrap: wrap; gap:=
+ 10px; align-items: center;">
+        <div class=3D"sc-host" data-sc-name=3D"RivusPill" data-dc-tpl=3D"62=
+"><div data-dc-tpl=3D"2" style=3D"display: inline-flex; align-items: center=
+; gap: 8px; background: linear-gradient(135deg, rgba(30, 190, 250, 0.12), r=
+gba(110, 30, 200, 0.12)); border: 1px solid rgba(110, 30, 200, 0.16); paddi=
+ng: 6px 12px; border-radius: 999px; font-family: Montserrat, sans-serif;">
+  <span data-dc-tpl=3D"4" style=3D"width: 7px; height: 7px; border-radius: =
+50%; background: rgb(31, 181, 115); box-shadow: rgba(31, 181, 115, 0.18) 0p=
+x 0px 0px 3px; flex-shrink: 0;"></span>
+ =20
+  <span data-dc-tpl=3D"9" style=3D"font-size: 12px; font-weight: 600; color=
+: rgb(58, 42, 82); white-space: nowrap;"><span class=3D"sc-interp">Rivus is=
+ online</span></span></div></div>
+        <div class=3D"sc-host" data-sc-name=3D"RivusPill" data-dc-tpl=3D"63=
+"><div data-dc-tpl=3D"2" style=3D"display: inline-flex; align-items: center=
+; gap: 8px; background: linear-gradient(135deg, rgba(30, 190, 250, 0.12), r=
+gba(110, 30, 200, 0.12)); border: 1px solid rgba(110, 30, 200, 0.16); paddi=
+ng: 6px 12px; border-radius: 999px; font-family: Montserrat, sans-serif;">
+  <span data-dc-tpl=3D"4" style=3D"width: 7px; height: 7px; border-radius: =
+50%; background: rgb(31, 181, 115); box-shadow: rgba(31, 181, 115, 0.18) 0p=
+x 0px 0px 3px; flex-shrink: 0;"></span>
+ =20
+  <span data-dc-tpl=3D"9" style=3D"font-size: 12px; font-weight: 600; color=
+: rgb(58, 42, 82); white-space: nowrap;"><span class=3D"sc-interp">Rivus is=
+ handling</span></span></div></div>
+        <div class=3D"sc-host" data-sc-name=3D"RivusPill" data-dc-tpl=3D"64=
+"><div data-dc-tpl=3D"2" style=3D"display: inline-flex; align-items: center=
+; gap: 8px; background: linear-gradient(135deg, rgba(30, 190, 250, 0.12), r=
+gba(110, 30, 200, 0.12)); border: 1px solid rgba(110, 30, 200, 0.16); paddi=
+ng: 6px 12px; border-radius: 999px; font-family: Montserrat, sans-serif;">
+ =20
+  <span data-dc-tpl=3D"6" style=3D"width: 16px; height: 16px; border-radius=
+: 5px; background: linear-gradient(135deg, rgb(30, 190, 250), rgb(110, 30, =
+200)); display: flex; align-items: center; justify-content: center; flex-sh=
+rink: 0;"><svg data-dc-tpl=3D"7" width=3D"10" height=3D"10" viewBox=3D"0 0 =
+24 24" fill=3D"none" stroke=3D"#fff" stroke-width=3D"2.6" stroke-linecap=3D=
+"round" stroke-linejoin=3D"round"><path data-dc-tpl=3D"8" d=3D"M5 12l5 5L20=
+ 6"></path></svg></span>
+  <span data-dc-tpl=3D"9" style=3D"font-size: 12px; font-weight: 600; color=
+: rgb(58, 42, 82); white-space: nowrap;"><span class=3D"sc-interp">Rivus au=
+to-scheduled 6 jobs</span></span></div></div>
+      </div>
+      <div data-dc-tpl=3D"65" style=3D"font-size: 12px; color: rgb(138, 139=
+, 153); margin-top: 14px; line-height: 1.5;">Props: <span data-dc-tpl=3D"66=
+" style=3D"font-family: &quot;Roboto Mono&quot;, monospace; color: rgb(110,=
+ 30, 200);">label =C2=B7 variant(dot|check)</span></div>
+    </div>
+
+   =20
+    <div data-dc-tpl=3D"67" style=3D"background: rgb(255, 255, 255); border=
+: 1px solid rgb(233, 234, 240); border-radius: 14px; padding: 20px;">
+      <div data-dc-tpl=3D"68" style=3D"display: flex; align-items: center; =
+justify-content: space-between; margin-bottom: 16px;">
+        <div data-dc-tpl=3D"69" style=3D"font-size: 14px; font-weight: 600;=
+">Status badge</div>
+        <div data-dc-tpl=3D"70" style=3D"font-size: 11.5px; color: rgb(154,=
+ 155, 176); font-family: &quot;Roboto Mono&quot;, monospace;">StatusBadge</=
+div>
+      </div>
+      <div data-dc-tpl=3D"71" style=3D"display: flex; flex-wrap: wrap; gap:=
+ 9px; align-items: center;">
+        <div class=3D"sc-host" data-sc-name=3D"StatusBadge" data-dc-tpl=3D"=
+72"><span data-dc-tpl=3D"2" style=3D"display: inline-block; font-size: 11.5=
+px; font-weight: 600; padding: 4px 11px; border-radius: 999px; font-family:=
+ Montserrat, sans-serif; white-space: nowrap; color: rgb(31, 181, 115); bac=
+kground: rgba(31, 181, 115, 0.12);"><span class=3D"sc-interp">Paid up</span=
+></span></div>
+        <div class=3D"sc-host" data-sc-name=3D"StatusBadge" data-dc-tpl=3D"=
+73"><span data-dc-tpl=3D"2" style=3D"display: inline-block; font-size: 11.5=
+px; font-weight: 600; padding: 4px 11px; border-radius: 999px; font-family:=
+ Montserrat, sans-serif; white-space: nowrap; color: rgb(210, 80, 63); back=
+ground: rgba(240, 88, 75, 0.12);"><span class=3D"sc-interp">Balance due</sp=
+an></span></div>
+        <div class=3D"sc-host" data-sc-name=3D"StatusBadge" data-dc-tpl=3D"=
+74"><span data-dc-tpl=3D"2" style=3D"display: inline-block; font-size: 11.5=
+px; font-weight: 600; padding: 4px 11px; border-radius: 999px; font-family:=
+ Montserrat, sans-serif; white-space: nowrap; color: rgb(164, 114, 15); bac=
+kground: rgba(240, 160, 32, 0.14);"><span class=3D"sc-interp">Quote pending=
+</span></span></div>
+        <div class=3D"sc-host" data-sc-name=3D"StatusBadge" data-dc-tpl=3D"=
+75"><span data-dc-tpl=3D"2" style=3D"display: inline-block; font-size: 11.5=
+px; font-weight: 600; padding: 4px 11px; border-radius: 999px; font-family:=
+ Montserrat, sans-serif; white-space: nowrap; color: rgb(110, 30, 200); bac=
+kground: rgba(110, 30, 200, 0.1);"><span class=3D"sc-interp">New lead</span=
+></span></div>
+        <div class=3D"sc-host" data-sc-name=3D"StatusBadge" data-dc-tpl=3D"=
+76"><span data-dc-tpl=3D"2" style=3D"display: inline-block; font-size: 11.5=
+px; font-weight: 600; padding: 4px 11px; border-radius: 999px; font-family:=
+ Montserrat, sans-serif; white-space: nowrap; color: rgb(164, 114, 15); bac=
+kground: rgba(240, 160, 32, 0.14);"><span class=3D"sc-interp">Reminder sent=
+</span></span></div>
+      </div>
+      <div data-dc-tpl=3D"77" style=3D"font-size: 12px; color: rgb(138, 139=
+, 153); margin-top: 14px; line-height: 1.5;">Props: <span data-dc-tpl=3D"78=
+" style=3D"font-family: &quot;Roboto Mono&quot;, monospace; color: rgb(110,=
+ 30, 200);">label =C2=B7 tone(paid|due|quote|lead|neutral)</span></div>
+    </div>
+  </div>
+
+ =20
+  <div data-dc-tpl=3D"79" style=3D"background: rgb(255, 255, 255); border: =
+1px solid rgb(233, 234, 240); border-radius: 14px; padding: 20px; margin-bo=
+ttom: 18px;">
+    <div data-dc-tpl=3D"80" style=3D"display: flex; align-items: center; ju=
+stify-content: space-between; margin-bottom: 16px;">
+      <div data-dc-tpl=3D"81" style=3D"font-size: 14px; font-weight: 600;">=
+Metric card</div>
+      <div data-dc-tpl=3D"82" style=3D"font-size: 11.5px; color: rgb(154, 1=
+55, 176); font-family: &quot;Roboto Mono&quot;, monospace;">MetricCard</div=
+>
+    </div>
+    <div data-dc-tpl=3D"83" style=3D"display: grid; grid-template-columns: =
+repeat(4, 1fr); gap: 16px; background: rgb(246, 247, 251); border-radius: 1=
+2px; padding: 16px;">
+      <div class=3D"sc-host" data-sc-name=3D"MetricCard" data-dc-tpl=3D"84"=
+><div data-dc-tpl=3D"2" style=3D"background: rgb(255, 255, 255); border: 1p=
+x solid rgb(233, 234, 240); border-radius: 14px; padding: 18px; font-family=
+: Montserrat, sans-serif;">
+  <div data-dc-tpl=3D"3" style=3D"font-size: 12px; font-weight: 600; color:=
+ rgb(138, 139, 153); margin-bottom: 12px;"><span class=3D"sc-interp">Conver=
+sations today</span></div>
+  <div data-dc-tpl=3D"4" style=3D"display: flex; align-items: baseline; gap=
+: 8px;">
+    <span data-dc-tpl=3D"5" style=3D"font-size: 30px; font-weight: 600; let=
+ter-spacing: -0.02em; color: rgb(22, 22, 31);"><span class=3D"sc-interp">38=
+</span></span>
+    <span data-dc-tpl=3D"7" style=3D"font-size: 12px; font-weight: 600; col=
+or: rgb(31, 181, 115);"><span class=3D"sc-interp">+12%</span></span>
+  </div>
+  <div data-dc-tpl=3D"9" style=3D"font-size: 12px; color: rgb(138, 139, 153=
+); margin-top: 6px;"><span class=3D"sc-interp">34 handled by Rivus</span></=
+div></div></div>
+      <div class=3D"sc-host" data-sc-name=3D"MetricCard" data-dc-tpl=3D"85"=
+><div data-dc-tpl=3D"2" style=3D"background: rgb(255, 255, 255); border: 1p=
+x solid rgb(233, 234, 240); border-radius: 14px; padding: 18px; font-family=
+: Montserrat, sans-serif;">
+  <div data-dc-tpl=3D"3" style=3D"font-size: 12px; font-weight: 600; color:=
+ rgb(138, 139, 153); margin-bottom: 12px;"><span class=3D"sc-interp">Jobs b=
+ooked</span></div>
+  <div data-dc-tpl=3D"4" style=3D"display: flex; align-items: baseline; gap=
+: 8px;">
+    <span data-dc-tpl=3D"5" style=3D"font-size: 30px; font-weight: 600; let=
+ter-spacing: -0.02em; color: rgb(22, 22, 31);"><span class=3D"sc-interp">6<=
+/span></span>
+    <span data-dc-tpl=3D"7" style=3D"font-size: 12px; font-weight: 600; col=
+or: rgb(138, 139, 153);"><span class=3D"sc-interp">today</span></span>
+  </div>
+  <div data-dc-tpl=3D"9" style=3D"font-size: 12px; color: rgb(138, 139, 153=
+); margin-top: 6px;"><span class=3D"sc-interp">$4,200 pipeline value</span>=
+</div></div></div>
+      <div class=3D"sc-host" data-sc-name=3D"MetricCard" data-dc-tpl=3D"86"=
+><div data-dc-tpl=3D"2" style=3D"background: rgb(255, 255, 255); border: 1p=
+x solid rgb(233, 234, 240); border-radius: 14px; padding: 18px; font-family=
+: Montserrat, sans-serif;">
+  <div data-dc-tpl=3D"3" style=3D"font-size: 12px; font-weight: 600; color:=
+ rgb(138, 139, 153); margin-bottom: 12px;"><span class=3D"sc-interp">Avg. r=
+esponse time</span></div>
+  <div data-dc-tpl=3D"4" style=3D"display: flex; align-items: baseline; gap=
+: 8px;">
+    <span data-dc-tpl=3D"5" style=3D"font-size: 30px; font-weight: 600; let=
+ter-spacing: -0.02em; color: rgb(22, 22, 31);"><span class=3D"sc-interp">12=
+s</span></span>
+   =20
+  </div>
+  <div data-dc-tpl=3D"9" style=3D"font-size: 12px; color: rgb(138, 139, 153=
+); margin-top: 6px;"><span class=3D"sc-interp">Was 4h before Rivus</span></=
+div></div></div>
+      <div class=3D"sc-host" data-sc-name=3D"MetricCard" data-dc-tpl=3D"87"=
+><div data-dc-tpl=3D"2" style=3D"background: rgb(255, 255, 255); border: 1p=
+x solid rgb(233, 234, 240); border-radius: 14px; padding: 18px; font-family=
+: Montserrat, sans-serif;">
+  <div data-dc-tpl=3D"3" style=3D"font-size: 12px; font-weight: 600; color:=
+ rgb(138, 139, 153); margin-bottom: 12px;"><span class=3D"sc-interp">Open i=
+nvoices</span></div>
+  <div data-dc-tpl=3D"4" style=3D"display: flex; align-items: baseline; gap=
+: 8px;">
+    <span data-dc-tpl=3D"5" style=3D"font-size: 30px; font-weight: 600; let=
+ter-spacing: -0.02em; color: rgb(22, 22, 31);"><span class=3D"sc-interp">$8=
+,140</span></span>
+   =20
+  </div>
+  <div data-dc-tpl=3D"9" style=3D"font-size: 12px; color: rgb(138, 139, 153=
+); margin-top: 6px;"><span class=3D"sc-interp">5 invoices =C2=B7 QuickBooks=
+</span></div></div></div>
+    </div>
+    <div data-dc-tpl=3D"88" style=3D"font-size: 12px; color: rgb(138, 139, =
+153); margin-top: 14px; line-height: 1.5;">Props: <span data-dc-tpl=3D"89" =
+style=3D"font-family: &quot;Roboto Mono&quot;, monospace; color: rgb(110, 3=
+0, 200);">label =C2=B7 value =C2=B7 delta =C2=B7 tone(positive|neutral) =C2=
+=B7 sub</span></div>
+  </div>
+
+  <div data-dc-tpl=3D"90" style=3D"display: grid; grid-template-columns: 1f=
+r 1.4fr; gap: 18px; margin-bottom: 18px; align-items: start;">
+   =20
+    <div data-dc-tpl=3D"91" style=3D"background: rgb(255, 255, 255); border=
+: 1px solid rgb(233, 234, 240); border-radius: 14px; padding: 20px;">
+      <div data-dc-tpl=3D"92" style=3D"display: flex; align-items: center; =
+justify-content: space-between; margin-bottom: 16px;">
+        <div data-dc-tpl=3D"93" style=3D"font-size: 14px; font-weight: 600;=
+">Avatar</div>
+        <div data-dc-tpl=3D"94" style=3D"font-size: 11.5px; color: rgb(154,=
+ 155, 176); font-family: &quot;Roboto Mono&quot;, monospace;">Avatar</div>
+      </div>
+      <div data-dc-tpl=3D"95" style=3D"display: flex; align-items: flex-end=
+; gap: 14px;">
+        <div class=3D"sc-host" data-sc-name=3D"Avatar" data-dc-tpl=3D"96"><=
+div data-dc-tpl=3D"2" style=3D"border-radius: 50%; background: rgb(236, 238=
+, 244); color: rgb(74, 75, 88); display: flex; align-items: center; justify=
+-content: center; font-weight: 600; flex-shrink: 0; font-family: Montserrat=
+, sans-serif; width: 30px; height: 30px; font-size: 10px;"><span class=3D"s=
+c-interp">MT</span></div></div>
+        <div class=3D"sc-host" data-sc-name=3D"Avatar" data-dc-tpl=3D"97"><=
+div data-dc-tpl=3D"2" style=3D"border-radius: 50%; background: rgb(236, 238=
+, 244); color: rgb(74, 75, 88); display: flex; align-items: center; justify=
+-content: center; font-weight: 600; flex-shrink: 0; font-family: Montserrat=
+, sans-serif; width: 40px; height: 40px; font-size: 14px;"><span class=3D"s=
+c-interp">PA</span></div></div>
+        <div class=3D"sc-host" data-sc-name=3D"Avatar" data-dc-tpl=3D"98"><=
+div data-dc-tpl=3D"2" style=3D"border-radius: 50%; background: rgb(236, 238=
+, 244); color: rgb(74, 75, 88); display: flex; align-items: center; justify=
+-content: center; font-weight: 600; flex-shrink: 0; font-family: Montserrat=
+, sans-serif; width: 50px; height: 50px; font-size: 17px;"><span class=3D"s=
+c-interp">GK</span></div></div>
+        <div class=3D"sc-host" data-sc-name=3D"Avatar" data-dc-tpl=3D"99"><=
+div data-dc-tpl=3D"2" style=3D"border-radius: 50%; background: rgb(236, 238=
+, 244); color: rgb(74, 75, 88); display: flex; align-items: center; justify=
+-content: center; font-weight: 600; flex-shrink: 0; font-family: Montserrat=
+, sans-serif; width: 58px; height: 58px; font-size: 20px;"><span class=3D"s=
+c-interp">DW</span></div></div>
+      </div>
+      <div data-dc-tpl=3D"100" style=3D"font-size: 12px; color: rgb(138, 13=
+9, 153); margin-top: 14px; line-height: 1.5;">Props: <span data-dc-tpl=3D"1=
+01" style=3D"font-family: &quot;Roboto Mono&quot;, monospace; color: rgb(11=
+0, 30, 200);">initials =C2=B7 size</span></div>
+    </div>
+
+   =20
+    <div data-dc-tpl=3D"102" style=3D"background: rgb(255, 255, 255); borde=
+r: 1px solid rgb(233, 234, 240); border-radius: 14px; padding: 20px;">
+      <div data-dc-tpl=3D"103" style=3D"display: flex; align-items: center;=
+ justify-content: space-between; margin-bottom: 16px;">
+        <div data-dc-tpl=3D"104" style=3D"font-size: 14px; font-weight: 600=
+;">Primary button</div>
+        <div data-dc-tpl=3D"105" style=3D"font-size: 11.5px; color: rgb(154=
+, 155, 176); font-family: &quot;Roboto Mono&quot;, monospace;">recipe =C2=
+=B7 inline</div>
+      </div>
+      <div data-dc-tpl=3D"106" style=3D"display: flex; flex-wrap: wrap; gap=
+: 12px; align-items: center;">
+        <button data-dc-tpl=3D"107" class=3D"scp0" style=3D"display: flex; =
+align-items: center; gap: 8px; background: linear-gradient(135deg, rgb(30, =
+190, 250), rgb(110, 30, 200)); color: rgb(255, 255, 255); border-width: med=
+ium; border-style: none; border-color: currentcolor; border-image: initial;=
+ padding: 11px 16px; border-radius: 11px; font-family: inherit; font-size: =
+13.5px; font-weight: 600; cursor: pointer;">
+          <svg data-dc-tpl=3D"108" width=3D"16" height=3D"16" viewBox=3D"0 =
+0 24 24" fill=3D"none" stroke=3D"#fff" stroke-width=3D"2" stroke-linecap=3D=
+"round"><path data-dc-tpl=3D"109" d=3D"M12 5v14M5 12h14"></path></svg>
+          New job
+        </button>
+        <button data-dc-tpl=3D"110" class=3D"scp1" style=3D"background: rgb=
+(255, 255, 255); border: 1px solid rgb(236, 236, 242); color: rgb(58, 59, 7=
+2); padding: 11px 16px; border-radius: 11px; font-family: inherit; font-siz=
+e: 13.5px; font-weight: 600; cursor: pointer;">Secondary</button>
+      </div>
+      <div data-dc-tpl=3D"111" style=3D"font-size: 12px; color: rgb(138, 13=
+9, 153); margin-top: 14px; line-height: 1.5;">Primary actions use the gradi=
+ent at <span data-dc-tpl=3D"112" style=3D"font-family: &quot;Roboto Mono&qu=
+ot;, monospace; color: rgb(110, 30, 200);">11px radius</span>; secondary is=
+ white with a hairline border. Both stay inline =E2=80=94 no shared button =
+DC.</div>
+    </div>
+  </div></div></div></div></div>
+
+
+
+</body></html>
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: image/svg+xml
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://15b5e0f9-5329-43e0-8d6a-0aed95d8ce1a.claudeusercontent.com/v1/design/projects/15b5e0f9-5329-43e0-8d6a-0aed95d8ce1a/serve/assets/rivus-symbol-white.svg
+
+<svg xmlns=3D"http://www.w3.org/2000/svg" xmlns:xlink=3D"http://www.w3.org/=
+1999/xlink" viewBox=3D"107 119 285 261"><defs><radialGradient id=3D"a" cx=
+=3D"283.14" cy=3D"328.06" r=3D"245.61" gradientTransform=3D"translate(244.0=
+7 707.61) rotate(-126.22) scale(1 0.78)" gradientUnits=3D"userSpaceOnUse"><=
+stop offset=3D"0" stop-color=3D"#1ebefa"></stop><stop offset=3D"1" stop-col=
+or=3D"#6e1ec8"></stop></radialGradient></defs><title>Rivus Symbol RGB</titl=
+e><path fill=3D"#ffffff" d=3D"M356.7,317.35c30.8-33.33,38.66-82.42,20-125.0=
+6C358.55,150.78,319.65,125,275.19,125H153.38a40.09,40.09,0,0,0-40.09,40.09V=
+367.65a7.35,7.35,0,0,0,7.36,7.35h20a7.35,7.35,0,0,0,7.36-7.35V173.18a13.42,=
+13.42,0,0,1,13.42-13.42H275.19c31.33,0,58.55,18.72,71,48.85s6.44,63.68-15.3=
+8,85.49l-40.45,40.45a2.44,2.44,0,0,0,0,3.43l6.5,6.5a1.45,1.45,0,0,1-1,2.47h=
+-33.5a2.17,2.17,0,0,1-2.17-2.17v-33.5a1.45,1.45,0,0,1,2.47-1l6.74,6.74a2.42=
+,2.42,0,0,0,3.43,0l40.44-40.44c17.83-17.83,16.86-41.88,10-58.44-6.71-16.21-=
+22.87-33.52-48.09-33.52h-94a8.28,8.28,0,0,0-8.28,8.28V367.65a7.35,7.35,0,0,=
+0,7.35,7.35h20.05a7.36,7.36,0,0,0,7.36-7.35V223.43a4.08,4.08,0,0,1,4.08-4.0=
+8h63.47c7.4,0,13.42,3.7,16.42,10.56a22.6,22.6,0,0,1-4.19,23.4c-6.66,7.17-13=
+.81,14.8-18.46,19.62a4,4,0,0,1-5.69,0l-18-18c-5.56-5.56-12.76-3.42-12.76,4.=
+45V365.47a9.06,9.06,0,0,0,9.05,9.06H349.2a6.47,6.47,0,0,0,4.57-11L335.7,345=
+.4a4.07,4.07,0,0,1-.05-5.72Q344.67,330.35,356.7,317.35Z"></path></svg>
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: image/svg+xml
+Content-Transfer-Encoding: quoted-printable
+Content-Location: blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d8ce1a.claudeusercontent.com/63e7bcfe-ef7a-4e19-829b-2e64a93c4f81
+
+<svg xmlns=3D"http://www.w3.org/2000/svg" xmlns:xlink=3D"http://www.w3.org/=
+1999/xlink" viewBox=3D"58 194 383 111"><defs><radialGradient id=3D"a" cx=3D=
+"120" cy=3D"284.35" r=3D"108.07" gradientTransform=3D"matrix(-0.54, -0.73, =
+0.57, -0.42, 33.67, 488.31)" gradientUnits=3D"userSpaceOnUse"><stop offset=
+=3D"0" stop-color=3D"#1ebefa"></stop><stop offset=3D"1" stop-color=3D"#6e1e=
+c8"></stop></radialGradient></defs><title>Rivus Logo Horizontal Positive RG=
+B</title><path fill=3D"url(#a)" d=3D"M225.2,267.56h-8.67a.48.48,0,0,0-.48.4=
+8v11a2.3,2.3,0,0,1-2.3,2.3h-7.83a2.3,2.3,0,0,1-2.3-2.3V234.74a2.3,2.3,0,0,1=
+,2.3-2.3h19.56c12.92,0,20.32,6.14,20.32,17,0,7.33-3,12.64-8.55,15.54a.33.33=
+,0,0,0-.13.47l8.55,13.44a1.55,1.55,0,0,1-1.31,2.39H235a3.19,3.19,0,0,1-2.83=
+-1.71l-6.07-11.49A1,1,0,0,0,225.2,267.56Zm.28-9.77c5.37,0,8.52-2.73,8.52-7.=
+89s-3.15-7.69-8.52-7.69h-8.95a.48.48,0,0,0-.48.48v14.62a.48.48,0,0,0,.48.48=
+Z"></path><path fill=3D"url(#a)" d=3D"M258.71,279V234.74a2.3,2.3,0,0,1,2.3-=
+2.3h7.83a2.3,2.3,0,0,1,2.3,2.3V279a2.3,2.3,0,0,1-2.3,2.3H261A2.3,2.3,0,0,1,=
+258.71,279Z"></path><path fill=3D"url(#a)" d=3D"M298.15,279,281,234.87a1.78=
+,1.78,0,0,1,1.66-2.43h8.65a2.87,2.87,0,0,1,2.69,1.89l11.61,32.31a.22.22,0,0=
+,0,.41,0l11.62-32.31a2.84,2.84,0,0,1,2.69-1.89h8.15a1.79,1.79,0,0,1,1.66,2.=
+44L312.85,279a3.72,3.72,0,0,1-3.46,2.36h-7.77A3.72,3.72,0,0,1,298.15,279Z">=
+</path><path fill=3D"url(#a)" d=3D"M384.6,260.79c0,12.92-8.59,21.09-22.28,2=
+1.09s-22.56-8.17-22.56-21.09V234.74a2.3,2.3,0,0,1,2.3-2.3h7.83a2.3,2.3,0,0,=
+1,2.3,2.3v26.05c0,6.63,4.26,10.68,10.2,10.68s9.85-4.05,9.85-10.68V234.74a2.=
+3,2.3,0,0,1,2.3-2.3h7.75a2.3,2.3,0,0,1,2.31,2.3Z"></path><path fill=3D"url(=
+#a)" d=3D"M435.07,239.23l-2.72,5.64a2.29,2.29,0,0,1-3.09,1.06c-4.74-2.4-10.=
+12-4-13.59-4-3.22,0-5.38,1.18-5.38,3.56,0,8.45,25.84,3.63,25.84,21.3,0,9.77=
+-8.66,14.94-19.56,14.94a36.74,36.74,0,0,1-20.82-6.66,2.26,2.26,0,0,1-.66-2.=
+87l2.7-5.36a2.27,2.27,0,0,1,3.35-.85c4.87,3.47,11.14,5.68,15.57,5.68,3.91,0=
+,6.36-1.46,6.36-4.26,0-8.66-25.84-3.49-25.84-20.81,0-9,7.75-14.73,19.48-14.=
+73A37.56,37.56,0,0,1,434,236.17,2.34,2.34,0,0,1,435.07,239.23Z"></path><pat=
+h class=3D"b" d=3D"M161.24,276.94a46.28,46.28,0,0,0,8-50C162,210.31,146.42,=
+200,128.64,200H79.91a16,16,0,0,0-16,16v81A3,3,0,0,0,66.82,300h8a2.94,2.94,0=
+,0,0,2.94-2.94V219.27a5.37,5.37,0,0,1,5.37-5.37h45.49c12.53,0,23.42,7.49,28=
+.41,19.54s2.57,25.47-6.16,34.2l-16.17,16.18a1,1,0,0,0,0,1.37l2.6,2.6a.58.58=
+,0,0,1-.41,1h-13.4a.87.87,0,0,1-.87-.87v-13.4a.58.58,0,0,1,1-.41l2.69,2.7a1=
+,1,0,0,0,1.37,0l16.18-16.18c7.13-7.13,6.74-16.75,4-23.38s-9.15-13.4-19.23-1=
+3.4H91a3.31,3.31,0,0,0-3.31,3.31v69.91A2.94,2.94,0,0,0,90.65,300h8a2.94,2.9=
+4,0,0,0,2.94-2.94V239.37a1.64,1.64,0,0,1,1.64-1.63h25.39A6.84,6.84,0,0,1,13=
+5.2,242a9,9,0,0,1-1.67,9.36c-2.67,2.87-5.53,5.92-7.39,7.85a1.58,1.58,0,0,1-=
+2.27,0L116.65,252c-2.22-2.23-5.1-1.37-5.1,1.77v42.44a3.62,3.62,0,0,0,3.62,3=
+.62h43.07a2.59,2.59,0,0,0,1.83-4.42l-7.23-7.23a1.63,1.63,0,0,1,0-2.29Q156.4=
+2,282.15,161.24,276.94Z"></path></svg>
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://fonts.googleapis.com/css2?family=Montserrat:wght@600&display=swap
+
+@charset "utf-8";
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w0aXp-p7K4KLjztg.woff2") format("woff2=
+"); unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F=
+, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w9aXp-p7K4KLjztg.woff2") format("woff2=
+"); unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w2aXp-p7K4KLjztg.woff2") format("woff2=
+"); unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U=
++1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20A=
+B; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w3aXp-p7K4KLjztg.woff2") format("woff2=
+"); unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U=
++304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-2=
+0AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu173w5aXp-p7K4KLg.woff2") format("woff2");=
+ unicode-range: U+0-FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U=
++304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+=
+2215, U+FEFF, U+FFFD; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600&display=swap
+
+@charset "utf-8";
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 400;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WRhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 400;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459W1hyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 400;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WZhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301,=
+ U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 400;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WdhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, =
+U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+=
+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 400;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WlhyyTh89Y.woff2") format("woff2"); unicode-range: U+0-=
+FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, =
+U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD=
+; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WRhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459W1hyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WZhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301,=
+ U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WdhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, =
+U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+=
+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WlhyyTh89Y.woff2") format("woff2"); unicode-range: U+0-=
+FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, =
+U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD=
+; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WRhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459W1hyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WZhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301,=
+ U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WdhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, =
+U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+=
+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WlhyyTh89Y.woff2") format("woff2"); unicode-range: U+0-=
+FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, =
+U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD=
+; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://fonts.googleapis.com/css2?family=Montserrat:wght@500;600&display=swap
+
+@charset "utf-8";
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WRhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459W1hyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WZhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301,=
+ U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WdhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, =
+U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+=
+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WlhyyTh89Y.woff2") format("woff2"); unicode-range: U+0-=
+FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, =
+U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD=
+; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WRhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459W1hyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WZhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301,=
+ U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WdhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, =
+U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+=
+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WlhyyTh89Y.woff2") format("woff2"); unicode-range: U+0-=
+FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, =
+U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD=
+; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://fonts.googleapis.com/css2?family=Montserrat:wght@500;600;700&display=swap
+
+@charset "utf-8";
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WRhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459W1hyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WZhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301,=
+ U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WdhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, =
+U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+=
+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WlhyyTh89Y.woff2") format("woff2"); unicode-range: U+0-=
+FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, =
+U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD=
+; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WRhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459W1hyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WZhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301,=
+ U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WdhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, =
+U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+=
+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WlhyyTh89Y.woff2") format("woff2"); unicode-range: U+0-=
+FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, =
+U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD=
+; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 700;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WRhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 700;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459W1hyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 700;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WZhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++102-103, U+110-111, U+128-129, U+168-169, U+1A0-1A1, U+1AF-1B0, U+300-301,=
+ U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 700;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WdhyyTh89ZNpQ.woff2") format("woff2"); unicode-range: U=
++100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2FF, U+304, U+308, U+329, =
+U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+=
+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 700;=
+ font-display: swap; src: url("https://fonts.gstatic.com/s/montserrat/v31/J=
+TUSjIg1_i6t8kCHKm459WlhyyTh89Y.woff2") format("woff2"); unicode-range: U+0-=
+FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, U+2DC, U+304, U+308, U+329, =
+U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD=
+; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: cid:css-aedb1fcb-ae22-4ab0-8b88-cbaab0069f8a@mhtml.blink
+
+@charset "utf-8";
+=0A
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: cid:css-864c9c22-cb8a-4d97-93d6-a99d7ab93872@mhtml.blink
+
+@charset "utf-8";
+
+* { box-sizing: border-box; }
+
+body { margin: 0px; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: cid:css-ddfcec38-1c34-4cf8-ae61-8d19c3e77e18@mhtml.blink
+
+@charset "utf-8";
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 300;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/a1ffc0e3-bc2e-418a-b69f-2198a1fa43b2") format("=
+woff2"); unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640=
+-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 300;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/6d14da53-bf51-408e-b73c-e77632188f9d") format("=
+woff2"); unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 300;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/62871b1a-9b73-4ae4-8a8b-6a28d00ed574") format("=
+woff2"); unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1=
+A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, =
+U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 300;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/a072022d-f89f-413a-a4f5-3dabe3873eba") format("=
+woff2"); unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2=
+FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+2=
+0A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 300;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/999cba38-f4aa-4047-b9af-a5a1e22eac0a") format("=
+woff2"); unicode-range: U+0-FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, =
+U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+=
+2212, U+2215, U+FEFF, U+FFFD; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 400;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/a1ffc0e3-bc2e-418a-b69f-2198a1fa43b2") format("=
+woff2"); unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640=
+-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 400;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/6d14da53-bf51-408e-b73c-e77632188f9d") format("=
+woff2"); unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 400;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/62871b1a-9b73-4ae4-8a8b-6a28d00ed574") format("=
+woff2"); unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1=
+A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, =
+U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 400;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/a072022d-f89f-413a-a4f5-3dabe3873eba") format("=
+woff2"); unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2=
+FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+2=
+0A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 400;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/999cba38-f4aa-4047-b9af-a5a1e22eac0a") format("=
+woff2"); unicode-range: U+0-FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, =
+U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+=
+2212, U+2215, U+FEFF, U+FFFD; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/a1ffc0e3-bc2e-418a-b69f-2198a1fa43b2") format("=
+woff2"); unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640=
+-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/6d14da53-bf51-408e-b73c-e77632188f9d") format("=
+woff2"); unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/62871b1a-9b73-4ae4-8a8b-6a28d00ed574") format("=
+woff2"); unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1=
+A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, =
+U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/a072022d-f89f-413a-a4f5-3dabe3873eba") format("=
+woff2"); unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2=
+FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+2=
+0A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 500;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/999cba38-f4aa-4047-b9af-a5a1e22eac0a") format("=
+woff2"); unicode-range: U+0-FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, =
+U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+=
+2212, U+2215, U+FEFF, U+FFFD; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/a1ffc0e3-bc2e-418a-b69f-2198a1fa43b2") format("=
+woff2"); unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640=
+-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/6d14da53-bf51-408e-b73c-e77632188f9d") format("=
+woff2"); unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/62871b1a-9b73-4ae4-8a8b-6a28d00ed574") format("=
+woff2"); unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1=
+A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, =
+U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/a072022d-f89f-413a-a4f5-3dabe3873eba") format("=
+woff2"); unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2=
+FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+2=
+0A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 600;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/999cba38-f4aa-4047-b9af-a5a1e22eac0a") format("=
+woff2"); unicode-range: U+0-FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, =
+U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+=
+2212, U+2215, U+FEFF, U+FFFD; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 700;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/a1ffc0e3-bc2e-418a-b69f-2198a1fa43b2") format("=
+woff2"); unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640=
+-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 700;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/6d14da53-bf51-408e-b73c-e77632188f9d") format("=
+woff2"); unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 700;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/62871b1a-9b73-4ae4-8a8b-6a28d00ed574") format("=
+woff2"); unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A0-1=
+A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF9, =
+U+20AB; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 700;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/a072022d-f89f-413a-a4f5-3dabe3873eba") format("=
+woff2"); unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2DD-2=
+FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+2=
+0A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: Montserrat; font-style: normal; font-weight: 700;=
+ font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed95d=
+8ce1a.claudeusercontent.com/999cba38-f4aa-4047-b9af-a5a1e22eac0a") format("=
+woff2"); unicode-range: U+0-FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2DA, =
+U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+=
+2212, U+2215, U+FEFF, U+FFFD; }
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 4=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/1a19e45b-8075-4a1e-b93d-b32126e63ba6") forma=
+t("woff2"); unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A=
+640-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 4=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/7a4daf96-e6f7-4023-9645-e69e7800c523") forma=
+t("woff2"); unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; =
+}
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 4=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/c41a93c6-a7fc-48c5-abd1-7d157d77b91c") forma=
+t("woff2"); unicode-range: U+370-377, U+37A-37F, U+384-38A, U+38C, U+38E-3A=
+1, U+3A3-3FF; }
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 4=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/ba3dd8d5-d3ca-49dd-a2a2-5c012226491f") forma=
+t("woff2"); unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A=
+0-1A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF=
+9, U+20AB; }
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 4=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/517f7d47-12a4-459e-8d21-271288f26308") forma=
+t("woff2"); unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2D=
+D-2FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, =
+U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 4=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/5d3d0ed6-80f3-4ca1-9ece-5d7d59954128") forma=
+t("woff2"); unicode-range: U+0-FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2D=
+A, U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,=
+ U+2212, U+2215, U+FEFF, U+FFFD; }
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 5=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/1a19e45b-8075-4a1e-b93d-b32126e63ba6") forma=
+t("woff2"); unicode-range: U+460-52F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A=
+640-A69F, U+FE2E-FE2F; }
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 5=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/7a4daf96-e6f7-4023-9645-e69e7800c523") forma=
+t("woff2"); unicode-range: U+301, U+400-45F, U+490-491, U+4B0-4B1, U+2116; =
+}
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 5=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/c41a93c6-a7fc-48c5-abd1-7d157d77b91c") forma=
+t("woff2"); unicode-range: U+370-377, U+37A-37F, U+384-38A, U+38C, U+38E-3A=
+1, U+3A3-3FF; }
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 5=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/ba3dd8d5-d3ca-49dd-a2a2-5c012226491f") forma=
+t("woff2"); unicode-range: U+102-103, U+110-111, U+128-129, U+168-169, U+1A=
+0-1A1, U+1AF-1B0, U+300-301, U+303-304, U+308-309, U+323, U+329, U+1EA0-1EF=
+9, U+20AB; }
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 5=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/517f7d47-12a4-459e-8d21-271288f26308") forma=
+t("woff2"); unicode-range: U+100-2BA, U+2BD-2C5, U+2C7-2CC, U+2CE-2D7, U+2D=
+D-2FF, U+304, U+308, U+329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, =
+U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF; }
+
+@font-face { font-family: "Roboto Mono"; font-style: normal; font-weight: 5=
+00; font-display: swap; src: url("blob:https://15b5e0f9-5329-43e0-8d6a-0aed=
+95d8ce1a.claudeusercontent.com/5d3d0ed6-80f3-4ca1-9ece-5d7d59954128") forma=
+t("woff2"); unicode-range: U+0-FF, U+131, U+152-153, U+2BB-2BC, U+2C6, U+2D=
+A, U+2DC, U+304, U+308, U+329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193,=
+ U+2212, U+2215, U+FEFF, U+FFFD; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: cid:css-a36257f3-c259-440b-a8c7-32b141fda2c6@mhtml.blink
+
+@charset "utf-8";
+
+html, body { height: 100%; margin: 0px; }
+
+#dc-root, #dc-root > .sc-host { height: 100%; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: cid:css-12fecc26-cc94-4f75-bd8c-ca6da7e6677e@mhtml.blink
+
+@charset "utf-8";
+
+.scp0:hover { filter: brightness(1.06); }
+
+.scp1:hover { background: rgb(243, 244, 248); }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: cid:css-776974b1-ed17-4d00-9fe3-0610e93ec548@mhtml.blink
+
+@charset "utf-8";
+
+x-dc { display: none !important; }
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: cid:css-3026d320-2ccd-45b2-8578-52c5f7e34245@mhtml.blink
+
+@charset "utf-8";
+
+.sc-placeholder { background: rgba(255, 255, 255, 0.3); border: 1px solid r=
+gba(0, 0, 0, 0.5); border-radius: 2px; box-sizing: border-box; overflow: hi=
+dden; }
+
+@keyframes sc-shine {=20
+  0% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+html.sc-dc-streaming .sc-placeholder, html.sc-dc-streaming .sc-interp.sc-mi=
+ssing { position: relative; background: color-mix(in srgb, currentcolor 5%,=
+ transparent); border-color: transparent; }
+
+html.sc-dc-streaming .sc-placeholder::before, html.sc-dc-streaming .sc-inte=
+rp.sc-missing::before { content: ""; position: absolute; inset: 0px; pointe=
+r-events: none; background: linear-gradient(90deg, rgba(217, 119, 87, 0) 25=
+%, rgba(247, 225, 211, 0.95) 37%, rgba(217, 119, 87, 0) 63%) 0% 0% / 400% 1=
+00%; animation: 1.4s ease 0s infinite normal none running sc-shine; }
+
+html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::bef=
+ore, html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp=
+.sc-missing)::before { animation: auto ease 0s 1 normal none running none; =
+background: color-mix(in srgb, currentcolor 8%, transparent); }
+
+.sc-placeholder-error { padding: 4px 8px; font: 11px / 1.4 ui-monospace, mo=
+nospace; color: rgba(0, 0, 0, 0.7); word-break: break-word; }
+
+.sc-interp.sc-missing { display: inline-block; width: 2em; height: 1em; ove=
+rflow: hidden; vertical-align: text-bottom; background: rgba(255, 255, 255,=
+ 0.3); border: 1px solid rgba(0, 0, 0, 0.5); border-radius: 2px; box-sizing=
+: border-box; color: transparent; user-select: none; }
+
+.sc-interp.sc-unresolved { font-family: ui-monospace, monospace; font-size:=
+ 0.85em; color: rgba(0, 0, 0, 0.5); background: rgba(0, 0, 0, 0.05); border=
+-radius: 3px; padding: 0px 3px; }
+
+.sc-host.sc-has-error { position: relative; }
+
+.sc-logic-error { position: absolute; top: 8px; left: 8px; z-index: 2147483=
+647; max-width: 60ch; padding: 6px 10px; background: rgb(176, 0, 32); color=
+: rgb(255, 255, 255); font: 12px / 1.4 ui-monospace, monospace; border-radi=
+us: 4px; white-space: pre-wrap; pointer-events: none; }
+
+@media print {
+  @page { margin: 0.5cm; }
+  figure, table { break-inside: avoid; }
+  #dc-root, #dc-root > .sc-host { height: auto; }
+  *, ::before, ::after { print-color-adjust: exact; backdrop-filter: none !=
+important; animation-delay: -99s !important; animation-duration: 0.001s !im=
+portant; animation-iteration-count: 1 !important; animation-fill-mode: both=
+ !important; animation-play-state: running !important; transition-duration:=
+ 0s !important; }
+}
+------MultipartBoundary--mC9QAOBwXWLTUvTBCX0tQbvlUFAGZAXz5ckf67SB2L------


### PR DESCRIPTION
## What

Adds the **Rivus design system** to the repo root and makes it the canonical reference for every user-facing surface.

## Changes

- **`DESIGN_SYSTEM.md`** — a clean, agent- and human-usable spec extracted from the uploaded design system:
  - **Color** tokens (Brand, Surfaces, Status, Text) with hex values
  - **Typography** scale (Montserrat, weights 400/500/600) with sizes, weights, and letter-spacing
  - **Signature gradient** (`linear-gradient(135deg, #1ebefa, #6e1ec8)`) and its one-job usage rule
  - **Radius** scale and elevation/focus notes
  - **Components** with their props: `BriefingBanner`, `RivusPill`, `StatusBadge`, `MetricCard`, `Avatar`, primary/secondary buttons
- **`Rivus-Design-System.mhtml`** — the original interactive reference, preserved in root. Excluded from the `@rivus/api` Docker build context via `.dockerignore` (it's a visual reference; `DESIGN_SYSTEM.md` is the spec).
- **`AGENTS.md`** — new **Design system** section requiring all UI (website, app, docs, and any visible surface) to follow `DESIGN_SYSTEM.md`: use its tokens and components, reserve the gradient for Rivus-the-agent, and add to the doc first when something's missing. Cross-referenced from the `website` and `app` package notes.
- **`CLAUDE.md`** — essentials bullet pointing at `DESIGN_SYSTEM.md`.

## Notes

No code or dependency changes — docs and a reference asset only, so the lint/type-check/test gates are unaffected. The `.mhtml` was parsed offline to extract exact token values (colors, type sizes/weights, gradients, radii) into the markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wG5rN9yzLYrk4bJdVRtKX

---
_Generated by [Claude Code](https://claude.ai/code/session_019wG5rN9yzLYrk4bJdVRtKX)_