### PR TITLE
feat(agent): JWT/cookie auth so the agent can answer from company + knowledge base

### DIFF
--- a/.github/workflows/deploy-development.yaml
+++ b/.github/workflows/deploy-development.yaml
@@ -35,10 +35,18 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # Shared with the API so the agent can verify its session tokens.
+      DEV_JWT_SECRET: ${{ secrets.DEV_JWT_SECRET }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm --filter @rivus/agent exec wrangler deploy --env development
+      # Keep the agent's JWT_SECRET in sync with the API. Skipped until the GitHub
+      # secret exists (until then the agent just treats every request as anonymous).
+      - name: Sync the shared JWT secret
+        if: ${{ env.DEV_JWT_SECRET != '' }}
+        run: |
+          printf '%s' "$DEV_JWT_SECRET" | pnpm --filter @rivus/agent exec wrangler secret put JWT_SECRET --env development
 
   deploy-docs:
     name: Deploy docs

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -39,10 +39,24 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # The agent verifies the API's session tokens, so it must share the same
+      # JWT_SECRET. Required in production — without it the agent treats every
+      # request as anonymous and authenticated chat never works.
+      PROD_JWT_SECRET: ${{ secrets.PROD_JWT_SECRET }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
+      - name: Require the shared JWT secret
+        run: |
+          if [ -z "$PROD_JWT_SECRET" ]; then
+            echo "::error::Set PROD_JWT_SECRET (the same value as the API) before deploying the agent."
+            exit 1
+          fi
       - run: pnpm --filter @rivus/agent exec wrangler deploy --env production
+      # Keep the agent's JWT_SECRET in sync with the API so it can verify tokens.
+      - name: Sync the shared JWT secret
+        run: |
+          printf '%s' "$PROD_JWT_SECRET" | pnpm --filter @rivus/agent exec wrangler secret put JWT_SECRET --env production
 
   deploy-docs:
     name: Deploy docs

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -5,11 +5,44 @@ A Cloudflare Agent is a **Durable Object** with conversation state built in, so
 each chat is its own addressable, stateful instance rather than a stateless
 function call.
 
-Right now the agent does exactly one thing on purpose: **it says hello.** That is
-the first milestone — proof that the app can reach the agent and get a reply all
-the way back. The reply logic is a single pure function (`replyTo`), so turning
-"hello" into a real model-backed assistant later means changing only that one
-place.
+It greets anyone who opens it, and — once a request is **authenticated** — it can
+answer from the signed-in user's own Rivus account: their company details (e.g.
+"what's our website?") and their knowledge base (search, update, and add FAQs).
+The reply logic is still a set of small, pure, unit-tested functions, so turning
+the deterministic understanding layer (`intent.ts`) into a real model-backed
+assistant later means changing only that one place.
+
+## Authentication
+
+The agent verifies the **same session JWT that `@rivus/api` issues**, so a user
+who is signed in to the Rivus app is recognised automatically. The token arrives
+either as an `Authorization: Bearer <jwt>` header (native app) or as the
+`rivus_session` HttpOnly cookie (web app). Verification is local (HMAC-SHA256 via
+Web Crypto) against the shared `JWT_SECRET`, so an unauthenticated caller gets a
+friendly nudge to sign in without any network round-trip.
+
+A valid signature only proves the token is ours and unexpired — it isn't the
+authority on live membership or permissions. So for anything that touches data,
+the agent **forwards the user's token to the Rivus API** (`RIVUS_API_URL`) and
+lets the API enforce tenancy (account scoping) and role permissions exactly as it
+does for the app. The agent orchestrates and formats; the API stays the single
+source of truth. Any `401`/`403` from the API is turned into a clear sentence.
+
+> **Web + cookies across subdomains.** For the browser to send the cookie to
+> `agent.rivus.ai`, the API must scope it to the shared parent domain — set
+> `COOKIE_DOMAIN=.rivus.ai` on `@rivus/api`. Native clients use the bearer token
+> and need no cookie.
+
+### Configuration
+
+| Binding          | Kind   | Example                | Purpose                                             |
+| ---------------- | ------ | ---------------------- | --------------------------------------------------- |
+| `JWT_SECRET`     | secret | (match the API)        | Verifies session tokens. `wrangler secret put JWT_SECRET`. |
+| `RIVUS_API_URL`  | var    | `https://api.rivus.ai` | The REST API the agent calls on the user's behalf.  |
+| `ALLOWED_ORIGINS`| var    | `https://app.rivus.ai` | Credentialed-CORS allowlist (`*` = any, dev only).  |
+
+`RIVUS_API_URL` and `ALLOWED_ORIGINS` are set per environment in `wrangler.jsonc`;
+`JWT_SECRET` is a deploy-time secret and must equal the API's.
 
 ## How it fits together
 
@@ -48,13 +81,17 @@ each gets its own isolated state.
 
 ## Source layout
 
-| File                | Runtime?            | Role                                                          |
-| ------------------- | ------------------- | ------------------------------------------------------------ |
-| `src/conversation.ts` | pure (Node)       | `replyTo(messages)` — the greeting logic. The heart of the agent. |
+| File                  | Runtime?          | Role                                                          |
+| --------------------- | ----------------- | ------------------------------------------------------------ |
+| `src/conversation.ts` | pure (Node)       | `replyTo(messages)` — the greeting logic.                    |
+| `src/auth.ts`         | pure (Node)       | Extract + verify the session JWT (bearer or cookie, HS256).  |
+| `src/intent.ts`       | pure (Node)       | `parseIntent(text)` — deterministic understanding layer.     |
+| `src/api.ts`          | pure (Node)       | Rivus API client the agent calls on the user's behalf.       |
+| `src/assistant.ts`    | pure (Node)       | `respond()` — verify session → intent → API → formatted reply. |
 | `src/http.ts`         | pure (Node)       | Request parsing, CORS, and `handleChat` / `handlePublicRoute`. |
 | `src/agent.ts`        | Workers runtime   | `RivusAgent` Durable Object — a thin adapter over the pure modules. |
 | `src/index.ts`        | Workers runtime   | Worker entrypoint: health/CORS + `routeAgentRequest`.        |
-| `src/types.ts`        | shared             | `Env`, `ChatMessage`, `ChatReply`, agent state.              |
+| `src/types.ts`        | shared            | `Env`, `SessionClaims`, `ChatMessage`, `ChatReply`, agent state. |
 
 The pure modules import nothing from the Agents SDK (which pulls in
 `cloudflare:workers`, unavailable under Node), which is what keeps the tests
@@ -78,11 +115,20 @@ curl http://localhost:8787/health
 curl http://localhost:8787/agents/rivus-agent/default
 # {"reply":"Hello! I'm Rivus, your AI assistant. 👋"}
 
-# POST a conversation, the way the app does.
+# POST a conversation, the way the app does. Without a session, Rivus greets and
+# nudges you to sign in.
 curl -X POST http://localhost:8787/agents/rivus-agent/default \
   -H 'content-type: application/json' \
   -d '{"messages":[{"role":"user","content":"hi"}]}'
-# {"reply":"Hello! I'm Rivus, your AI assistant. 👋"}
+# {"reply":"Hello! I'm Rivus, your AI assistant. 👋 Sign in to Rivus and I can …"}
+
+# Authenticated: forward a session token (the JWT the API issues) and ask about
+# your account. Requires JWT_SECRET (matching the API) and RIVUS_API_URL set.
+curl -X POST http://localhost:8787/agents/rivus-agent/default \
+  -H 'content-type: application/json' \
+  -H "authorization: Bearer $RIVUS_JWT" \
+  -d '{"messages":[{"role":"user","content":"what is our website?"}]}'
+# {"reply":"Your website is https://acme.example."}
 ```
 
 To see it end-to-end from the app, run the agent (`pnpm --filter @rivus/agent
@@ -123,13 +169,16 @@ Object. The named environments map to `dev-agent.rivus.ai` and `agent.rivus.ai`
 
 ## Extending it
 
-When you're ready for the agent to do more than greet:
-
-- Put the real logic in `replyTo` (or call a model from `onRequest` and keep
-  `replyTo` as the fallback). The app and the routing don't change.
-- Use the Durable Object's state/SQL (`this.state`, `this.setState`, `this.sql`)
-  to remember the conversation. `messagesSeen` is already wired as a starting
-  point.
-- For streaming/token-by-token replies, switch the app to the Agents SDK's
+- **Smarter understanding.** `parseIntent` is deterministic on purpose (testable,
+  predictable). To make it model-backed, replace just that function — `assistant.ts`
+  consumes the same `Intent` shape, and the app and routing don't change.
+- **More capabilities.** `assistant.ts` already calls the API for company context
+  and FAQ search/update/create; add a new API method in `api.ts` and a branch in
+  `respond` to cover more (customers, items, …). Permissions come for free — the
+  API enforces them and the agent surfaces any `403`.
+- **Memory.** Use the Durable Object's state/SQL (`this.state`, `this.setState`,
+  `this.sql`) to remember the conversation. `messagesSeen` is already wired as a
+  starting point.
+- **Streaming.** For token-by-token replies, switch the app to the Agents SDK's
   WebSocket client (`agents/react`) — the same `/agents/rivus-agent/:name`
   endpoint already supports it.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -16,6 +16,7 @@
 		"clean": "rm -rf dist coverage .wrangler"
 	},
 	"dependencies": {
+		"@rivus/core": "workspace:*",
 		"agents": "^0.16.1",
 		"zod": "catalog:"
 	},

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -19,6 +19,8 @@ export class RivusAgent extends Agent<Env, RivusAgentState> {
 		if (request.method === 'POST') {
 			this.setState({ messagesSeen: this.state.messagesSeen + 1 });
 		}
-		return handleChat(request);
+		// `this.env` carries the Worker bindings/secrets (JWT_SECRET, RIVUS_API_URL,
+		// ALLOWED_ORIGINS) so the chat handler can authenticate and call the API.
+		return handleChat(request, this.env);
 	}
 }

--- a/packages/agent/src/api.test.ts
+++ b/packages/agent/src/api.test.ts
@@ -124,6 +124,21 @@ describe('createRivusApiClient', () => {
 		expect(nthCall(fetch, 0).init?.method).toBe('POST');
 	});
 
+	it('checks for a similar FAQ before creating', async () => {
+		const fetch = vi
+			.fn<typeof globalThis.fetch>()
+			.mockResolvedValue(jsonResponse({ match: faq, reason: 'same topic', merged: null }));
+		const client = createRivusApiClient(BASE, TOKEN, fetch);
+
+		const result = await client.findSimilarFaq({ question: 'Do you offer refunds?' });
+		expect(result.match?.id).toBe('faq_1');
+		const { url, init } = nthCall(fetch, 0);
+		expect(url).toBe(`${BASE}/v1/faqs/similar`);
+		expect(init?.method).toBe('POST');
+		// The optional answer defaults to an empty string on the wire.
+		expect(init?.body).toBe(JSON.stringify({ question: 'Do you offer refunds?', answer: '' }));
+	});
+
 	it('throws AgentApiError carrying the status and API message on non-2xx', async () => {
 		const fetch = vi
 			.fn<typeof globalThis.fetch>()

--- a/packages/agent/src/api.test.ts
+++ b/packages/agent/src/api.test.ts
@@ -1,0 +1,166 @@
+import type { FaqId } from '@rivus/core';
+import { describe, expect, it, vi } from 'vitest';
+import { AgentApiError, createRivusApiClient } from './api';
+
+const BASE = 'https://api.test';
+const TOKEN = 'header.jwt.signature';
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'content-type': 'application/json' },
+	});
+}
+
+/** The url + init of the nth recorded fetch call (throws if it wasn't made). */
+function nthCall(
+	mock: { mock: { calls: ReadonlyArray<readonly unknown[]> } },
+	n: number,
+): { url: string; init: RequestInit | undefined } {
+	const call = mock.mock.calls[n];
+	if (!call) {
+		throw new Error(`expected fetch call #${n}`);
+	}
+	return { url: String(call[0]), init: call[1] as RequestInit | undefined };
+}
+
+const account = {
+	id: 'acct_1',
+	name: 'Acme Plumbing',
+	slug: 'acme-plumbing',
+	phone: '+1 206 555 0100',
+	address: '1 Main St',
+	website: 'https://acme.example',
+	timezone: 'America/Los_Angeles',
+	status: 'active' as const,
+	canceledAt: null,
+	createdAt: '2026-01-01T00:00:00.000Z',
+	updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const session = {
+	user: {
+		id: 'user_1',
+		email: 'owner@acme.example',
+		name: 'Pat Owner',
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+	},
+	account,
+	role: 'owner' as const,
+};
+
+const faq = {
+	id: 'faq_1',
+	accountId: 'acct_1',
+	question: 'Do you offer refunds?',
+	answer: 'Yes, within 30 days.',
+	category: 'Billing',
+	status: 'published' as const,
+	createdAt: '2026-01-01T00:00:00.000Z',
+	updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('createRivusApiClient', () => {
+	it('fetches the session, forwarding the bearer token', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(jsonResponse(session));
+		const client = createRivusApiClient(BASE, TOKEN, fetch);
+
+		expect(await client.me()).toEqual(session);
+		const { url, init } = nthCall(fetch, 0);
+		expect(url).toBe(`${BASE}/v1/auth/me`);
+		expect(init?.method).toBe('GET');
+		expect((init?.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+	});
+
+	it('normalizes a trailing slash on the base URL', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(jsonResponse(session));
+		const client = createRivusApiClient(`${BASE}/`, TOKEN, fetch);
+		await client.me();
+		expect(nthCall(fetch, 0).url).toBe(`${BASE}/v1/auth/me`);
+	});
+
+	it('lists FAQs with default and explicit pagination', async () => {
+		const page = { data: [faq], meta: pageMeta(1) };
+		// A fresh Response per call — a Response body can only be read once.
+		const fetch = vi
+			.fn<typeof globalThis.fetch>()
+			.mockImplementation(async () => jsonResponse(page));
+		const client = createRivusApiClient(BASE, TOKEN, fetch);
+
+		await client.listFaqs();
+		expect(nthCall(fetch, 0).url).toBe(`${BASE}/v1/faqs?page=1&pageSize=20`);
+
+		await client.listFaqs({ page: 2, pageSize: 100 });
+		expect(nthCall(fetch, 1).url).toBe(`${BASE}/v1/faqs?page=2&pageSize=100`);
+	});
+
+	it('updates an FAQ with a JSON body and content-type', async () => {
+		const fetch = vi
+			.fn<typeof globalThis.fetch>()
+			.mockResolvedValue(jsonResponse({ ...faq, answer: 'Updated.' }));
+		const client = createRivusApiClient(BASE, TOKEN, fetch);
+
+		const updated = await client.updateFaq('faq_1' as FaqId, { answer: 'Updated.' });
+		expect(updated.answer).toBe('Updated.');
+		const { url, init } = nthCall(fetch, 0);
+		expect(url).toBe(`${BASE}/v1/faqs/faq_1`);
+		expect(init?.method).toBe('PATCH');
+		expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+		expect(init?.body).toBe(JSON.stringify({ answer: 'Updated.' }));
+	});
+
+	it('creates an FAQ', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(jsonResponse(faq, 201));
+		const client = createRivusApiClient(BASE, TOKEN, fetch);
+
+		const created = await client.createFaq({
+			question: 'Do you offer refunds?',
+			answer: 'Yes, within 30 days.',
+			category: '',
+			status: 'published',
+		});
+		expect(created.id).toBe('faq_1');
+		expect(nthCall(fetch, 0).init?.method).toBe('POST');
+	});
+
+	it('throws AgentApiError carrying the status and API message on non-2xx', async () => {
+		const fetch = vi
+			.fn<typeof globalThis.fetch>()
+			.mockResolvedValue(jsonResponse({ message: 'Insufficient permissions' }, 403));
+		const client = createRivusApiClient(BASE, TOKEN, fetch);
+
+		await expect(client.updateFaq('faq_1' as FaqId, { answer: 'x' })).rejects.toMatchObject({
+			name: 'AgentApiError',
+			status: 403,
+			message: 'Insufficient permissions',
+		});
+	});
+
+	it('falls back to a generic message when the error body has none', async () => {
+		const fetch = vi
+			.fn<typeof globalThis.fetch>()
+			.mockImplementation(async () => new Response('', { status: 500 }));
+		const client = createRivusApiClient(BASE, TOKEN, fetch);
+
+		await expect(client.me()).rejects.toBeInstanceOf(AgentApiError);
+		await expect(client.me()).rejects.toMatchObject({ status: 500 });
+	});
+
+	it('rejects a response that does not match the expected shape', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(jsonResponse({ nope: true }));
+		const client = createRivusApiClient(BASE, TOKEN, fetch);
+		await expect(client.me()).rejects.toThrow();
+	});
+});
+
+function pageMeta(total: number) {
+	return {
+		page: 1,
+		pageSize: 20,
+		total,
+		totalPages: 1,
+		hasNextPage: false,
+		hasPreviousPage: false,
+	};
+}

--- a/packages/agent/src/api.ts
+++ b/packages/agent/src/api.ts
@@ -1,0 +1,199 @@
+import type {
+	Account,
+	AccountId,
+	CreateFaqInput,
+	Faq,
+	FaqId,
+	Role,
+	UpdateFaqInput,
+	User,
+	UserId,
+} from '@rivus/core';
+import { z } from 'zod';
+
+/**
+ * The slice of the Rivus REST API the agent uses on a signed-in user's behalf.
+ *
+ * The agent never touches the database directly — all tenant data lives behind
+ * `@rivus/api`. So once a request is authenticated, the agent acts as a client
+ * of that API, forwarding the user's token as a bearer header. The API therefore
+ * stays the single source of truth and enforces tenancy (account scoping) and
+ * permissions (role checks) exactly as it does for the app; the agent just
+ * orchestrates and formats. Responses are Zod-validated so callers get trusted,
+ * well-typed data — mirroring the app's own API client.
+ */
+
+export type FetchLike = typeof globalThis.fetch;
+
+/** Error thrown for any non-2xx API response, carrying the HTTP status. */
+export class AgentApiError extends Error {
+	readonly status: number;
+
+	constructor(message: string, status: number) {
+		super(message);
+		this.name = 'AgentApiError';
+		this.status = status;
+	}
+}
+
+// `@rivus/core` brands its ids (a `FaqId` can't be passed where a `UserId` is
+// expected). The wire format is a plain string; this casts the string schema so
+// the *inferred* output keeps the brand, exactly as the app's API client does.
+const branded = <T>() => z.string().min(1) as unknown as z.ZodType<T>;
+
+const userSchema = z.object({
+	id: branded<UserId>(),
+	email: z.string(),
+	name: z.string(),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+}) satisfies z.ZodType<User>;
+
+const accountSchema = z.object({
+	id: branded<AccountId>(),
+	name: z.string(),
+	slug: z.string(),
+	phone: z.string(),
+	address: z.string(),
+	website: z.string(),
+	timezone: z.string(),
+	status: z.enum(['active', 'canceled']),
+	canceledAt: z.string().nullable(),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+}) satisfies z.ZodType<Account>;
+
+const roleSchemaLocal: z.ZodType<Role> = z.enum(['owner', 'manager', 'member']);
+
+const sessionSchema = z.object({
+	user: userSchema,
+	account: accountSchema,
+	role: roleSchemaLocal,
+});
+export type SessionView = z.infer<typeof sessionSchema>;
+
+const faqSchema = z.object({
+	id: branded<FaqId>(),
+	accountId: branded<AccountId>(),
+	question: z.string(),
+	answer: z.string(),
+	category: z.string(),
+	status: z.enum(['published', 'draft']),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+}) satisfies z.ZodType<Faq>;
+
+const paginationMetaSchema = z.object({
+	page: z.number().int(),
+	pageSize: z.number().int(),
+	total: z.number().int(),
+	totalPages: z.number().int(),
+	hasNextPage: z.boolean(),
+	hasPreviousPage: z.boolean(),
+});
+
+const faqListSchema = z.object({
+	data: z.array(faqSchema),
+	meta: paginationMetaSchema,
+});
+export type FaqListResult = z.infer<typeof faqListSchema>;
+
+const errorBodySchema = z.object({
+	error: z.string().optional(),
+	message: z.string().optional(),
+	statusCode: z.number().optional(),
+});
+
+/** Options for {@link RivusApiClient.listFaqs}. */
+export interface ListFaqsQuery {
+	page?: number;
+	pageSize?: number;
+}
+
+export interface RivusApiClient {
+	/** The current session: the user, their company, and their role. */
+	me(): Promise<SessionView>;
+	/** A page of the account's FAQs (the knowledge base). */
+	listFaqs(query?: ListFaqsQuery): Promise<FaqListResult>;
+	/** Apply a partial update to one FAQ. */
+	updateFaq(id: FaqId, patch: UpdateFaqInput): Promise<Faq>;
+	/** Create a new FAQ. */
+	createFaq(input: CreateFaqInput): Promise<Faq>;
+}
+
+/** Strip a single trailing slash so `${base}${path}` never doubles up. */
+function normalizeBaseUrl(baseUrl: string): string {
+	return baseUrl.replace(/\/+$/, '');
+}
+
+function safeJsonParse(raw: string): unknown {
+	try {
+		return JSON.parse(raw);
+	} catch {
+		return raw;
+	}
+}
+
+/**
+ * Build a Rivus API client bound to a signed-in user's bearer `token`. Every
+ * request carries `Authorization: Bearer <token>`, so the API authenticates and
+ * authorizes as if the user called it directly.
+ */
+export function createRivusApiClient(
+	baseUrl: string,
+	token: string,
+	fetchImpl: FetchLike = fetch,
+): RivusApiClient {
+	const root = normalizeBaseUrl(baseUrl);
+
+	async function request<T>(path: string, schema: z.ZodType<T>, init?: RequestInit): Promise<T> {
+		const response = await fetchImpl(`${root}${path}`, {
+			...init,
+			headers: {
+				Authorization: `Bearer ${token}`,
+				...(init?.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+				...init?.headers,
+			},
+		});
+		const raw = await response.text();
+		const body = raw.length > 0 ? safeJsonParse(raw) : undefined;
+
+		if (!response.ok) {
+			const parsed = errorBodySchema.safeParse(body);
+			const message =
+				(parsed.success && parsed.data.message) ||
+				`Rivus API request to ${path} failed with status ${response.status}`;
+			throw new AgentApiError(message, response.status);
+		}
+
+		return schema.parse(body);
+	}
+
+	return {
+		me() {
+			return request('/v1/auth/me', sessionSchema, { method: 'GET' });
+		},
+
+		listFaqs(query?: ListFaqsQuery) {
+			const search = new URLSearchParams({
+				page: String(query?.page ?? 1),
+				pageSize: String(query?.pageSize ?? 20),
+			});
+			return request(`/v1/faqs?${search.toString()}`, faqListSchema, { method: 'GET' });
+		},
+
+		updateFaq(id: FaqId, patch: UpdateFaqInput) {
+			return request(`/v1/faqs/${encodeURIComponent(id)}`, faqSchema, {
+				method: 'PATCH',
+				body: JSON.stringify(patch),
+			});
+		},
+
+		createFaq(input: CreateFaqInput) {
+			return request('/v1/faqs', faqSchema, {
+				method: 'POST',
+				body: JSON.stringify(input),
+			});
+		},
+	};
+}

--- a/packages/agent/src/api.ts
+++ b/packages/agent/src/api.ts
@@ -1,13 +1,15 @@
-import type {
-	Account,
-	AccountId,
-	CreateFaqInput,
-	Faq,
-	FaqId,
-	Role,
-	UpdateFaqInput,
-	User,
-	UserId,
+import {
+	type Account,
+	type AccountId,
+	accountStatusSchema,
+	type CreateFaqInput,
+	type Faq,
+	type FaqId,
+	faqStatusSchema,
+	roleSchema,
+	type UpdateFaqInput,
+	type User,
+	type UserId,
 } from '@rivus/core';
 import { z } from 'zod';
 
@@ -57,18 +59,17 @@ const accountSchema = z.object({
 	address: z.string(),
 	website: z.string(),
 	timezone: z.string(),
-	status: z.enum(['active', 'canceled']),
+	// Reuse the core enums so the agent never drifts from the API's source of truth.
+	status: accountStatusSchema,
 	canceledAt: z.string().nullable(),
 	createdAt: z.string(),
 	updatedAt: z.string(),
 }) satisfies z.ZodType<Account>;
 
-const roleSchemaLocal: z.ZodType<Role> = z.enum(['owner', 'manager', 'member']);
-
 const sessionSchema = z.object({
 	user: userSchema,
 	account: accountSchema,
-	role: roleSchemaLocal,
+	role: roleSchema,
 });
 export type SessionView = z.infer<typeof sessionSchema>;
 
@@ -78,7 +79,7 @@ const faqSchema = z.object({
 	question: z.string(),
 	answer: z.string(),
 	category: z.string(),
-	status: z.enum(['published', 'draft']),
+	status: faqStatusSchema,
 	createdAt: z.string(),
 	updatedAt: z.string(),
 }) satisfies z.ZodType<Faq>;

--- a/packages/agent/src/api.ts
+++ b/packages/agent/src/api.ts
@@ -99,6 +99,13 @@ const faqListSchema = z.object({
 });
 export type FaqListResult = z.infer<typeof faqListSchema>;
 
+const faqSimilaritySchema = z.object({
+	match: faqSchema.nullable(),
+	reason: z.string(),
+	merged: z.object({ question: z.string(), answer: z.string() }).nullable(),
+});
+export type FaqSimilarityResult = z.infer<typeof faqSimilaritySchema>;
+
 const errorBodySchema = z.object({
 	error: z.string().optional(),
 	message: z.string().optional(),
@@ -120,6 +127,12 @@ export interface RivusApiClient {
 	updateFaq(id: FaqId, patch: UpdateFaqInput): Promise<Faq>;
 	/** Create a new FAQ. */
 	createFaq(input: CreateFaqInput): Promise<Faq>;
+	/**
+	 * Ask whether a semantically similar FAQ already exists (AI-assisted), before
+	 * creating one. Returns `{ match: null }` when nothing similar is found — or
+	 * always, when the API has no AI provider configured.
+	 */
+	findSimilarFaq(input: { question: string; answer?: string }): Promise<FaqSimilarityResult>;
 }
 
 /** Strip a single trailing slash so `${base}${path}` never doubles up. */
@@ -194,6 +207,13 @@ export function createRivusApiClient(
 			return request('/v1/faqs', faqSchema, {
 				method: 'POST',
 				body: JSON.stringify(input),
+			});
+		},
+
+		findSimilarFaq(input: { question: string; answer?: string }) {
+			return request('/v1/faqs/similar', faqSimilaritySchema, {
+				method: 'POST',
+				body: JSON.stringify({ question: input.question, answer: input.answer ?? '' }),
 			});
 		},
 	};

--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -298,6 +298,15 @@ describe('respond — knowledge base reads', () => {
 		expect(reply).toContain('What are your HR policies?');
 	});
 
+	it('matches accented (non-ASCII) search terms', async () => {
+		const faqs = [makeFaq({ question: 'Café opening hours?', answer: 'We open at 8am.' })];
+		const reply = await ask('search faqs for café', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+		});
+		expect(reply).toContain('Café opening hours?');
+	});
+
 	it('says when a search finds nothing', async () => {
 		const reply = await ask('search faqs for skydiving', {
 			token: TOKEN,

--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -1,0 +1,461 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import type { FetchLike } from './api';
+import { respond } from './assistant';
+import { GREETING } from './conversation';
+import type { ChatMessage, Env } from './types';
+
+const SECRET = 'test-secret-value-1234';
+const API_URL = 'https://api.test';
+
+const encoder = new TextEncoder();
+
+function base64Url(bytes: Uint8Array): string {
+	let binary = '';
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function signToken(payload: Record<string, unknown>, secret = SECRET): Promise<string> {
+	const seg = (value: unknown) => base64Url(encoder.encode(JSON.stringify(value)));
+	const data = `${seg({ alg: 'HS256', typ: 'JWT' })}.${seg(payload)}`;
+	const key = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign'],
+	);
+	const signature = new Uint8Array(await crypto.subtle.sign('HMAC', key, encoder.encode(data)));
+	return `${data}.${base64Url(signature)}`;
+}
+
+let TOKEN: string;
+beforeAll(async () => {
+	TOKEN = await signToken({
+		sub: 'user_1',
+		email: 'owner@acme.example',
+		accountId: 'acct_1',
+		role: 'owner',
+		exp: Math.floor(Date.now() / 1000) + 3600,
+	});
+});
+
+const user = (content: string): ChatMessage => ({ role: 'user', content });
+
+function makeAccount(over: Partial<Record<string, string>> = {}) {
+	return {
+		id: 'acct_1',
+		name: 'Acme Plumbing',
+		slug: 'acme-plumbing',
+		phone: '+1 206 555 0100',
+		address: '1 Main St',
+		website: 'https://acme.example',
+		timezone: 'America/Los_Angeles',
+		status: 'active',
+		canceledAt: null,
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+		...over,
+	};
+}
+
+function sessionBody(account = makeAccount()) {
+	return {
+		user: {
+			id: 'user_1',
+			email: 'owner@acme.example',
+			name: 'Pat Owner',
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		},
+		account,
+		role: 'owner',
+	};
+}
+
+function makeFaq(over: Partial<Record<string, string>> = {}) {
+	return {
+		id: 'faq_1',
+		accountId: 'acct_1',
+		question: 'Do you offer refunds?',
+		answer: 'Yes, within 30 days.',
+		category: 'Billing',
+		status: 'published',
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+		...over,
+	};
+}
+
+function page(faqs: ReturnType<typeof makeFaq>[], total = faqs.length) {
+	return {
+		data: faqs,
+		meta: {
+			page: 1,
+			pageSize: 100,
+			total,
+			totalPages: 1,
+			hasNextPage: false,
+			hasPreviousPage: false,
+		},
+	};
+}
+
+interface Route {
+	when: (url: string, method: string) => boolean;
+	body: unknown;
+	status?: number;
+}
+
+/** A fetch that answers each call from the first matching route (fresh Response). */
+function router(routes: Route[]): FetchLike {
+	return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = String(input);
+		const method = init?.method ?? 'GET';
+		const route = routes.find((r) => r.when(url, method));
+		if (!route) {
+			throw new Error(`no mock route for ${method} ${url}`);
+		}
+		return new Response(JSON.stringify(route.body), {
+			status: route.status ?? 200,
+			headers: { 'content-type': 'application/json' },
+		});
+	}) as unknown as FetchLike;
+}
+
+const onGetMe: Route['when'] = (url, method) => method === 'GET' && url.endsWith('/v1/auth/me');
+const onListFaqs: Route['when'] = (url, method) => method === 'GET' && url.includes('/v1/faqs?');
+const onUpdateFaq: Route['when'] = (_url, method) => method === 'PATCH';
+const onCreateFaq: Route['when'] = (url, method) => method === 'POST' && url.endsWith('/v1/faqs');
+
+function envWith(over: Partial<Env> = {}): Env {
+	return { JWT_SECRET: SECRET, RIVUS_API_URL: API_URL, ...over } as unknown as Env;
+}
+
+function anonRequest(): Request {
+	return new Request('https://agent.test/chat', { method: 'POST' });
+}
+
+function authedRequest(token = TOKEN): Request {
+	return new Request('https://agent.test/chat', {
+		method: 'POST',
+		headers: { Authorization: `Bearer ${token}` },
+	});
+}
+
+/** Run respond with sensible defaults; pass a token to authenticate. */
+function ask(
+	content: string,
+	opts: { token?: string; fetchImpl?: FetchLike; env?: Env } = {},
+): Promise<string> {
+	return respond({
+		env: opts.env ?? envWith(),
+		request: opts.token ? authedRequest(opts.token) : anonRequest(),
+		messages: content === '' ? [] : [user(content)],
+		fetchImpl: opts.fetchImpl,
+	});
+}
+
+describe('respond — conversational', () => {
+	it('greets an anonymous caller and nudges them to sign in', async () => {
+		const reply = await ask('');
+		expect(reply).toContain(GREETING);
+		expect(reply).toMatch(/sign in/i);
+	});
+
+	it('greets a signed-in caller by email', async () => {
+		const reply = await ask('hi', { token: TOKEN });
+		expect(reply).toContain('owner@acme.example');
+	});
+
+	it('explains its capabilities for help', async () => {
+		const anon = await ask('what can you do?');
+		expect(anon).toMatch(/knowledge base/i);
+		expect(anon).toMatch(/sign in first/i);
+
+		const authed = await ask('help', { token: TOKEN });
+		expect(authed).toMatch(/company details/i);
+		expect(authed).not.toMatch(/sign in first/i);
+	});
+
+	it('handles an unrelated ask gracefully', async () => {
+		const anon = await ask('what is the meaning of life');
+		expect(anon).toContain(GREETING);
+
+		const authed = await ask('what is the meaning of life', { token: TOKEN });
+		expect(authed).toMatch(/not sure how to help/i);
+	});
+});
+
+describe('respond — auth gating', () => {
+	it('requires sign-in for protected asks', async () => {
+		const reply = await ask('what is our website?');
+		expect(reply).toMatch(/signed in/i);
+	});
+
+	it('reports when the API is not configured', async () => {
+		const reply = await ask('what is our website?', {
+			token: TOKEN,
+			env: envWith({ RIVUS_API_URL: undefined }),
+		});
+		expect(reply).toMatch(/fully configured/i);
+	});
+});
+
+describe('respond — company info', () => {
+	it('answers a specific field', async () => {
+		const reply = await ask('what is our website?', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onGetMe, body: sessionBody() }]),
+		});
+		expect(reply).toBe('Your website is https://acme.example.');
+	});
+
+	it('explains when a field is not set yet', async () => {
+		const reply = await ask('what is our website?', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onGetMe, body: sessionBody(makeAccount({ website: '' })) }]),
+		});
+		expect(reply).toMatch(/haven’t added a website/i);
+	});
+
+	it('summarizes the whole record for a generic ask, showing blanks', async () => {
+		const reply = await ask('tell me about my business', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onGetMe, body: sessionBody(makeAccount({ phone: '' })) }]),
+		});
+		expect(reply).toContain('Acme Plumbing');
+		expect(reply).toContain('Website: https://acme.example');
+		expect(reply).toContain('Phone: not set');
+	});
+});
+
+describe('respond — knowledge base reads', () => {
+	it('lists FAQs', async () => {
+		const faqs = [makeFaq(), makeFaq({ id: 'faq_2', question: 'Where are you located?' })];
+		const reply = await ask('list our faqs', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+		});
+		expect(reply).toContain('has 2 FAQs');
+		expect(reply).toContain('Do you offer refunds?');
+		expect(reply).toContain('Where are you located?');
+	});
+
+	it('uses the singular for a single FAQ', async () => {
+		const reply = await ask('show me the knowledge base', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page([makeFaq()]) }]),
+		});
+		expect(reply).toContain('has 1 FAQ:');
+	});
+
+	it('notes how many more FAQs exist beyond the first ten', async () => {
+		const faqs = Array.from({ length: 12 }, (_, i) =>
+			makeFaq({ id: `faq_${i}`, question: `Question ${i}?` }),
+		);
+		const reply = await ask('list faqs', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+		});
+		expect(reply).toMatch(/and 2 more/i);
+	});
+
+	it('reports an empty knowledge base', async () => {
+		const reply = await ask('list faqs', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page([]) }]),
+		});
+		expect(reply).toMatch(/knowledge base is empty/i);
+	});
+
+	it('searches and ranks by relevance', async () => {
+		const faqs = [
+			makeFaq({
+				id: 'faq_1',
+				question: 'What is your refund policy?',
+				answer: 'Refunds in 30 days.',
+			}),
+			makeFaq({ id: 'faq_2', question: 'Where are you located?', answer: 'Seattle.' }),
+		];
+		const reply = await ask('search the FAQ for refund', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+		});
+		expect(reply).toMatch(/found about “refund”/i);
+		expect(reply).toContain('What is your refund policy?');
+		expect(reply).not.toContain('Where are you located?');
+	});
+
+	it('falls back to a substring match for a short query', async () => {
+		const faqs = [makeFaq({ question: 'What are your HR policies?', answer: 'See the handbook.' })];
+		const reply = await ask('do we have an faq about hr', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+		});
+		expect(reply).toContain('What are your HR policies?');
+	});
+
+	it('says when a search finds nothing', async () => {
+		const reply = await ask('search faqs for skydiving', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page([makeFaq()]) }]),
+		});
+		expect(reply).toMatch(/couldn’t find anything/i);
+	});
+
+	it('truncates a very long answer in results', async () => {
+		const longAnswer = `${'x'.repeat(400)} END`;
+		const faqs = [makeFaq({ question: 'Refund policy?', answer: longAnswer })];
+		const reply = await ask('search faqs for refund', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+		});
+		expect(reply).toContain('…');
+		expect(reply).not.toContain('END');
+	});
+});
+
+describe('respond — knowledge base writes', () => {
+	it('updates a matched FAQ with a new answer', async () => {
+		const faqs = [makeFaq({ question: 'What is your return policy?' })];
+		const reply = await ask('update the faq about return to say we accept returns within 14 days', {
+			token: TOKEN,
+			fetchImpl: router([
+				{ when: onListFaqs, body: page(faqs) },
+				{
+					when: onUpdateFaq,
+					body: makeFaq({
+						question: 'What is your return policy?',
+						answer: 'we accept returns within 14 days',
+					}),
+				},
+			]),
+		});
+		expect(reply).toMatch(/Done — I updated/i);
+		expect(reply).toContain('we accept returns within 14 days');
+	});
+
+	it('asks what to change when only a topic is given', async () => {
+		const faqs = [makeFaq({ question: 'What is your return policy?', answer: 'Old answer.' })];
+		const reply = await ask('change the faq about return', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+		});
+		expect(reply).toMatch(/currently says/i);
+		expect(reply).toMatch(/what should the new answer be/i);
+	});
+
+	it('asks which FAQ when several match', async () => {
+		const faqs = [
+			makeFaq({ id: 'faq_1', question: 'What is your return policy?' }),
+			makeFaq({ id: 'faq_2', question: 'How do I start a return?' }),
+		];
+		const reply = await ask('update the faq about return to say see our policy page', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+		});
+		expect(reply).toMatch(/which one/i);
+		expect(reply).toContain('What is your return policy?');
+		expect(reply).toContain('How do I start a return?');
+	});
+
+	it('says when no FAQ matches the topic', async () => {
+		const reply = await ask('update the faq about parking to say there is none', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page([makeFaq()]) }]),
+		});
+		expect(reply).toMatch(/couldn’t find an FAQ about “parking”/i);
+	});
+
+	it('asks for a topic when an update names none', async () => {
+		const reply = await ask('update an faq', { token: TOKEN, fetchImpl: router([]) });
+		expect(reply).toMatch(/which faq should i update/i);
+	});
+
+	it('reports an empty knowledge base on update', async () => {
+		const reply = await ask('update the faq about return to say hello', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page([]) }]),
+		});
+		expect(reply).toMatch(/knowledge base is empty/i);
+	});
+
+	it('rejects an invalid (too long) answer before calling the API', async () => {
+		const faqs = [makeFaq({ question: 'What is your return policy?' })];
+		const huge = 'y'.repeat(4001);
+		const reply = await ask(`update the faq about return to say ${huge}`, {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+		});
+		expect(reply).toMatch(/4000 characters or fewer/i);
+	});
+
+	it('creates an FAQ from an explicit question and answer', async () => {
+		const reply = await ask('add an faq question: Do you ship? answer: Yes, nationwide.', {
+			token: TOKEN,
+			fetchImpl: router([
+				{
+					when: onCreateFaq,
+					body: makeFaq({ question: 'Do you ship?', answer: 'Yes, nationwide.' }),
+				},
+			]),
+		});
+		expect(reply).toMatch(/Added a new FAQ/i);
+		expect(reply).toContain('Do you ship?');
+	});
+
+	it('asks for the answer when only a question is given', async () => {
+		const reply = await ask('create a new faq about warranty', {
+			token: TOKEN,
+			fetchImpl: router([]),
+		});
+		expect(reply).toMatch(/what should the answer be/i);
+	});
+
+	it('asks for both parts when neither is given', async () => {
+		const reply = await ask('add a faq', { token: TOKEN, fetchImpl: router([]) });
+		expect(reply).toMatch(/what question should the FAQ answer/i);
+	});
+
+	it('rejects an invalid (too long) new question before calling the API', async () => {
+		const longQuestion = 'q'.repeat(301);
+		const reply = await ask(`add an faq question: ${longQuestion} answer: short`, {
+			token: TOKEN,
+			fetchImpl: router([]),
+		});
+		expect(reply).toMatch(/300 characters or fewer/i);
+	});
+});
+
+describe('respond — API error handling', () => {
+	it('explains an expired session (401)', async () => {
+		const reply = await ask('what is our website?', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onGetMe, body: { message: 'nope' }, status: 401 }]),
+		});
+		expect(reply).toMatch(/session looks like it expired/i);
+	});
+
+	it('explains a permission error (403)', async () => {
+		const faqs = [makeFaq({ question: 'What is your return policy?' })];
+		const reply = await ask('update the faq about return to say new answer', {
+			token: TOKEN,
+			fetchImpl: router([
+				{ when: onListFaqs, body: page(faqs) },
+				{ when: onUpdateFaq, body: { message: 'forbidden' }, status: 403 },
+			]),
+		});
+		expect(reply).toMatch(/don’t have permission/i);
+	});
+
+	it('handles an unexpected API failure (500)', async () => {
+		const reply = await ask('search faqs for refund', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onListFaqs, body: { message: 'boom' }, status: 500 }]),
+		});
+		expect(reply).toMatch(/couldn’t reach your Rivus data/i);
+	});
+});

--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -128,7 +128,12 @@ function router(routes: Route[]): FetchLike {
 const onGetMe: Route['when'] = (url, method) => method === 'GET' && url.endsWith('/v1/auth/me');
 const onListFaqs: Route['when'] = (url, method) => method === 'GET' && url.includes('/v1/faqs?');
 const onUpdateFaq: Route['when'] = (_url, method) => method === 'PATCH';
+const onSimilarFaq: Route['when'] = (url, method) =>
+	method === 'POST' && url.endsWith('/v1/faqs/similar');
 const onCreateFaq: Route['when'] = (url, method) => method === 'POST' && url.endsWith('/v1/faqs');
+
+/** The "no duplicate found" response from /v1/faqs/similar (the common case). */
+const noSimilarFaq = { match: null, reason: '', merged: null };
 
 function envWith(over: Partial<Env> = {}): Env {
 	return { JWT_SECRET: SECRET, RIVUS_API_URL: API_URL, ...over } as unknown as Env;
@@ -408,6 +413,7 @@ describe('respond — knowledge base writes', () => {
 		const reply = await ask('add an faq question: Do you ship? answer: Yes, nationwide.', {
 			token: TOKEN,
 			fetchImpl: router([
+				{ when: onSimilarFaq, body: noSimilarFaq },
 				{
 					when: onCreateFaq,
 					body: makeFaq({ question: 'Do you ship?', answer: 'Yes, nationwide.' }),
@@ -416,6 +422,19 @@ describe('respond — knowledge base writes', () => {
 		});
 		expect(reply).toMatch(/Added a new FAQ/i);
 		expect(reply).toContain('Do you ship?');
+	});
+
+	it('warns instead of creating a duplicate FAQ', async () => {
+		const existing = makeFaq({ question: 'Do you ship nationwide?', answer: 'Yes.' });
+		const reply = await ask('add an faq question: Do you ship? answer: Yes, nationwide.', {
+			token: TOKEN,
+			fetchImpl: router([
+				{ when: onSimilarFaq, body: { match: existing, reason: 'same topic', merged: null } },
+				// createFaq must NOT be called — there's no route for it, so a call would throw.
+			]),
+		});
+		expect(reply).toMatch(/looks a lot like an existing FAQ/i);
+		expect(reply).toContain('Do you ship nationwide?');
 	});
 
 	it('asks for the answer when only a question is given', async () => {

--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -354,7 +354,9 @@ describe('respond — knowledge base writes', () => {
 			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
 		});
 		expect(reply).toMatch(/currently says/i);
-		expect(reply).toMatch(/what should the new answer be/i);
+		// Stateless: it asks for the whole instruction in one message, not a follow-up.
+		expect(reply).toMatch(/in one message/i);
+		expect(reply).toMatch(/to say/i);
 	});
 
 	it('asks which FAQ when several match', async () => {
@@ -421,7 +423,27 @@ describe('respond — knowledge base writes', () => {
 			token: TOKEN,
 			fetchImpl: router([]),
 		});
-		expect(reply).toMatch(/what should the answer be/i);
+		expect(reply).toMatch(/in one message/i);
+		expect(reply).toMatch(/warranty/i);
+	});
+
+	it('searches every page of a large knowledge base before reporting a miss', async () => {
+		// Page 1 is full and signals more; the match lives on page 2. A single-page
+		// scan would wrongly report "nothing found".
+		const filler = Array.from({ length: 100 }, (_, i) =>
+			makeFaq({ id: `f${i}`, question: `Filler ${i}?`, answer: 'n/a' }),
+		);
+		const target = makeFaq({ id: 'target', question: 'What is your refund policy?', answer: 'X.' });
+		const firstPage = page(filler);
+		const fetchImpl = router([
+			{
+				when: (url, method) => method === 'GET' && url.includes('page=1'),
+				body: { data: filler, meta: { ...firstPage.meta, hasNextPage: true } },
+			},
+			{ when: (url, method) => method === 'GET' && url.includes('page=2'), body: page([target]) },
+		]);
+		const reply = await ask('search faqs for refund', { token: TOKEN, fetchImpl });
+		expect(reply).toContain('What is your refund policy?');
 	});
 
 	it('asks for both parts when neither is given', async () => {

--- a/packages/agent/src/assistant.ts
+++ b/packages/agent/src/assistant.ts
@@ -331,7 +331,9 @@ const STOPWORDS = new Set([
 
 /** Lowercased word tokens worth matching on (short/stopword tokens dropped). */
 function tokenize(value: string): string[] {
-	return (value.toLowerCase().match(/[a-z0-9]+/g) ?? []).filter(
+	// Unicode letter/number classes (not ASCII-only ranges) so accented and
+	// non-Latin knowledge bases (e.g. "café", non-Latin scripts) tokenize correctly.
+	return (value.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []).filter(
 		(token) => token.length > 2 && !STOPWORDS.has(token),
 	);
 }

--- a/packages/agent/src/assistant.ts
+++ b/packages/agent/src/assistant.ts
@@ -209,6 +209,28 @@ function companyFieldSentence(
 // One page wide enough to cover a small business's whole knowledge base, so a
 // search or topic match considers everything rather than just the newest few.
 const FAQ_SCAN_PAGE_SIZE = 100;
+// Bound the scan so a pathological knowledge base can't fan out unbounded API
+// calls inside one Worker request. 10 pages × 100 = 1000 FAQs — far beyond a real
+// small business — after which we tell the user the scan was partial.
+const FAQ_SCAN_MAX_PAGES = 10;
+
+/**
+ * Read the account's FAQs across pages (the API caps a page at 100 and returns
+ * newest-first), so a search or topic match considers the whole knowledge base —
+ * not just the most recent 100. `complete` is false when the cap cut the scan short.
+ */
+async function scanFaqs(api: RivusApiClient): Promise<{ faqs: Faq[]; complete: boolean }> {
+	const faqs: Faq[] = [];
+	let page = 1;
+	let hasNextPage = true;
+	while (hasNextPage && page <= FAQ_SCAN_MAX_PAGES) {
+		const result = await api.listFaqs({ page, pageSize: FAQ_SCAN_PAGE_SIZE });
+		faqs.push(...result.data);
+		hasNextPage = result.meta.hasNextPage;
+		page += 1;
+	}
+	return { faqs, complete: !hasNextPage };
+}
 
 async function faqListReply(api: RivusApiClient): Promise<string> {
 	const { data, meta } = await api.listFaqs({ page: 1, pageSize: 20 });
@@ -226,13 +248,14 @@ async function faqListReply(api: RivusApiClient): Promise<string> {
 }
 
 async function faqSearchReply(api: RivusApiClient, query: string): Promise<string> {
-	const { data, meta } = await api.listFaqs({ page: 1, pageSize: FAQ_SCAN_PAGE_SIZE });
-	if (meta.total === 0) {
+	const { faqs, complete } = await scanFaqs(api);
+	if (faqs.length === 0) {
 		return EMPTY_KB;
 	}
-	const ranked = rankFaqs(data, query);
+	const ranked = rankFaqs(faqs, query);
 	if (ranked.length === 0) {
-		return `I couldn’t find anything in your knowledge base about “${query}”. Try different wording, or ask me to list all your FAQs.`;
+		const scope = complete ? 'your knowledge base' : `the ${faqs.length} most recent FAQs`;
+		return `I couldn’t find anything in ${scope} about “${query}”. Try different wording, or ask me to list all your FAQs.`;
 	}
 	const lines = ranked.slice(0, 3).map((faq) => `• ${faq.question}\n  ${snippet(faq.answer)}`);
 	return [`Here’s what I found about “${query}”:`, ...lines].join('\n');
@@ -245,11 +268,11 @@ async function faqUpdateReply(
 	if (intent.topic === '') {
 		return 'Which FAQ should I update? Tell me the topic — e.g. “update the FAQ about refunds to say we offer 30-day refunds.”';
 	}
-	const { data, meta } = await api.listFaqs({ page: 1, pageSize: FAQ_SCAN_PAGE_SIZE });
-	if (meta.total === 0) {
+	const { faqs } = await scanFaqs(api);
+	if (faqs.length === 0) {
 		return EMPTY_KB;
 	}
-	const matches = matchFaqsByTopic(data, intent.topic);
+	const matches = matchFaqsByTopic(faqs, intent.topic);
 	if (matches.length > 1) {
 		const options = matches.slice(0, 5).map((faq) => `• ${faq.question}`);
 		return [`I found a few FAQs that could match “${intent.topic}”. Which one?`, ...options].join(
@@ -261,7 +284,10 @@ async function faqUpdateReply(
 		return `I couldn’t find an FAQ about “${intent.topic}”. Ask me to list your FAQs and I’ll show you what’s there.`;
 	}
 	if (intent.answer === null) {
-		return `The FAQ “${target.question}” currently says:\n  ${snippet(target.answer)}\nWhat should the new answer be?`;
+		// Rivus replies one message at a time with no memory of this turn, so ask for
+		// the whole instruction in a single message rather than a follow-up it can't
+		// tie back to this FAQ.
+		return `The FAQ “${target.question}” currently says:\n  ${snippet(target.answer)}\nTo change it, send the whole instruction in one message, e.g. “update the FAQ about ${intent.topic} to say <your new answer>”.`;
 	}
 	const parsed = updateFaqSchema.safeParse({ answer: intent.answer });
 	if (!parsed.success) {
@@ -279,9 +305,10 @@ async function faqCreateReply(
 		return 'Sure — what question should the FAQ answer, and what’s the answer? For example: “add an FAQ question: Do you offer refunds? answer: Yes, within 30 days.”';
 	}
 	// The parser only fills `answer` alongside a `question`, so a lone question here
-	// means we still need the answer before we can file it.
+	// means we still need the answer. Rivus has no memory of this turn, so ask for
+	// the full command in one message rather than a follow-up.
 	if (intent.answer === null) {
-		return `Got it — the question is “${intent.question}”. What should the answer be?`;
+		return `Got it — the question is “${intent.question}”. Send it in one message with the answer, e.g. “add an FAQ question: ${intent.question} answer: <your answer>”.`;
 	}
 	const parsed = createFaqSchema.safeParse({ question: intent.question, answer: intent.answer });
 	if (!parsed.success) {

--- a/packages/agent/src/assistant.ts
+++ b/packages/agent/src/assistant.ts
@@ -314,6 +314,16 @@ async function faqCreateReply(
 	if (!parsed.success) {
 		return parsed.error.issues[0]?.message ?? 'That FAQ doesn’t look valid — please try again.';
 	}
+	// Mirror the app's pre-create flow: surface a near-duplicate (AI-assisted) and
+	// steer the user toward updating it instead of polluting the knowledge base.
+	// The check is a no-op when the API has no AI provider configured.
+	const similar = await api.findSimilarFaq({
+		question: parsed.data.question,
+		answer: parsed.data.answer,
+	});
+	if (similar.match) {
+		return `That looks a lot like an existing FAQ — “${similar.match.question}”. I didn’t add a duplicate. To update that one instead, say “update the FAQ about ${similar.match.question} to say ${parsed.data.answer}”, or reword your question if it’s genuinely different.`;
+	}
 	const created = await api.createFaq(parsed.data);
 	return `Added a new FAQ: “${created.question}”.`;
 }

--- a/packages/agent/src/assistant.ts
+++ b/packages/agent/src/assistant.ts
@@ -1,0 +1,385 @@
+import { createFaqSchema, type Faq, updateFaqSchema } from '@rivus/core';
+import { AgentApiError, createRivusApiClient, type FetchLike, type RivusApiClient } from './api';
+import { authenticate } from './auth';
+import { GREETING, lastUserMessage } from './conversation';
+import { type CompanyField, type Intent, parseIntent } from './intent';
+import type { ChatMessage, Env, SessionClaims } from './types';
+
+/**
+ * The authenticated brain of the agent. Given a conversation and the incoming
+ * request, it:
+ *
+ *   1. verifies the session (JWT from a bearer header or the `rivus_session`
+ *      cookie — see `auth.ts`),
+ *   2. understands the latest ask (`intent.ts`), and
+ *   3. for signed-in users, fulfils it by calling the Rivus API on their behalf
+ *      (`api.ts`) and formatting the result.
+ *
+ * Everything protected (company facts, knowledge-base reads/writes) requires a
+ * valid session; anonymous callers get a friendly nudge to sign in. The API
+ * stays the authority on permissions, so the agent simply forwards the user's
+ * token and turns any 401/403 into a clear sentence.
+ *
+ * It performs I/O only through the injected `fetch`, so — like the app's API
+ * client — it is unit-tested hermetically with a mocked `fetch` and a locally
+ * signed token.
+ */
+
+export interface RespondDeps {
+	env: Env;
+	request: Request;
+	messages: ChatMessage[];
+	/** Injected for tests; defaults to the global `fetch` in the Worker. */
+	fetchImpl?: FetchLike;
+}
+
+const SIGN_IN_REQUIRED =
+	"You'll need to be signed in for that. Once you sign in to Rivus, I can pull up your company details and search or update your knowledge base.";
+
+const NOT_CONFIGURED =
+	"I can't reach your Rivus account right now — the agent isn't fully configured. Please try again later.";
+
+const EMPTY_KB =
+	"Your knowledge base is empty. Add your first FAQ and I'll be able to search and update it for you.";
+
+/** Human label for each company field, used in the full-record summary. */
+const FIELD_LABEL: Record<CompanyField, string> = {
+	name: 'Business name',
+	website: 'Website',
+	phone: 'Phone',
+	address: 'Address',
+	timezone: 'Time zone',
+	slug: 'Rivus handle',
+	status: 'Account status',
+};
+
+/** Produce the agent's reply to the most recent user turn. */
+export async function respond(deps: RespondDeps): Promise<string> {
+	const { env, request, messages, fetchImpl } = deps;
+	const intent = parseIntent(lastUserMessage(messages) ?? '');
+	const session = await authenticate(request, env.JWT_SECRET);
+
+	// Conversational intents need no data and work signed in or out.
+	if (intent.kind === 'greeting') {
+		return greetingReply(session?.claims ?? null);
+	}
+	if (intent.kind === 'help') {
+		return helpReply(session?.claims ?? null);
+	}
+	if (intent.kind === 'unknown') {
+		return unknownReply(session?.claims ?? null);
+	}
+
+	// Everything below is gated on a valid session.
+	if (!session) {
+		return SIGN_IN_REQUIRED;
+	}
+	if (!env.RIVUS_API_URL) {
+		return NOT_CONFIGURED;
+	}
+	const api = createRivusApiClient(env.RIVUS_API_URL, session.token, fetchImpl);
+
+	try {
+		switch (intent.kind) {
+			case 'company_info':
+				return await companyInfoReply(api, intent.fields);
+			case 'faq_list':
+				return await faqListReply(api);
+			case 'faq_search':
+				return await faqSearchReply(api, intent.query);
+			case 'faq_update':
+				return await faqUpdateReply(api, intent);
+			case 'faq_create':
+				return await faqCreateReply(api, intent);
+		}
+	} catch (error) {
+		return apiErrorReply(error);
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/* Conversational replies                                                     */
+/* -------------------------------------------------------------------------- */
+
+function greetingReply(claims: SessionClaims | null): string {
+	if (!claims) {
+		return `${GREETING} Sign in to Rivus and I can pull up your company details and your knowledge base.`;
+	}
+	return `${GREETING} You're signed in as ${claims.email}. Ask me about your company details — like your website — or to search and update your knowledge base.`;
+}
+
+function helpReply(claims: SessionClaims | null): string {
+	const lines = [
+		'Here’s what I can do:',
+		'• Tell you your company details — e.g. “what’s our website?”',
+		'• Search your knowledge base — e.g. “find FAQs about refunds”',
+		'• Update or add an FAQ — e.g. “update the FAQ about returns to say …”',
+	];
+	if (!claims) {
+		lines.push('', 'Sign in first and I’ll do all of this against your account.');
+	}
+	return lines.join('\n');
+}
+
+function unknownReply(claims: SessionClaims | null): string {
+	if (!claims) {
+		return `${GREETING} I can help with your company details and your knowledge base once you’re signed in. Try “what’s our website?” or “search the FAQ for pricing.”`;
+	}
+	return 'I’m not sure how to help with that yet. I can tell you your company details (like your website) or search and update your knowledge base — try “what’s our phone number?” or “find FAQs about pricing.”';
+}
+
+/* -------------------------------------------------------------------------- */
+/* Company context                                                            */
+/* -------------------------------------------------------------------------- */
+
+async function companyInfoReply(api: RivusApiClient, fields: CompanyField[]): Promise<string> {
+	const { account } = await api.me();
+	if (fields.length === 0) {
+		// Generic ask → the whole record, with blanks shown so it reads as complete.
+		const rows = (Object.keys(FIELD_LABEL) as CompanyField[]).map((field) => {
+			const value = companyFieldValue(account, field);
+			return `• ${FIELD_LABEL[field]}: ${value === '' ? 'not set' : value}`;
+		});
+		return [`Here’s what I have for ${account.name}:`, ...rows].join('\n');
+	}
+	return fields.map((field) => companyFieldSentence(account, field)).join('\n');
+}
+
+function companyFieldValue(
+	account: {
+		name: string;
+		website: string;
+		phone: string;
+		address: string;
+		timezone: string;
+		slug: string;
+		status: string;
+	},
+	field: CompanyField,
+): string {
+	switch (field) {
+		case 'name':
+			return account.name;
+		case 'website':
+			return account.website;
+		case 'phone':
+			return account.phone;
+		case 'address':
+			return account.address;
+		case 'timezone':
+			return account.timezone;
+		case 'slug':
+			return account.slug;
+		case 'status':
+			return account.status;
+	}
+}
+
+function companyFieldSentence(
+	account: Parameters<typeof companyFieldValue>[0],
+	field: CompanyField,
+): string {
+	const value = companyFieldValue(account, field);
+	if (value === '') {
+		const label = FIELD_LABEL[field].toLowerCase();
+		return `You haven’t added a ${label} yet — you can set one in Settings.`;
+	}
+	switch (field) {
+		case 'name':
+			return `Your business name is ${value}.`;
+		case 'website':
+			return `Your website is ${value}.`;
+		case 'phone':
+			return `Your phone number is ${value}.`;
+		case 'address':
+			return `Your address is ${value}.`;
+		case 'timezone':
+			return `Your time zone is ${value}.`;
+		case 'slug':
+			return `Your Rivus handle is ${value}.`;
+		case 'status':
+			return `Your account is ${value}.`;
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/* Knowledge base                                                             */
+/* -------------------------------------------------------------------------- */
+
+// One page wide enough to cover a small business's whole knowledge base, so a
+// search or topic match considers everything rather than just the newest few.
+const FAQ_SCAN_PAGE_SIZE = 100;
+
+async function faqListReply(api: RivusApiClient): Promise<string> {
+	const { data, meta } = await api.listFaqs({ page: 1, pageSize: 20 });
+	if (meta.total === 0) {
+		return EMPTY_KB;
+	}
+	const shown = data.slice(0, 10).map((faq) => `• ${faq.question}`);
+	const remainder = meta.total - shown.length;
+	const header = `Your knowledge base has ${meta.total} FAQ${meta.total === 1 ? '' : 's'}:`;
+	const lines = [header, ...shown];
+	if (remainder > 0) {
+		lines.push(`…and ${remainder} more. Ask me to search for a topic to narrow it down.`);
+	}
+	return lines.join('\n');
+}
+
+async function faqSearchReply(api: RivusApiClient, query: string): Promise<string> {
+	const { data, meta } = await api.listFaqs({ page: 1, pageSize: FAQ_SCAN_PAGE_SIZE });
+	if (meta.total === 0) {
+		return EMPTY_KB;
+	}
+	const ranked = rankFaqs(data, query);
+	if (ranked.length === 0) {
+		return `I couldn’t find anything in your knowledge base about “${query}”. Try different wording, or ask me to list all your FAQs.`;
+	}
+	const lines = ranked.slice(0, 3).map((faq) => `• ${faq.question}\n  ${snippet(faq.answer)}`);
+	return [`Here’s what I found about “${query}”:`, ...lines].join('\n');
+}
+
+async function faqUpdateReply(
+	api: RivusApiClient,
+	intent: Extract<Intent, { kind: 'faq_update' }>,
+): Promise<string> {
+	if (intent.topic === '') {
+		return 'Which FAQ should I update? Tell me the topic — e.g. “update the FAQ about refunds to say we offer 30-day refunds.”';
+	}
+	const { data, meta } = await api.listFaqs({ page: 1, pageSize: FAQ_SCAN_PAGE_SIZE });
+	if (meta.total === 0) {
+		return EMPTY_KB;
+	}
+	const matches = matchFaqsByTopic(data, intent.topic);
+	if (matches.length > 1) {
+		const options = matches.slice(0, 5).map((faq) => `• ${faq.question}`);
+		return [`I found a few FAQs that could match “${intent.topic}”. Which one?`, ...options].join(
+			'\n',
+		);
+	}
+	const [target] = matches;
+	if (!target) {
+		return `I couldn’t find an FAQ about “${intent.topic}”. Ask me to list your FAQs and I’ll show you what’s there.`;
+	}
+	if (intent.answer === null) {
+		return `The FAQ “${target.question}” currently says:\n  ${snippet(target.answer)}\nWhat should the new answer be?`;
+	}
+	const parsed = updateFaqSchema.safeParse({ answer: intent.answer });
+	if (!parsed.success) {
+		return parsed.error.issues[0]?.message ?? 'That update doesn’t look valid — please try again.';
+	}
+	const updated = await api.updateFaq(target.id, { answer: intent.answer });
+	return `Done — I updated “${updated.question}”. It now reads:\n  ${snippet(updated.answer)}`;
+}
+
+async function faqCreateReply(
+	api: RivusApiClient,
+	intent: Extract<Intent, { kind: 'faq_create' }>,
+): Promise<string> {
+	if (intent.question === null && intent.answer === null) {
+		return 'Sure — what question should the FAQ answer, and what’s the answer? For example: “add an FAQ question: Do you offer refunds? answer: Yes, within 30 days.”';
+	}
+	// The parser only fills `answer` alongside a `question`, so a lone question here
+	// means we still need the answer before we can file it.
+	if (intent.answer === null) {
+		return `Got it — the question is “${intent.question}”. What should the answer be?`;
+	}
+	const parsed = createFaqSchema.safeParse({ question: intent.question, answer: intent.answer });
+	if (!parsed.success) {
+		return parsed.error.issues[0]?.message ?? 'That FAQ doesn’t look valid — please try again.';
+	}
+	const created = await api.createFaq(parsed.data);
+	return `Added a new FAQ: “${created.question}”.`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Errors & text helpers                                                      */
+/* -------------------------------------------------------------------------- */
+
+function apiErrorReply(error: unknown): string {
+	if (error instanceof AgentApiError) {
+		if (error.status === 401) {
+			return 'Your session looks like it expired. Please sign in again and I’ll pick right back up.';
+		}
+		if (error.status === 403) {
+			return 'You don’t have permission to do that on this account.';
+		}
+	}
+	return 'Sorry — I couldn’t reach your Rivus data just now. Please try again in a moment.';
+}
+
+// Words too common to help a knowledge-base match; dropped before scoring.
+const STOPWORDS = new Set([
+	'the',
+	'and',
+	'for',
+	'our',
+	'you',
+	'your',
+	'what',
+	'whats',
+	'about',
+	'faq',
+	'faqs',
+	'have',
+	'does',
+	'with',
+	'this',
+	'that',
+	'are',
+	'can',
+]);
+
+/** Lowercased word tokens worth matching on (short/stopword tokens dropped). */
+function tokenize(value: string): string[] {
+	return (value.toLowerCase().match(/[a-z0-9]+/g) ?? []).filter(
+		(token) => token.length > 2 && !STOPWORDS.has(token),
+	);
+}
+
+/** How many query tokens appear anywhere in an FAQ's question/answer/category. */
+function scoreFaq(tokens: string[], faq: Faq): number {
+	const haystack = `${faq.question} ${faq.answer} ${faq.category}`.toLowerCase();
+	let score = 0;
+	for (const token of tokens) {
+		if (haystack.includes(token)) {
+			score += 1;
+		}
+	}
+	return score;
+}
+
+/** FAQs ranked by relevance to `query`, best first, zero-score entries dropped. */
+function rankFaqs(faqs: Faq[], query: string): Faq[] {
+	const tokens = tokenize(query);
+	const needle = query.trim().toLowerCase();
+	return faqs
+		.map((faq) => {
+			// Fall back to a raw substring match when the query is all stopwords/short.
+			const score =
+				tokens.length > 0
+					? scoreFaq(tokens, faq)
+					: needle.length > 0 && `${faq.question} ${faq.answer}`.toLowerCase().includes(needle)
+						? 1
+						: 0;
+			return { faq, score };
+		})
+		.filter((entry) => entry.score > 0)
+		.sort((a, b) => b.score - a.score)
+		.map((entry) => entry.faq);
+}
+
+/** FAQs that plausibly concern `topic` — question substring first, then ranking. */
+function matchFaqsByTopic(faqs: Faq[], topic: string): Faq[] {
+	const needle = topic.trim().toLowerCase();
+	const byQuestion = faqs.filter((faq) => faq.question.toLowerCase().includes(needle));
+	if (byQuestion.length > 0) {
+		return byQuestion;
+	}
+	return rankFaqs(faqs, topic);
+}
+
+/** Collapse whitespace and cap a long answer so a reply stays scannable. */
+function snippet(text: string, max = 180): string {
+	const clean = text.replace(/\s+/g, ' ').trim();
+	return clean.length <= max ? clean : `${clean.slice(0, max - 1).trimEnd()}…`;
+}

--- a/packages/agent/src/auth.test.ts
+++ b/packages/agent/src/auth.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import {
+	authenticate,
+	extractSessionToken,
+	parseCookies,
+	SESSION_COOKIE,
+	verifySessionToken,
+} from './auth';
+
+const SECRET = 'test-secret-value-1234';
+
+const encoder = new TextEncoder();
+
+function base64Url(bytes: Uint8Array): string {
+	let binary = '';
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function encodeSegment(value: unknown): string {
+	return base64Url(encoder.encode(JSON.stringify(value)));
+}
+
+/** Mint an HS256 JWT the way `@rivus/api` does, for verification tests. */
+async function signToken(
+	payload: Record<string, unknown>,
+	secret = SECRET,
+	header: Record<string, unknown> = { alg: 'HS256', typ: 'JWT' },
+): Promise<string> {
+	const data = `${encodeSegment(header)}.${encodeSegment(payload)}`;
+	const key = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(secret),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign'],
+	);
+	const signature = new Uint8Array(await crypto.subtle.sign('HMAC', key, encoder.encode(data)));
+	return `${data}.${base64Url(signature)}`;
+}
+
+const validClaims = {
+	sub: 'user_1',
+	email: 'owner@acme.com',
+	accountId: 'acct_1',
+	role: 'owner' as const,
+};
+
+/** A token that expires an hour out, so it's valid "now". */
+function freshPayload(over: Record<string, unknown> = {}) {
+	return { ...validClaims, exp: Math.floor(Date.now() / 1000) + 3600, ...over };
+}
+
+function requestWith(headers: Record<string, string>): Request {
+	return new Request('https://agent.test/agents/rivus-agent/default', { method: 'POST', headers });
+}
+
+describe('parseCookies', () => {
+	it('returns an empty object for no header', () => {
+		expect(parseCookies(null)).toEqual({});
+	});
+
+	it('parses one and many cookies, trimming whitespace', () => {
+		expect(parseCookies('a=1')).toEqual({ a: '1' });
+		expect(parseCookies('a=1; b=2;c=3')).toEqual({ a: '1', b: '2', c: '3' });
+	});
+
+	it('URL-decodes values and tolerates malformed encoding', () => {
+		expect(parseCookies('x=hello%20world')).toEqual({ x: 'hello world' });
+		expect(parseCookies('x=100%')).toEqual({ x: '100%' });
+	});
+
+	it('skips entries with no name', () => {
+		expect(parseCookies('=oops; a=1')).toEqual({ a: '1' });
+	});
+});
+
+describe('extractSessionToken', () => {
+	it('reads a Bearer token (case-insensitive)', () => {
+		expect(extractSessionToken(requestWith({ Authorization: 'Bearer abc.def.ghi' }))).toBe(
+			'abc.def.ghi',
+		);
+		expect(extractSessionToken(requestWith({ authorization: 'bearer xyz' }))).toBe('xyz');
+	});
+
+	it('falls back to the session cookie', () => {
+		expect(extractSessionToken(requestWith({ cookie: `${SESSION_COOKIE}=cookie.jwt` }))).toBe(
+			'cookie.jwt',
+		);
+	});
+
+	it('prefers the Authorization header over the cookie', () => {
+		const request = requestWith({
+			Authorization: 'Bearer header.jwt',
+			cookie: `${SESSION_COOKIE}=cookie.jwt`,
+		});
+		expect(extractSessionToken(request)).toBe('header.jwt');
+	});
+
+	it('returns null when neither is present', () => {
+		expect(extractSessionToken(requestWith({}))).toBeNull();
+		// A non-Bearer Authorization scheme is ignored.
+		expect(extractSessionToken(requestWith({ Authorization: 'Basic abc' }))).toBeNull();
+	});
+});
+
+describe('verifySessionToken', () => {
+	it('accepts a valid, unexpired token and returns the claims', async () => {
+		const token = await signToken(freshPayload());
+		expect(await verifySessionToken(token, SECRET)).toEqual(validClaims);
+	});
+
+	it('accepts a token with no exp', async () => {
+		const token = await signToken(validClaims);
+		expect(await verifySessionToken(token, SECRET)).toEqual(validClaims);
+	});
+
+	it('rejects when no secret is configured', async () => {
+		const token = await signToken(freshPayload());
+		expect(await verifySessionToken(token, undefined)).toBeNull();
+	});
+
+	it('rejects a token signed with a different secret', async () => {
+		const token = await signToken(freshPayload(), 'some-other-secret');
+		expect(await verifySessionToken(token, SECRET)).toBeNull();
+	});
+
+	it('rejects an expired token', async () => {
+		const token = await signToken(freshPayload({ exp: Math.floor(Date.now() / 1000) - 10 }));
+		expect(await verifySessionToken(token, SECRET)).toBeNull();
+	});
+
+	it('rejects a not-yet-valid token', async () => {
+		const token = await signToken(freshPayload({ nbf: Math.floor(Date.now() / 1000) + 600 }));
+		expect(await verifySessionToken(token, SECRET)).toBeNull();
+	});
+
+	it('rejects an alg other than HS256 (no alg:none, no algorithm confusion)', async () => {
+		const none = await signToken(freshPayload(), SECRET, { alg: 'none', typ: 'JWT' });
+		expect(await verifySessionToken(none, SECRET)).toBeNull();
+		const rs256 = await signToken(freshPayload(), SECRET, { alg: 'RS256', typ: 'JWT' });
+		expect(await verifySessionToken(rs256, SECRET)).toBeNull();
+	});
+
+	it('rejects a structurally malformed token', async () => {
+		expect(await verifySessionToken('only.two', SECRET)).toBeNull();
+		expect(await verifySessionToken('a.b.c.d', SECRET)).toBeNull();
+		expect(await verifySessionToken('', SECRET)).toBeNull();
+	});
+
+	it('rejects a token whose segments are not valid base64url JSON', async () => {
+		expect(await verifySessionToken('!!!.@@@.###', SECRET)).toBeNull();
+	});
+
+	it('rejects a valid signature over claims missing a required field', async () => {
+		const { accountId, ...withoutAccount } = freshPayload();
+		void accountId;
+		const token = await signToken(withoutAccount);
+		expect(await verifySessionToken(token, SECRET)).toBeNull();
+	});
+
+	it('rejects a token carrying an invalid role', async () => {
+		const token = await signToken(freshPayload({ role: 'superadmin' }));
+		expect(await verifySessionToken(token, SECRET)).toBeNull();
+	});
+});
+
+describe('authenticate', () => {
+	it('returns the token and claims for a valid bearer session', async () => {
+		const token = await signToken(freshPayload());
+		const result = await authenticate(requestWith({ Authorization: `Bearer ${token}` }), SECRET);
+		expect(result).toEqual({ token, claims: validClaims });
+	});
+
+	it('returns the session from the cookie', async () => {
+		const token = await signToken(freshPayload());
+		const result = await authenticate(
+			requestWith({ cookie: `${SESSION_COOKIE}=${token}` }),
+			SECRET,
+		);
+		expect(result?.claims).toEqual(validClaims);
+	});
+
+	it('returns null when there is no token', async () => {
+		expect(await authenticate(requestWith({}), SECRET)).toBeNull();
+	});
+
+	it('returns null when the token does not verify', async () => {
+		const token = await signToken(freshPayload(), 'wrong-secret');
+		expect(
+			await authenticate(requestWith({ Authorization: `Bearer ${token}` }), SECRET),
+		).toBeNull();
+	});
+});

--- a/packages/agent/src/auth.ts
+++ b/packages/agent/src/auth.ts
@@ -123,7 +123,8 @@ export async function verifySessionToken(
 	const header = decodeJson(headerSegment);
 	// Only accept HS256 — the algorithm the API signs with. Honouring the token's
 	// own `alg` blindly would let an attacker downgrade to `none` or swap algorithms.
-	if (!header || header.alg !== 'HS256') {
+	// (A null header — malformed segment — also fails this check.)
+	if (header?.alg !== 'HS256') {
 		return null;
 	}
 

--- a/packages/agent/src/auth.ts
+++ b/packages/agent/src/auth.ts
@@ -1,0 +1,194 @@
+import { type AccountId, roleSchema, type UserId } from '@rivus/core';
+import { z } from 'zod';
+import type { SessionClaims } from './types';
+
+/**
+ * Session authentication for the agent.
+ *
+ * The agent verifies the very same session JWT that `@rivus/api` issues, so a
+ * user who is signed in to the Rivus app is automatically recognised here. The
+ * token arrives one of two ways:
+ *
+ * - **Bearer header** — `Authorization: Bearer <jwt>` (native app, which has no
+ *   cookie jar and holds the token in memory).
+ * - **Cookie** — the `rivus_session` HttpOnly cookie (web app), which the browser
+ *   sends automatically once the API has scoped it to the shared parent domain.
+ *
+ * Verification is done locally with Web Crypto (HMAC-SHA256), available in both
+ * the Workers runtime and Node, which keeps this module pure and unit-testable.
+ * A valid signature only proves the token was minted by us and hasn't expired —
+ * the API remains the authority on live membership/permission state, so the
+ * agent still forwards the token and honours any 401/403 the API returns.
+ */
+
+/** Name of the HttpOnly cookie that carries the session JWT (matches `@rivus/api`). */
+export const SESSION_COOKIE = 'rivus_session';
+
+/** Validates the decoded JWT payload carries a well-formed Rivus session. */
+const claimsSchema = z.object({
+	sub: z.string().min(1),
+	email: z.string().min(1),
+	accountId: z.string().min(1),
+	role: roleSchema,
+});
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** Parse a `Cookie` header into a name→value map (values are URL-decoded). */
+export function parseCookies(header: string | null): Record<string, string> {
+	const out: Record<string, string> = {};
+	if (!header) {
+		return out;
+	}
+	for (const part of header.split(';')) {
+		const eq = part.indexOf('=');
+		if (eq === -1) {
+			continue;
+		}
+		const name = part.slice(0, eq).trim();
+		if (!name) {
+			continue;
+		}
+		const rawValue = part.slice(eq + 1).trim();
+		try {
+			out[name] = decodeURIComponent(rawValue);
+		} catch {
+			// A value with a stray `%` isn't valid percent-encoding; keep it verbatim
+			// rather than dropping the cookie.
+			out[name] = rawValue;
+		}
+	}
+	return out;
+}
+
+/**
+ * Pull the raw session token off a request — the `Authorization: Bearer` header
+ * first (native), then the `rivus_session` cookie (web). Returns `null` when
+ * neither is present.
+ */
+export function extractSessionToken(request: Request, cookieName = SESSION_COOKIE): string | null {
+	const authorization = request.headers.get('authorization');
+	if (authorization) {
+		const match = /^Bearer\s+(.+)$/i.exec(authorization.trim());
+		if (match?.[1]) {
+			return match[1].trim();
+		}
+	}
+	const cookies = parseCookies(request.headers.get('cookie'));
+	return cookies[cookieName] ?? null;
+}
+
+/** Decode a base64url segment to bytes (tolerant of missing `=` padding). */
+function base64UrlToBytes(input: string): Uint8Array {
+	const padded = input.length % 4 === 0 ? input : input + '='.repeat(4 - (input.length % 4));
+	const base64 = padded.replace(/-/g, '+').replace(/_/g, '/');
+	const binary = atob(base64);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = binary.charCodeAt(i);
+	}
+	return bytes;
+}
+
+/** Decode a base64url JWT segment to its parsed JSON, or `null` if it's malformed. */
+function decodeJson(segment: string): Record<string, unknown> | null {
+	try {
+		const parsed = JSON.parse(decoder.decode(base64UrlToBytes(segment)));
+		return typeof parsed === 'object' && parsed !== null
+			? (parsed as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Verify a session JWT and return its claims, or `null` for anything we don't
+ * fully trust: wrong shape, an algorithm other than HS256 (so `alg: none` and
+ * key-confusion attacks are rejected), a bad signature, an expired/not-yet-valid
+ * token, or a missing secret.
+ */
+export async function verifySessionToken(
+	token: string,
+	secret: string | undefined,
+): Promise<SessionClaims | null> {
+	if (!secret) {
+		return null;
+	}
+	const [headerSegment, payloadSegment, signatureSegment, ...rest] = token.split('.');
+	if (!headerSegment || !payloadSegment || !signatureSegment || rest.length > 0) {
+		return null;
+	}
+	const header = decodeJson(headerSegment);
+	// Only accept HS256 — the algorithm the API signs with. Honouring the token's
+	// own `alg` blindly would let an attacker downgrade to `none` or swap algorithms.
+	if (!header || header.alg !== 'HS256') {
+		return null;
+	}
+
+	let signatureValid: boolean;
+	try {
+		const key = await crypto.subtle.importKey(
+			'raw',
+			encoder.encode(secret),
+			{ name: 'HMAC', hash: 'SHA-256' },
+			false,
+			['verify'],
+		);
+		signatureValid = await crypto.subtle.verify(
+			'HMAC',
+			key,
+			base64UrlToBytes(signatureSegment),
+			encoder.encode(`${headerSegment}.${payloadSegment}`),
+		);
+	} catch {
+		return null;
+	}
+	if (!signatureValid) {
+		return null;
+	}
+
+	const payload = decodeJson(payloadSegment);
+	if (!payload) {
+		return null;
+	}
+	const nowSeconds = Math.floor(Date.now() / 1000);
+	if (typeof payload.exp === 'number' && payload.exp <= nowSeconds) {
+		return null;
+	}
+	if (typeof payload.nbf === 'number' && payload.nbf > nowSeconds) {
+		return null;
+	}
+
+	const claims = claimsSchema.safeParse(payload);
+	if (!claims.success) {
+		return null;
+	}
+	// The branded id types are plain strings on the wire; re-brand them here so the
+	// rest of the agent gets the same precise types the API uses.
+	return {
+		sub: claims.data.sub as UserId,
+		email: claims.data.email,
+		accountId: claims.data.accountId as AccountId,
+		role: claims.data.role,
+	};
+}
+
+/**
+ * Resolve the authenticated session for a request, or `null` when there's no
+ * valid token. Convenience wrapper combining {@link extractSessionToken} and
+ * {@link verifySessionToken}; also returns the raw token so callers can forward
+ * it to the API.
+ */
+export async function authenticate(
+	request: Request,
+	secret: string | undefined,
+): Promise<{ token: string; claims: SessionClaims } | null> {
+	const token = extractSessionToken(request);
+	if (!token) {
+		return null;
+	}
+	const claims = await verifySessionToken(token, secret);
+	return claims ? { token, claims } : null;
+}

--- a/packages/agent/src/http.test.ts
+++ b/packages/agent/src/http.test.ts
@@ -114,6 +114,37 @@ describe('corsHeaders', () => {
 		);
 		expect(headers['Access-Control-Allow-Origin']).toBe('https://www.rivus.ai');
 	});
+
+	it('refuses a wildcard allowlist in production (credentialed CORS guard)', () => {
+		const env = { NODE_ENV: 'production', ALLOWED_ORIGINS: '*' } as Env;
+		expect(() =>
+			corsHeaders(request('/x', { headers: { Origin: 'https://evil.example' } }), env),
+		).toThrow(/production/i);
+	});
+
+	it('still reflects an explicit origin in production (no throw)', () => {
+		const env = { NODE_ENV: 'production', ALLOWED_ORIGINS: 'https://app.rivus.ai' } as Env;
+		const headers = corsHeaders(
+			request('/x', { headers: { Origin: 'https://app.rivus.ai' } }),
+			env,
+		);
+		expect(headers['Access-Control-Allow-Origin']).toBe('https://app.rivus.ai');
+		expect(headers['Access-Control-Allow-Credentials']).toBe('true');
+	});
+
+	it('matches a single-label subdomain wildcard but not nested subdomains', () => {
+		const env = { ALLOWED_ORIGINS: 'https://*.rivus.ai' } as Env;
+		expect(
+			corsHeaders(request('/x', { headers: { Origin: 'https://app.rivus.ai' } }), env)[
+				'Access-Control-Allow-Origin'
+			],
+		).toBe('https://app.rivus.ai');
+		expect(
+			corsHeaders(request('/x', { headers: { Origin: 'https://a.b.rivus.ai' } }), env)[
+				'Access-Control-Allow-Origin'
+			],
+		).toBeUndefined();
+	});
 });
 
 describe('jsonResponse / notFoundResponse', () => {

--- a/packages/agent/src/http.test.ts
+++ b/packages/agent/src/http.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import type { FetchLike } from './api';
 import { GREETING } from './conversation';
 import {
 	corsHeaders,
@@ -8,16 +9,47 @@ import {
 	notFoundResponse,
 	parseMessages,
 } from './http';
+import type { Env } from './types';
+
+const SECRET = 'test-secret-value-1234';
+const encoder = new TextEncoder();
+
+function base64Url(bytes: Uint8Array): string {
+	let binary = '';
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function signToken(payload: Record<string, unknown>): Promise<string> {
+	const seg = (value: unknown) => base64Url(encoder.encode(JSON.stringify(value)));
+	const data = `${seg({ alg: 'HS256', typ: 'JWT' })}.${seg(payload)}`;
+	const key = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(SECRET),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign'],
+	);
+	const signature = new Uint8Array(await crypto.subtle.sign('HMAC', key, encoder.encode(data)));
+	return `${data}.${base64Url(signature)}`;
+}
 
 function request(path: string, init?: RequestInit): Request {
 	return new Request(`https://agent.test${path}`, init);
 }
 
-function postJson(body: unknown): Request {
+function postJson(body: unknown, init?: RequestInit): Request {
 	return request('/agents/rivus-agent/default', {
 		method: 'POST',
-		headers: { 'content-type': 'application/json', Origin: 'https://app.rivus.ai' },
+		headers: {
+			'content-type': 'application/json',
+			Origin: 'https://app.rivus.ai',
+			...init?.headers,
+		},
 		body: JSON.stringify(body),
+		...init,
 	});
 }
 
@@ -52,12 +84,35 @@ describe('parseMessages', () => {
 });
 
 describe('corsHeaders', () => {
-	it('echoes the caller Origin', () => {
-		expect(corsHeaders(postJson({}))['Access-Control-Allow-Origin']).toBe('https://app.rivus.ai');
+	it('echoes an allowed Origin and allows credentials', () => {
+		const headers = corsHeaders(postJson({}));
+		expect(headers['Access-Control-Allow-Origin']).toBe('https://app.rivus.ai');
+		expect(headers['Access-Control-Allow-Credentials']).toBe('true');
+		expect(headers['Access-Control-Allow-Headers']).toContain('Authorization');
 	});
 
-	it('falls back to * when there is no Origin', () => {
-		expect(corsHeaders(request('/health'))['Access-Control-Allow-Origin']).toBe('*');
+	it('falls back to a plain wildcard when there is no Origin', () => {
+		const headers = corsHeaders(request('/health'));
+		expect(headers['Access-Control-Allow-Origin']).toBe('*');
+		expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+	});
+
+	it('does not reflect an Origin that is not on the allowlist', () => {
+		const env = { ALLOWED_ORIGINS: 'https://app.rivus.ai' } as Env;
+		const headers = corsHeaders(
+			request('/x', { headers: { Origin: 'https://evil.example' } }),
+			env,
+		);
+		expect(headers['Access-Control-Allow-Origin']).toBeUndefined();
+	});
+
+	it('reflects an explicitly allowlisted Origin', () => {
+		const env = { ALLOWED_ORIGINS: 'https://app.rivus.ai,https://www.rivus.ai' } as Env;
+		const headers = corsHeaders(
+			request('/x', { headers: { Origin: 'https://www.rivus.ai' } }),
+			env,
+		);
+		expect(headers['Access-Control-Allow-Origin']).toBe('https://www.rivus.ai');
 	});
 });
 
@@ -78,7 +133,7 @@ describe('jsonResponse / notFoundResponse', () => {
 });
 
 describe('handleChat', () => {
-	it('answers a CORS preflight with 204 and no body', async () => {
+	it('answers a CORS preflight with 204 allowing POST and Authorization', async () => {
 		const response = await handleChat(
 			request('/agents/rivus-agent/default', {
 				method: 'OPTIONS',
@@ -87,6 +142,7 @@ describe('handleChat', () => {
 		);
 		expect(response.status).toBe(204);
 		expect(response.headers.get('access-control-allow-methods')).toContain('POST');
+		expect(response.headers.get('access-control-allow-headers')).toContain('Authorization');
 	});
 
 	it('greets on GET so it can be smoke-tested from a browser', async () => {
@@ -95,21 +151,82 @@ describe('handleChat', () => {
 		expect(await response.json()).toEqual({ reply: GREETING });
 	});
 
-	it('replies with hello to a posted message', async () => {
+	it('greets and nudges an unauthenticated POST to sign in', async () => {
 		const response = await handleChat(postJson({ messages: [{ role: 'user', content: 'hi' }] }));
 		expect(response.status).toBe(200);
-		expect(await response.json()).toEqual({ reply: GREETING });
+		const body = (await response.json()) as { reply: string };
+		expect(body.reply).toContain(GREETING);
+		expect(body.reply).toMatch(/sign in/i);
 		expect(response.headers.get('access-control-allow-origin')).toBe('https://app.rivus.ai');
 	});
 
 	it('tolerates an empty or invalid POST body and still greets', async () => {
 		const empty = await handleChat(request('/agents/rivus-agent/default', { method: 'POST' }));
-		expect(await empty.json()).toEqual({ reply: GREETING });
+		expect(((await empty.json()) as { reply: string }).reply).toContain(GREETING);
 
 		const garbage = await handleChat(
 			request('/agents/rivus-agent/default', { method: 'POST', body: 'not json' }),
 		);
-		expect(await garbage.json()).toEqual({ reply: GREETING });
+		expect(((await garbage.json()) as { reply: string }).reply).toContain(GREETING);
+	});
+
+	it('serves an authenticated request from the user’s Rivus data', async () => {
+		const token = await signToken({
+			sub: 'user_1',
+			email: 'owner@acme.example',
+			accountId: 'acct_1',
+			role: 'owner',
+			exp: Math.floor(Date.now() / 1000) + 3600,
+		});
+		const account = {
+			id: 'acct_1',
+			name: 'Acme',
+			slug: 'acme',
+			phone: '',
+			address: '',
+			website: 'https://acme.example',
+			timezone: 'UTC',
+			status: 'active',
+			canceledAt: null,
+			createdAt: '2026-01-01T00:00:00.000Z',
+			updatedAt: '2026-01-01T00:00:00.000Z',
+		};
+		const fetchImpl = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						user: {
+							id: 'user_1',
+							email: 'owner@acme.example',
+							name: 'Pat',
+							createdAt: account.createdAt,
+							updatedAt: account.updatedAt,
+						},
+						account,
+						role: 'owner',
+					}),
+					{ status: 200, headers: { 'content-type': 'application/json' } },
+				),
+		) as unknown as FetchLike;
+
+		const env = { JWT_SECRET: SECRET, RIVUS_API_URL: 'https://api.test' } as unknown as Env;
+		const response = await handleChat(
+			postJson(
+				{ messages: [{ role: 'user', content: 'what is our website?' }] },
+				{ headers: { Authorization: `Bearer ${token}` } },
+			),
+			env,
+			fetchImpl,
+		);
+
+		expect(response.status).toBe(200);
+		expect(((await response.json()) as { reply: string }).reply).toBe(
+			'Your website is https://acme.example.',
+		);
+		expect(fetchImpl).toHaveBeenCalledWith(
+			'https://api.test/v1/auth/me',
+			expect.objectContaining({ method: 'GET' }),
+		);
 	});
 
 	it('rejects other methods with 405', async () => {

--- a/packages/agent/src/http.test.ts
+++ b/packages/agent/src/http.test.ts
@@ -260,6 +260,42 @@ describe('handleChat', () => {
 		);
 	});
 
+	it('blocks a cookie-authenticated POST from a disallowed origin (CSRF guard)', async () => {
+		const env = { ALLOWED_ORIGINS: 'https://app.rivus.ai' } as Env;
+		const response = await handleChat(
+			request('/agents/rivus-agent/default', {
+				method: 'POST',
+				headers: {
+					Origin: 'https://evil.example',
+					cookie: 'rivus_session=some.jwt.value',
+					'content-type': 'application/json',
+				},
+				body: JSON.stringify({ messages: [{ role: 'user', content: 'update a faq' }] }),
+			}),
+			env,
+		);
+		expect(response.status).toBe(403);
+	});
+
+	it('does not CSRF-block a bearer POST (not forgeable cross-site)', async () => {
+		const env = { ALLOWED_ORIGINS: 'https://app.rivus.ai' } as Env;
+		const response = await handleChat(
+			request('/agents/rivus-agent/default', {
+				method: 'POST',
+				headers: {
+					Origin: 'https://evil.example',
+					Authorization: 'Bearer not.a.real.token',
+					'content-type': 'application/json',
+				},
+				body: JSON.stringify({ messages: [{ role: 'user', content: 'hi' }] }),
+			}),
+			env,
+		);
+		// Bearer tokens can't be forged cross-site, so this isn't blocked — it just
+		// isn't authenticated, so Rivus greets and nudges to sign in.
+		expect(response.status).toBe(200);
+	});
+
 	it('rejects other methods with 405', async () => {
 		const response = await handleChat(request('/agents/rivus-agent/default', { method: 'DELETE' }));
 		expect(response.status).toBe(405);

--- a/packages/agent/src/http.ts
+++ b/packages/agent/src/http.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
+import { respond } from './assistant';
 import { replyTo } from './conversation';
-import type { ChatMessage } from './types';
+import type { ChatMessage, Env } from './types';
 
 // The app posts either a full `{ messages: [...] }` transcript or a shorthand
 // `{ message: "hi" }`. Both are tolerated; anything unparseable degrades to an
@@ -27,46 +28,80 @@ export function parseMessages(body: unknown): ChatMessage[] {
 	return parsed.success ? parsed.data : [];
 }
 
+/** Whether a browser `Origin` may make credentialed requests to the agent. */
+function originAllowed(origin: string, allowed: string | undefined): boolean {
+	const list = (allowed ?? '*')
+		.split(',')
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+	if (list.includes('*')) {
+		return true;
+	}
+	return list.includes(origin);
+}
+
 /**
  * CORS headers for the agent. The app is served from a different origin
- * (e.g. the Expo web bundle on app.rivus.ai, or localhost during dev), so the
- * browser requires these on every response and on the preflight. We echo the
- * caller's `Origin` because this is a public greeting endpoint.
+ * (e.g. app.rivus.ai, or localhost during dev), so the browser requires these on
+ * every response and on the preflight.
+ *
+ * Authenticated requests carry the session cookie, which means credentialed CORS:
+ * we must echo the *specific* allowed origin (never `*`) and set
+ * `Allow-Credentials`. `ALLOWED_ORIGINS` is the allowlist; a bare `*` (the dev
+ * default) reflects any origin but only for unauthenticated use, and a request
+ * with no `Origin` (curl / the native app) gets a plain wildcard with no
+ * credentials. `Authorization` is allowed so native clients can send the bearer
+ * token.
  */
-export function corsHeaders(request: Request): Record<string, string> {
-	return {
-		'Access-Control-Allow-Origin': request.headers.get('Origin') ?? '*',
+export function corsHeaders(request: Request, env?: Env): Record<string, string> {
+	const base: Record<string, string> = {
 		'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-		'Access-Control-Allow-Headers': 'Content-Type',
+		'Access-Control-Allow-Headers': 'Content-Type, Authorization',
 		'Access-Control-Max-Age': '86400',
-		Vary: 'Origin',
 	};
+	const origin = request.headers.get('Origin');
+	if (origin && originAllowed(origin, env?.ALLOWED_ORIGINS)) {
+		return {
+			...base,
+			'Access-Control-Allow-Origin': origin,
+			'Access-Control-Allow-Credentials': 'true',
+			Vary: 'Origin',
+		};
+	}
+	if (!origin) {
+		// No browser origin (curl / native bearer client): a plain public wildcard.
+		return { ...base, 'Access-Control-Allow-Origin': '*' };
+	}
+	// A browser origin that isn't on the allowlist: omit `Allow-Origin` so the
+	// browser blocks the response rather than us reflecting an untrusted origin.
+	return { ...base, Vary: 'Origin' };
 }
 
 /** JSON response carrying the CORS headers. */
-export function jsonResponse(body: unknown, request: Request, status = 200): Response {
+export function jsonResponse(body: unknown, request: Request, status = 200, env?: Env): Response {
 	return new Response(JSON.stringify(body), {
 		status,
-		headers: { 'content-type': 'application/json', ...corsHeaders(request) },
+		headers: { 'content-type': 'application/json', ...corsHeaders(request, env) },
 	});
 }
 
 /** Empty 204 answer to a browser CORS preflight. */
-export function corsPreflight(request: Request): Response {
-	return new Response(null, { status: 204, headers: corsHeaders(request) });
+export function corsPreflight(request: Request, env?: Env): Response {
+	return new Response(null, { status: 204, headers: corsHeaders(request, env) });
 }
 
 /** Liveness probe payload. */
-export function healthResponse(request: Request): Response {
-	return jsonResponse({ status: 'ok', agent: 'rivus' }, request);
+export function healthResponse(request: Request, env?: Env): Response {
+	return jsonResponse({ status: 'ok', agent: 'rivus' }, request, 200, env);
 }
 
 /** A 404 for an unmatched route. */
-export function notFoundResponse(request: Request, pathname: string): Response {
+export function notFoundResponse(request: Request, pathname: string, env?: Env): Response {
 	return jsonResponse(
 		{ error: 'Not Found', message: `No route for ${request.method} ${pathname}` },
 		request,
 		404,
+		env,
 	);
 }
 
@@ -82,26 +117,38 @@ async function readJson(request: Request): Promise<unknown> {
 
 /**
  * Handle a chat request to a Rivus agent instance. This is what the Durable
- * Object's `onRequest` delegates to, and it is pure (request in, response out)
- * so it is unit-tested under Node without the Workers runtime.
+ * Object's `onRequest` delegates to, and it is pure (request + env in, response
+ * out) so it is unit-tested under Node without the Workers runtime.
  *
  * - `GET` returns the greeting, which makes the endpoint a friendly smoke test
- *   you can hit straight from a browser.
- * - `POST` replies to the supplied conversation.
+ *   you can hit straight from a browser (no auth required).
+ * - `POST` replies to the supplied conversation. When the request carries a valid
+ *   session (bearer token or `rivus_session` cookie) the reply can draw on the
+ *   user's company and knowledge base; otherwise Rivus nudges them to sign in.
  * - `OPTIONS` answers the CORS preflight.
  */
-export async function handleChat(request: Request): Promise<Response> {
+export async function handleChat(
+	request: Request,
+	env?: Env,
+	fetchImpl?: typeof globalThis.fetch,
+): Promise<Response> {
 	if (request.method === 'OPTIONS') {
-		return corsPreflight(request);
+		return corsPreflight(request, env);
 	}
 	if (request.method === 'GET') {
-		return jsonResponse(replyTo([]), request);
+		return jsonResponse(replyTo([]), request, 200, env);
 	}
 	if (request.method !== 'POST') {
-		return jsonResponse({ error: 'Method Not Allowed', message: 'Use POST to chat' }, request, 405);
+		return jsonResponse(
+			{ error: 'Method Not Allowed', message: 'Use POST to chat' },
+			request,
+			405,
+			env,
+		);
 	}
 	const messages = parseMessages(await readJson(request));
-	return jsonResponse(replyTo(messages), request);
+	const reply = await respond({ env: env ?? ({} as Env), request, messages, fetchImpl });
+	return jsonResponse({ reply }, request, 200, env);
 }
 
 /**
@@ -110,13 +157,13 @@ export async function handleChat(request: Request): Promise<Response> {
  * and root probes. Returns `null` when the request should fall through to the
  * Agents SDK router. Pure, so `index.ts` stays a thin adapter.
  */
-export function handlePublicRoute(request: Request): Response | null {
+export function handlePublicRoute(request: Request, env?: Env): Response | null {
 	if (request.method === 'OPTIONS') {
-		return corsPreflight(request);
+		return corsPreflight(request, env);
 	}
 	const { pathname } = new URL(request.url);
 	if (pathname === '/health' || pathname === '/') {
-		return healthResponse(request);
+		return healthResponse(request, env);
 	}
 	return null;
 }

--- a/packages/agent/src/http.ts
+++ b/packages/agent/src/http.ts
@@ -28,16 +28,41 @@ export function parseMessages(body: unknown): ChatMessage[] {
 	return parsed.success ? parsed.data : [];
 }
 
-/** Whether a browser `Origin` may make credentialed requests to the agent. */
-function originAllowed(origin: string, allowed: string | undefined): boolean {
+/** Match an origin against one allowlist entry, supporting a single-label `*`. */
+function matchesOrigin(origin: string, pattern: string): boolean {
+	if (!pattern.includes('*')) {
+		return origin === pattern;
+	}
+	// Escape regex metachars, then turn `*` into a single-label wildcard so
+	// `https://*.rivus.ai` matches `app.rivus.ai` but not `a.b.rivus.ai` — the same
+	// rule the API's `parseCorsOrigin` uses.
+	const escaped = pattern.replace(/[.+^${}()|[\]\\?]/g, '\\$&').replace(/\*/g, '[^.]+');
+	return new RegExp(`^${escaped}$`).test(origin);
+}
+
+/**
+ * Whether a browser `Origin` may make credentialed requests to the agent.
+ *
+ * Credentialed CORS can't safely reflect a bare `*` — that would let any site
+ * make authenticated cross-origin requests and read a signed-in user's replies.
+ * So a bare `*` is refused in production (mirroring the API's boot-time guard);
+ * locally it reflects any origin for convenience. Deployed environments must list
+ * exact origins, or a single-label subdomain wildcard like `https://*.rivus.ai`.
+ */
+function originAllowed(origin: string, allowed: string | undefined, nodeEnv?: string): boolean {
 	const list = (allowed ?? '*')
 		.split(',')
 		.map((entry) => entry.trim())
 		.filter(Boolean);
 	if (list.includes('*')) {
+		if (nodeEnv === 'production') {
+			throw new Error(
+				"ALLOWED_ORIGINS must be an explicit origin allowlist in production, not '*': credentialed CORS reflects the request origin, so a wildcard would authorize every site.",
+			);
+		}
 		return true;
 	}
-	return list.includes(origin);
+	return list.some((pattern) => matchesOrigin(origin, pattern));
 }
 
 /**
@@ -60,7 +85,7 @@ export function corsHeaders(request: Request, env?: Env): Record<string, string>
 		'Access-Control-Max-Age': '86400',
 	};
 	const origin = request.headers.get('Origin');
-	if (origin && originAllowed(origin, env?.ALLOWED_ORIGINS)) {
+	if (origin && originAllowed(origin, env?.ALLOWED_ORIGINS, env?.NODE_ENV)) {
 		return {
 			...base,
 			'Access-Control-Allow-Origin': origin,

--- a/packages/agent/src/http.ts
+++ b/packages/agent/src/http.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { respond } from './assistant';
+import { parseCookies, SESSION_COOKIE } from './auth';
 import { replyTo } from './conversation';
 import type { ChatMessage, Env } from './types';
 
@@ -171,9 +172,50 @@ export async function handleChat(
 			env,
 		);
 	}
+	const csrf = csrfBlock(request, env);
+	if (csrf) {
+		return csrf;
+	}
 	const messages = parseMessages(await readJson(request));
 	const reply = await respond({ env: env ?? ({} as Env), request, messages, fetchImpl });
 	return jsonResponse({ reply }, request, 200, env);
+}
+
+/**
+ * CSRF guard for cookie-authenticated POSTs. CORS only controls whether the
+ * browser may *read* the response — it doesn't stop the request from running and
+ * mutating data (create/update FAQ). A `rivus_session` cookie scoped to the parent
+ * domain rides along on same-site requests (SameSite=Lax), so a malicious or
+ * compromised sibling subdomain could drive a write. Bearer requests aren't
+ * CSRF-able (an attacker can't supply the token), so we guard only requests that
+ * carry the cookie and no `Authorization` header, and require an allowlisted
+ * `Origin` — mirroring the API's CSRF hook. Skipped in local-dev wildcard mode.
+ */
+function csrfBlock(request: Request, env?: Env): Response | null {
+	const list = (env?.ALLOWED_ORIGINS ?? '*')
+		.split(',')
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+	if (list.includes('*')) {
+		// Local development (wildcard CORS) stays permissive, like the API.
+		return null;
+	}
+	const cookieAuthed =
+		SESSION_COOKIE in parseCookies(request.headers.get('cookie')) &&
+		!request.headers.get('authorization');
+	if (!cookieAuthed) {
+		return null;
+	}
+	const origin = request.headers.get('Origin');
+	if (origin && originAllowed(origin, env?.ALLOWED_ORIGINS, env?.NODE_ENV)) {
+		return null;
+	}
+	return jsonResponse(
+		{ error: 'Forbidden', message: 'Cross-origin request blocked' },
+		request,
+		403,
+		env,
+	);
 }
 
 /**

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,7 +11,7 @@ export default {
 	async fetch(request: Request, env: Env): Promise<Response> {
 		// Health, root, and CORS preflights are answered without spinning up an
 		// agent instance.
-		const direct = handlePublicRoute(request);
+		const direct = handlePublicRoute(request, env);
 		if (direct) {
 			return direct;
 		}
@@ -19,6 +19,6 @@ export default {
 		// Everything under `/agents/:agent/:name` is dispatched to the matching
 		// Durable Object by the Agents SDK; it returns null when nothing matches.
 		const routed = await routeAgentRequest(request, env);
-		return routed ?? notFoundResponse(request, new URL(request.url).pathname);
+		return routed ?? notFoundResponse(request, new URL(request.url).pathname, env);
 	},
 } satisfies ExportedHandler<Env>;

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -13,6 +13,12 @@ describe('parseIntent — conversational', () => {
 		expect(parseIntent('Good morning')).toEqual({ kind: 'greeting' });
 	});
 
+	it('recognises greetings with trailing punctuation', () => {
+		expect(parseIntent('hi!')).toEqual({ kind: 'greeting' });
+		expect(parseIntent('Hello.')).toEqual({ kind: 'greeting' });
+		expect(parseIntent('hey!!!')).toEqual({ kind: 'greeting' });
+	});
+
 	it('recognises help asks', () => {
 		expect(parseIntent('help')).toEqual({ kind: 'help' });
 		expect(parseIntent('What can you do?')).toEqual({ kind: 'help' });

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { parseIntent } from './intent';
+
+describe('parseIntent — conversational', () => {
+	it('treats an empty message as a greeting', () => {
+		expect(parseIntent('')).toEqual({ kind: 'greeting' });
+		expect(parseIntent('   ')).toEqual({ kind: 'greeting' });
+	});
+
+	it('recognises bare greetings', () => {
+		expect(parseIntent('hi')).toEqual({ kind: 'greeting' });
+		expect(parseIntent('Hello')).toEqual({ kind: 'greeting' });
+		expect(parseIntent('Good morning')).toEqual({ kind: 'greeting' });
+	});
+
+	it('recognises help asks', () => {
+		expect(parseIntent('help')).toEqual({ kind: 'help' });
+		expect(parseIntent('What can you do?')).toEqual({ kind: 'help' });
+		expect(parseIntent('how can you help me')).toEqual({ kind: 'help' });
+	});
+
+	it('falls back to unknown for an unrelated ask', () => {
+		expect(parseIntent('what is the meaning of life')).toEqual({ kind: 'unknown' });
+	});
+});
+
+describe('parseIntent — company info', () => {
+	it('detects a single field', () => {
+		expect(parseIntent('what is our website?')).toEqual({
+			kind: 'company_info',
+			fields: ['website'],
+		});
+		expect(parseIntent("what's our phone number")).toEqual({
+			kind: 'company_info',
+			fields: ['phone'],
+		});
+		expect(parseIntent('show me my address')).toEqual({
+			kind: 'company_info',
+			fields: ['address'],
+		});
+		expect(parseIntent('what time zone are we in')).toEqual({
+			kind: 'company_info',
+			fields: ['timezone'],
+		});
+	});
+
+	it('collects multiple requested fields in a stable order', () => {
+		expect(parseIntent('what are our website and phone number?')).toEqual({
+			kind: 'company_info',
+			fields: ['website', 'phone'],
+		});
+	});
+
+	it('treats a generic company ask as "everything" (empty fields)', () => {
+		expect(parseIntent('tell me about my business')).toEqual({ kind: 'company_info', fields: [] });
+		expect(parseIntent('show my company info')).toEqual({ kind: 'company_info', fields: [] });
+	});
+});
+
+describe('parseIntent — knowledge base', () => {
+	it('lists the knowledge base for a bare reference', () => {
+		expect(parseIntent('faqs')).toEqual({ kind: 'faq_list' });
+		expect(parseIntent('show me the knowledge base')).toEqual({ kind: 'faq_list' });
+		expect(parseIntent('list our FAQs')).toEqual({ kind: 'faq_list' });
+	});
+
+	it('extracts a search query', () => {
+		expect(parseIntent('search the FAQ for refunds')).toEqual({
+			kind: 'faq_search',
+			query: 'refunds',
+		});
+		expect(parseIntent('do we have an FAQ about parking?')).toEqual({
+			kind: 'faq_search',
+			query: 'parking',
+		});
+		expect(parseIntent('find FAQs about pricing')).toEqual({
+			kind: 'faq_search',
+			query: 'pricing',
+		});
+	});
+
+	it('parses an update with a new answer', () => {
+		expect(
+			parseIntent('update the FAQ about returns to say we accept returns within 30 days'),
+		).toEqual({
+			kind: 'faq_update',
+			topic: 'returns',
+			answer: 'we accept returns within 30 days',
+		});
+	});
+
+	it('parses an update without an answer (topic only)', () => {
+		expect(parseIntent('change the FAQ about shipping')).toEqual({
+			kind: 'faq_update',
+			topic: 'shipping',
+			answer: null,
+		});
+	});
+
+	it('asks for a topic when an update names none', () => {
+		expect(parseIntent('update an FAQ')).toEqual({ kind: 'faq_update', topic: '', answer: null });
+	});
+
+	it('parses a create with an explicit question/answer', () => {
+		expect(parseIntent('add an FAQ question: Do you ship? answer: Yes we do')).toEqual({
+			kind: 'faq_create',
+			question: 'Do you ship?',
+			answer: 'Yes we do',
+		});
+	});
+
+	it('parses a create with only a topic', () => {
+		expect(parseIntent('create a new FAQ about warranty')).toEqual({
+			kind: 'faq_create',
+			question: 'warranty',
+			answer: null,
+		});
+	});
+
+	it('parses a bare create with neither part', () => {
+		expect(parseIntent('add a faq')).toEqual({
+			kind: 'faq_create',
+			question: null,
+			answer: null,
+		});
+	});
+
+	it('routes a knowledge-base topic ask to search even without a search verb', () => {
+		expect(parseIntent('knowledge base about onboarding')).toEqual({
+			kind: 'faq_search',
+			query: 'onboarding',
+		});
+	});
+});

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -103,6 +103,20 @@ describe('parseIntent — knowledge base', () => {
 		});
 	});
 
+	it('keeps a multi-word topic that itself contains "to" intact', () => {
+		expect(parseIntent('update the faq about how to cancel to say just email us')).toEqual({
+			kind: 'faq_update',
+			topic: 'how to cancel',
+			answer: 'just email us',
+		});
+		// Bare "to" connector: split at the LAST " to ", not the first.
+		expect(parseIntent('change the faq about ways to pay to credit and cash')).toEqual({
+			kind: 'faq_update',
+			topic: 'ways to pay',
+			answer: 'credit and cash',
+		});
+	});
+
 	it('asks for a topic when an update names none', () => {
 		expect(parseIntent('update an FAQ')).toEqual({ kind: 'faq_update', topic: '', answer: null });
 	});
@@ -121,6 +135,18 @@ describe('parseIntent — knowledge base', () => {
 			question: 'warranty',
 			answer: null,
 		});
+	});
+
+	it('does not let a hyphenated "a" in the question hijack the answer split', () => {
+		expect(parseIntent('add an FAQ question: is there a-la-carte pricing answer: yes')).toEqual({
+			kind: 'faq_create',
+			question: 'is there a-la-carte pricing',
+			answer: 'yes',
+		});
+	});
+
+	it('treats "find FAQs in our knowledge base" as a list, not a search for "knowledge base"', () => {
+		expect(parseIntent('find FAQs in our knowledge base')).toEqual({ kind: 'faq_list' });
 	});
 
 	it('parses a bare create with neither part', () => {

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -132,8 +132,10 @@ export function parseIntent(raw: string): Intent {
 	if (HELP.test(lower)) {
 		return { kind: 'help' };
 	}
-	// A bare greeting with nothing else asked.
-	if (GREETING.test(lower) && lower.replace(GREETING, '').trim().length === 0) {
+	// A bare greeting with nothing else asked. Strip trailing punctuation first so
+	// "hi!" / "hello." still count as a plain hello rather than falling through.
+	const cleanLower = lower.replace(/[?.!]+$/, '').trim();
+	if (GREETING.test(cleanLower) && cleanLower.replace(GREETING, '').trim().length === 0) {
 		return { kind: 'greeting' };
 	}
 

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -83,7 +83,9 @@ function extractSearchQuery(text: string): string {
 	}
 	const stripped = text
 		.replace(/\b(search|find|look ?up|lookup|for|in|the|our|my)\b/gi, ' ')
-		.replace(FAQ_CONTEXT, ' ')
+		// Global flag: strip every FAQ/knowledge term, e.g. both words in
+		// "FAQs … knowledge base", so neither leaks into the query.
+		.replace(new RegExp(FAQ_CONTEXT.source, 'gi'), ' ')
 		.replace(/[?.!]+$/, '')
 		.replace(/\s+/g, ' ')
 		.trim();
@@ -92,13 +94,20 @@ function extractSearchQuery(text: string): string {
 
 /** Parse an FAQ-edit ask into its topic and (optional) replacement answer. */
 function parseFaqUpdate(text: string): { topic: string; answer: string | null } {
-	// "...about <topic> to (say) <answer>" — the richest form, both parts present.
-	const withAnswer =
-		/\b(?:about|regarding|for|on)\s+(.+?)\s+(?:to say|to read|to|so (?:that )?it (?:says|reads))\s+(.+)$/i.exec(
+	// Prefer an explicit connector ("to say"/"to read"/"so it says") — it's
+	// unambiguous, so a lazy topic is safe.
+	const explicit =
+		/\b(?:about|regarding|for|on)\s+(.+?)\s+(?:to say|to read|so (?:that )?it (?:says|reads))\s+(.+)$/i.exec(
 			text,
 		);
-	if (withAnswer?.[1] && withAnswer[2]) {
-		return { topic: trimTopic(withAnswer[1]), answer: withAnswer[2].trim().replace(/[?.!]+$/, '') };
+	if (explicit?.[1] && explicit[2]) {
+		return { topic: trimTopic(explicit[1]), answer: explicit[2].trim().replace(/[?.!]+$/, '') };
+	}
+	// Bare "to" connector. Use a *greedy* topic so a multi-word topic that itself
+	// contains "to" (e.g. "how to cancel") splits at the LAST " to ", not the first.
+	const bare = /\b(?:about|regarding|for|on)\s+(.+)\s+to\s+(.+)$/i.exec(text);
+	if (bare?.[1] && bare[2]) {
+		return { topic: trimTopic(bare[1]), answer: bare[2].trim().replace(/[?.!]+$/, '') };
 	}
 	// Just a topic: "update the FAQ about <topic>" — we'll ask what to change.
 	const topic = afterPreposition(text);
@@ -107,8 +116,10 @@ function parseFaqUpdate(text: string): { topic: string; answer: string | null } 
 
 /** Parse an FAQ-create ask into an explicit question/answer pair when supplied. */
 function parseFaqCreate(text: string): { question: string | null; answer: string | null } {
-	// "question: ... answer: ..." (or "q: ... a: ...").
-	const qa = /\b(?:question|q)\s*[:-]\s*(.+?)\s+(?:answer|a)\s*[:-]\s*(.+)$/i.exec(text);
+	// "question: ... answer: ..." (or "q: ..."). Only the full word "answer" marks
+	// the split — a bare single-letter "a" would match a stray "a-" / "a:" inside
+	// the question text (e.g. "a-la-carte") and truncate it.
+	const qa = /\b(?:question|q)\s*[:-]\s*(.+?)\s+answer\s*[:-]\s*(.+)$/i.exec(text);
 	if (qa?.[1] && qa[2]) {
 		return { question: qa[1].trim(), answer: qa[2].trim() };
 	}

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -1,0 +1,171 @@
+/**
+ * Turn a user's message into a structured {@link Intent}. This is the pure,
+ * deterministic "understanding" layer — no I/O, no model call — so it is
+ * exhaustively unit-tested and reused verbatim by the agent's reply logic.
+ *
+ * It is intentionally rule-based: the agent answers a focused set of asks
+ * (company facts + knowledge-base search/edits) where predictable, testable
+ * routing beats an opaque classifier. Swapping in an LLM later means replacing
+ * only this function — the orchestration in `assistant.ts` consumes the same
+ * `Intent` shape.
+ */
+
+/** A field of the company/account record the user can ask about. */
+export type CompanyField =
+	| 'name'
+	| 'website'
+	| 'phone'
+	| 'address'
+	| 'timezone'
+	| 'slug'
+	| 'status';
+
+export type Intent =
+	| { kind: 'greeting' }
+	| { kind: 'help' }
+	/** Asking about the company. An empty `fields` means "everything". */
+	| { kind: 'company_info'; fields: CompanyField[] }
+	/** Browse the whole knowledge base. */
+	| { kind: 'faq_list' }
+	/** Search the knowledge base for `query`. */
+	| { kind: 'faq_search'; query: string }
+	/** Edit an FAQ identified by `topic`; `answer` is the new text, or null if unsaid. */
+	| { kind: 'faq_update'; topic: string; answer: string | null }
+	/** Add an FAQ; `question`/`answer` are null when the user didn't supply them. */
+	| { kind: 'faq_create'; question: string | null; answer: string | null }
+	| { kind: 'unknown' };
+
+/** Keywords that put a message in "knowledge base" context. */
+const FAQ_CONTEXT = /\b(faqs?|knowledge[ -]?base|knowledge)\b/;
+const GREETING = /^(hi|hey|hello|yo|hiya|howdy|greetings|good (morning|afternoon|evening))\b/;
+const HELP = /\b(help|what can you do|what do you do|how can you help|what can you help with)\b/;
+
+/** Per-field keyword probes, checked to build the requested company `fields`. */
+const COMPANY_FIELD_PATTERNS: ReadonlyArray<readonly [CompanyField, RegExp]> = [
+	['website', /\b(website|web site|web address|url|homepage|home page|domain|site)\b/],
+	['phone', /\b(phone|telephone|phone number)\b/],
+	['address', /\b(address|location|street)\b/],
+	['timezone', /\b(time ?zone)\b/],
+	['name', /\b(business name|company name|name of (my|our|the) (company|business))\b/],
+	['slug', /\b(slug|handle)\b/],
+	['status', /\b(account status|subscription|plan)\b/],
+];
+
+/** Generic references to "the company" that mean "tell me everything". */
+const COMPANY_GENERIC =
+	/\b(company|business|account|my (info|information|details)|our (info|information|details)|about (my|our|the) (company|business)|profile)\b/;
+
+const UPDATE_VERB = /\b(update|change|edit|revise|modify|fix)\b/;
+const CREATE_VERB = /\b(add|create|new|make|insert)\b/;
+const LIST_VERB = /\b(list|show|view|see|browse|all (of )?(my|our|the)?)\b/;
+const SEARCH_VERB = /\b(search|find|look ?up|lookup|do we have|is there|tell me about)\b/;
+
+/** Strip a leading article so an extracted topic reads cleanly. */
+function trimTopic(value: string): string {
+	return value
+		.trim()
+		.replace(/^(the|an|a|our|my)\s+/i, '')
+		.replace(/[?.!]+$/, '')
+		.trim();
+}
+
+/** Pull the phrase after the first "about/for/on/regarding", if any. */
+function afterPreposition(text: string): string | null {
+	const match = /\b(?:about|regarding|related to|on the topic of|for|on)\s+(.+)$/i.exec(text);
+	return match?.[1] ? trimTopic(match[1]) : null;
+}
+
+/** A search query for an FAQ ask: the topic phrase, else the message minus FAQ/verb noise. */
+function extractSearchQuery(text: string): string {
+	const after = afterPreposition(text);
+	if (after) {
+		return after;
+	}
+	const stripped = text
+		.replace(/\b(search|find|look ?up|lookup|for|in|the|our|my)\b/gi, ' ')
+		.replace(FAQ_CONTEXT, ' ')
+		.replace(/[?.!]+$/, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+	return stripped;
+}
+
+/** Parse an FAQ-edit ask into its topic and (optional) replacement answer. */
+function parseFaqUpdate(text: string): { topic: string; answer: string | null } {
+	// "...about <topic> to (say) <answer>" — the richest form, both parts present.
+	const withAnswer =
+		/\b(?:about|regarding|for|on)\s+(.+?)\s+(?:to say|to read|to|so (?:that )?it (?:says|reads))\s+(.+)$/i.exec(
+			text,
+		);
+	if (withAnswer?.[1] && withAnswer[2]) {
+		return { topic: trimTopic(withAnswer[1]), answer: withAnswer[2].trim().replace(/[?.!]+$/, '') };
+	}
+	// Just a topic: "update the FAQ about <topic>" — we'll ask what to change.
+	const topic = afterPreposition(text);
+	return { topic: topic ?? '', answer: null };
+}
+
+/** Parse an FAQ-create ask into an explicit question/answer pair when supplied. */
+function parseFaqCreate(text: string): { question: string | null; answer: string | null } {
+	// "question: ... answer: ..." (or "q: ... a: ...").
+	const qa = /\b(?:question|q)\s*[:-]\s*(.+?)\s+(?:answer|a)\s*[:-]\s*(.+)$/i.exec(text);
+	if (qa?.[1] && qa[2]) {
+		return { question: qa[1].trim(), answer: qa[2].trim() };
+	}
+	// Otherwise treat any "about <topic>" as the question and ask for the answer.
+	const topic = afterPreposition(text);
+	return { question: topic, answer: null };
+}
+
+/**
+ * Classify a single user message. Precedence matters: knowledge-base asks are
+ * matched before company facts (so "search the FAQ about our hours" routes to
+ * search, not the company record), and the most specific verbs win within each.
+ */
+export function parseIntent(raw: string): Intent {
+	const text = raw.trim();
+	const lower = text.toLowerCase();
+
+	if (lower.length === 0) {
+		return { kind: 'greeting' };
+	}
+	if (HELP.test(lower)) {
+		return { kind: 'help' };
+	}
+	// A bare greeting with nothing else asked.
+	if (GREETING.test(lower) && lower.replace(GREETING, '').trim().length === 0) {
+		return { kind: 'greeting' };
+	}
+
+	if (FAQ_CONTEXT.test(lower)) {
+		if (UPDATE_VERB.test(lower)) {
+			return { kind: 'faq_update', ...parseFaqUpdate(text) };
+		}
+		if (CREATE_VERB.test(lower)) {
+			return { kind: 'faq_create', ...parseFaqCreate(text) };
+		}
+		// Search wins over list when there's an actual subject to search for.
+		if (SEARCH_VERB.test(lower) || afterPreposition(lower)) {
+			const query = extractSearchQuery(text);
+			return query.length > 0 ? { kind: 'faq_search', query } : { kind: 'faq_list' };
+		}
+		if (LIST_VERB.test(lower)) {
+			return { kind: 'faq_list' };
+		}
+		// A bare "faqs" / "knowledge base" — show the list.
+		return { kind: 'faq_list' };
+	}
+
+	const fields = COMPANY_FIELD_PATTERNS.filter(([, pattern]) => pattern.test(lower)).map(
+		([field]) => field,
+	);
+	if (fields.length > 0) {
+		return { kind: 'company_info', fields };
+	}
+	if (COMPANY_GENERIC.test(lower)) {
+		// Generic ask → return the whole record.
+		return { kind: 'company_info', fields: [] };
+	}
+
+	return { kind: 'unknown' };
+}

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1,8 +1,38 @@
+import type { AuthTokenPayload } from '@rivus/core';
+
 /** Bindings configured in wrangler.jsonc (and any secrets added at deploy time). */
 export interface Env {
 	/** The Rivus agent Durable Object namespace (see wrangler.jsonc). */
 	RivusAgent: DurableObjectNamespace;
+	/**
+	 * Shared HS256 secret used to verify the session JWTs that `@rivus/api` issues.
+	 * It must match the API's `JWT_SECRET` so a token signed by the API verifies
+	 * here. Set as a Worker secret (`wrangler secret put JWT_SECRET`), never a
+	 * plaintext var. When unset the agent simply treats every request as anonymous.
+	 */
+	JWT_SECRET?: string;
+	/**
+	 * Base URL of the Rivus REST API the agent calls on the signed-in user's behalf
+	 * (e.g. `https://api.rivus.ai`). The agent forwards the user's token so the API
+	 * stays the single authority for tenant data and permission checks.
+	 */
+	RIVUS_API_URL?: string;
+	/**
+	 * Comma-separated browser origins allowed to make credentialed (cookie-bearing)
+	 * requests, e.g. `https://app.rivus.ai`. A bare `*` (the default, for local
+	 * development) reflects any origin. Credentialed CORS can't use a wildcard, so
+	 * production must list the app's exact origin — otherwise any site could read a
+	 * signed-in user's agent replies.
+	 */
+	ALLOWED_ORIGINS?: string;
 }
+
+/**
+ * The claims carried by a verified Rivus session JWT — the same payload
+ * `@rivus/api` signs at sign-in (`sub`, `email`, `accountId`, `role`). Reused
+ * here so the agent and API agree on exactly what a session means.
+ */
+export type SessionClaims = AuthTokenPayload;
 
 /** A single chat turn. Mirrors the shape the app's agent client sends. */
 export interface ChatMessage {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -25,6 +25,13 @@ export interface Env {
 	 * signed-in user's agent replies.
 	 */
 	ALLOWED_ORIGINS?: string;
+	/**
+	 * Deployment mode (`production` | `development`). In `production` a wildcard
+	 * `ALLOWED_ORIGINS` is refused so credentialed CORS can never reflect an
+	 * arbitrary origin — mirroring the API's boot-time guard. Set per environment
+	 * in wrangler.jsonc; unset locally (treated as development).
+	 */
+	NODE_ENV?: string;
 }
 
 /**

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -12,7 +12,14 @@ export default defineConfig({
 			// SDK (which pulls in `cloudflare:workers`, unavailable under Node), so they
 			// are validated by `wrangler deploy --dry-run` and local `wrangler dev`
 			// rather than unit tests — see README.
-			include: ['src/conversation.ts', 'src/http.ts'],
+			include: [
+				'src/conversation.ts',
+				'src/http.ts',
+				'src/auth.ts',
+				'src/api.ts',
+				'src/intent.ts',
+				'src/assistant.ts',
+			],
 			exclude: ['src/**/*.test.ts'],
 			thresholds: {
 				lines: 90,

--- a/packages/agent/wrangler.jsonc
+++ b/packages/agent/wrangler.jsonc
@@ -33,7 +33,10 @@
 		"development": {
 			"name": "rivus-agent-dev",
 			"routes": [{ "pattern": "dev-agent.rivus.ai", "custom_domain": true }],
+			// Deployed environments run in production mode with an explicit origin
+			// allowlist (never `*`), so the credentialed-CORS guard stays satisfied.
 			"vars": {
+				"NODE_ENV": "production",
 				"RIVUS_API_URL": "https://dev-api.rivus.ai",
 				"ALLOWED_ORIGINS": "https://dev-app.rivus.ai"
 			},
@@ -45,6 +48,7 @@
 			"name": "rivus-agent",
 			"routes": [{ "pattern": "agent.rivus.ai", "custom_domain": true }],
 			"vars": {
+				"NODE_ENV": "production",
 				"RIVUS_API_URL": "https://api.rivus.ai",
 				"ALLOWED_ORIGINS": "https://app.rivus.ai"
 			},

--- a/packages/agent/wrangler.jsonc
+++ b/packages/agent/wrangler.jsonc
@@ -9,6 +9,15 @@
 	"observability": {
 		"enabled": true
 	},
+	// Plain (non-secret) vars for local `wrangler dev`. `RIVUS_API_URL` is the Rivus
+	// REST API the agent calls on a signed-in user's behalf; `ALLOWED_ORIGINS` is the
+	// credentialed-CORS allowlist (`*` reflects any origin — local dev only).
+	// The shared `JWT_SECRET` (used to verify session tokens; must match the API's)
+	// is a *secret*, not a var: set it with `wrangler secret put JWT_SECRET`.
+	"vars": {
+		"RIVUS_API_URL": "http://localhost:4000",
+		"ALLOWED_ORIGINS": "*"
+	},
 	// Each Agent is a SQLite-backed Durable Object. The binding name kebab-cases to
 	// the URL segment the SDK routes on: `RivusAgent` -> `/agents/rivus-agent/:name`.
 	"durable_objects": {
@@ -16,12 +25,18 @@
 	},
 	"migrations": [{ "tag": "v1", "new_sqlite_classes": ["RivusAgent"] }],
 	// Named environments. `durable_objects` is non-inheritable, so each environment
-	// redeclares it; `main`, `migrations` and `observability` are inherited.
-	// Deploy with `wrangler deploy --env development`.
+	// redeclares it; `main`, `migrations` and `observability` are inherited. Each
+	// environment pins its own `RIVUS_API_URL` and `ALLOWED_ORIGINS` (the latter
+	// must be the app's exact origin in deployed environments — credentialed CORS
+	// can't use a wildcard). Deploy with `wrangler deploy --env development`.
 	"env": {
 		"development": {
 			"name": "rivus-agent-dev",
 			"routes": [{ "pattern": "dev-agent.rivus.ai", "custom_domain": true }],
+			"vars": {
+				"RIVUS_API_URL": "https://dev-api.rivus.ai",
+				"ALLOWED_ORIGINS": "https://dev-app.rivus.ai"
+			},
 			"durable_objects": {
 				"bindings": [{ "name": "RivusAgent", "class_name": "RivusAgent" }]
 			}
@@ -29,6 +44,10 @@
 		"production": {
 			"name": "rivus-agent",
 			"routes": [{ "pattern": "agent.rivus.ai", "custom_domain": true }],
+			"vars": {
+				"RIVUS_API_URL": "https://api.rivus.ai",
+				"ALLOWED_ORIGINS": "https://app.rivus.ai"
+			},
 			"durable_objects": {
 				"bindings": [{ "name": "RivusAgent", "class_name": "RivusAgent" }]
 			}

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1,4 +1,4 @@
-import cors from '@fastify/cors';
+import cors, { type FastifyCorsOptionsDelegateCallback } from '@fastify/cors';
 import helmet from '@fastify/helmet';
 import sensible from '@fastify/sensible';
 import Fastify, { type FastifyError, type FastifyInstance } from 'fastify';
@@ -112,23 +112,37 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 			'CORS_ORIGIN must be an explicit origin allowlist in production, not "*": credentialed CORS reflects the request origin, so a wildcard would authorize every site.',
 		);
 	}
-	app.register(cors, {
-		// Web clients send the session cookie cross-origin (app.rivus.ai →
-		// api.rivus.ai), which requires credentialed CORS. A credentialed request
-		// can't use a wildcard `Access-Control-Allow-Origin`, so reflect the request
-		// origin when configured wide-open (local dev only) and otherwise echo only
-		// the configured allowlist.
-		origin: corsOrigin === '*' ? true : corsOrigin,
-		credentials: true,
-		// `@fastify/cors` v11 narrowed its default `methods` to `GET,HEAD,POST`, so
-		// preflight for any other verb answers without it in
-		// `Access-Control-Allow-Methods` — the browser then blocks the real request
-		// and `fetch` rejects with "Failed to fetch". The web app's writes are
-		// cross-origin (app.rivus.ai → api.rivus.ai) and preflighted, so without
-		// this every PATCH (edit FAQ, update account) and DELETE (remove FAQ) fails.
-		// Advertise exactly the verbs the API serves.
-		methods: ['GET', 'HEAD', 'POST', 'PATCH', 'DELETE'],
-	});
+	// The app's own origin: the only one allowed to make *credentialed* (cookie-
+	// bearing) cross-origin requests in deployed environments (see below).
+	const appOrigin = new URL(deps.config.APP_URL).origin;
+	// A per-request CORS delegate so credentials can vary by origin.
+	//
+	// Web clients send the session cookie cross-origin (app.rivus.ai →
+	// api.rivus.ai), which requires credentialed CORS — and a credentialed response
+	// can't use a wildcard `Access-Control-Allow-Origin`, so reflect the request
+	// origin when wide-open (local dev only) and otherwise echo only the configured
+	// allowlist. The session cookie is scoped to the parent domain (`.rivus.ai`) so
+	// it also reaches the app and the agent — which means a *sibling* subdomain
+	// (marketing, docs) could send it too. To stop those origins from *reading*
+	// cookie-authenticated responses, credentialed CORS is granted only to the app's
+	// own origin; other allowlisted origins still get plain CORS for public reads
+	// (e.g. `/health`). Local dev (wildcard) stays fully permissive.
+	const corsDelegate: FastifyCorsOptionsDelegateCallback = (request, callback) => {
+		const credentials = corsOrigin === '*' || request.headers.origin === appOrigin;
+		callback(null, {
+			origin: corsOrigin === '*' ? true : corsOrigin,
+			credentials,
+			// `@fastify/cors` v11 narrowed its default `methods` to `GET,HEAD,POST`, so
+			// preflight for any other verb answers without it in
+			// `Access-Control-Allow-Methods` — the browser then blocks the real request
+			// and `fetch` rejects with "Failed to fetch". The web app's writes are
+			// cross-origin (app.rivus.ai → api.rivus.ai) and preflighted, so without
+			// this every PATCH (edit FAQ, update account) and DELETE (remove FAQ) fails.
+			// Advertise exactly the verbs the API serves.
+			methods: ['GET', 'HEAD', 'POST', 'PATCH', 'DELETE'],
+		});
+	};
+	app.register(cors, () => corsDelegate);
 
 	// CSRF defense for cookie-authenticated writes. The session cookie rides along
 	// automatically on same-site requests, so a malicious or compromised same-site
@@ -137,7 +151,6 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	// unsafe methods that actually carry the session cookie, and require the request
 	// to originate from the app itself. Local development (wildcard CORS) stays
 	// permissive; the deployed environments (an explicit allowlist) enforce it.
-	const appOrigin = new URL(deps.config.APP_URL).origin;
 	const enforceCsrf = corsOrigin !== '*';
 	app.addHook('onRequest', async (request) => {
 		if (!enforceCsrf || request.method === 'GET' || request.method === 'HEAD') {

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -12,6 +12,11 @@ const envSchema = z
 			.default('mongodb://localhost:27017/rivus?replicaSet=rs0&directConnection=true'),
 		JWT_SECRET: z.string().min(8).default(DEV_JWT_SECRET),
 		JWT_EXPIRES_IN: z.string().default('7d'),
+		// Domain the session cookie is scoped to. Unset (the default) makes it a
+		// host-only cookie for the API's own host. Set it to the shared parent domain
+		// (e.g. `.rivus.ai`) so sibling subdomains — the app *and the agent* — receive
+		// the cookie, which is what lets a web user chat with an authenticated agent.
+		COOKIE_DOMAIN: z.string().min(1).optional(),
 		LOG_LEVEL: z
 			.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'])
 			.default('info'),

--- a/packages/api/src/plugins/auth.ts
+++ b/packages/api/src/plugins/auth.ts
@@ -15,6 +15,10 @@ export const SESSION_COOKIE = 'rivus_session';
  * app's API calls while cross-site requests don't send it), and `Secure` in
  * production where everything is HTTPS. `maxAge` is passed in to match the JWT's
  * own expiry so the browser drops the cookie exactly when the token dies.
+ *
+ * When `COOKIE_DOMAIN` is configured (e.g. `.rivus.ai`) the cookie is scoped to
+ * that parent domain so every sibling subdomain — the app and the agent — receives
+ * it; left unset it stays a host-only cookie for the API alone.
  */
 export function sessionCookieOptions(
 	config: Config,
@@ -25,6 +29,7 @@ export function sessionCookieOptions(
 		secure: config.NODE_ENV === 'production',
 		sameSite: 'lax',
 		path: '/',
+		...(config.COOKIE_DOMAIN ? { domain: config.COOKIE_DOMAIN } : {}),
 		...(maxAgeSeconds !== undefined ? { maxAge: maxAgeSeconds } : {}),
 	};
 }

--- a/packages/api/test/auth.test.ts
+++ b/packages/api/test/auth.test.ts
@@ -1,6 +1,7 @@
 import type { AccountId, UserId } from '@rivus/core';
 import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadConfig } from '../src/config';
 import { SESSION_COOKIE } from '../src/plugins/auth';
 import { ConflictError } from '../src/repositories/errors';
 import { createInMemoryRepositories } from '../src/repositories/memory';
@@ -545,5 +546,33 @@ describe('session cookie', () => {
 		// Cleared: the cookie is re-sent with an empty value so the browser drops it.
 		expect(setCookieHeader(res)).toContain(`${SESSION_COOKIE}=`);
 		expect(sessionCookieValue(res)).toBe('');
+	});
+
+	it('scopes the cookie to COOKIE_DOMAIN so subdomains (app, agent) receive it', async () => {
+		// A parent-domain cookie is what lets a web user reach an authenticated agent
+		// on a sibling subdomain (agent.rivus.ai) with the session set by the API.
+		const scoped = await buildTestApp({
+			config: loadConfig({
+				NODE_ENV: 'test',
+				JWT_SECRET: 'test-secret-value-1234',
+				COOKIE_DOMAIN: '.rivus.ai',
+			} as NodeJS.ProcessEnv),
+		});
+		const email = 'domain@example.com';
+		await requestSignup(scoped, signupBody({ email }));
+		const verified = await verifyCode(scoped, email, latestCodeFor(scoped, email));
+		expect(setCookieHeader(verified)).toMatch(/Domain=\.rivus\.ai/i);
+
+		// Logout must clear with the same Domain or the browser won't drop it.
+		const out = await scoped.inject({ method: 'POST', url: '/v1/auth/logout' });
+		expect(setCookieHeader(out)).toMatch(/Domain=\.rivus\.ai/i);
+		await scoped.close();
+	});
+
+	it('omits the Domain attribute when COOKIE_DOMAIN is unset (host-only)', async () => {
+		const email = 'hostonly@example.com';
+		await requestSignup(app, signupBody({ email }));
+		const verified = await verifyCode(app, email, latestCodeFor(app, email));
+		expect(setCookieHeader(verified)).not.toMatch(/Domain=/i);
 	});
 });

--- a/packages/api/test/cors.test.ts
+++ b/packages/api/test/cors.test.ts
@@ -66,6 +66,19 @@ describe('CORS', () => {
 		expect(res.headers['access-control-allow-credentials']).toBe('true');
 	});
 
+	it('grants credentials only to the app origin, not other allowlisted origins', async () => {
+		// The default test APP_URL is https://app.rivus.ai. A sibling origin (the
+		// marketing site) is still allowlisted for plain CORS — so public reads like
+		// /health work — but must NOT get credentialed CORS, or it could read a
+		// signed-in user's cookie-authenticated responses once the cookie is
+		// parent-domain scoped.
+		app = buildAppWithCors('https://app.rivus.ai,https://www.rivus.ai');
+		const res = await preflight(app, 'https://www.rivus.ai');
+
+		expect(res.headers['access-control-allow-origin']).toBe('https://www.rivus.ai');
+		expect(res.headers['access-control-allow-credentials']).toBeUndefined();
+	});
+
 	it('advertises the write verbs the API serves (PATCH, DELETE) in preflight', async () => {
 		// `@fastify/cors` v11 narrowed its default `methods` to `GET,HEAD,POST`. Without
 		// an explicit list, a cross-origin PATCH/DELETE preflight (editing or deleting an

--- a/packages/api/worker/index.ts
+++ b/packages/api/worker/index.ts
@@ -9,6 +9,9 @@ export interface Env {
 	RESEND_API_KEY: string;
 	EMAIL_FROM: string;
 	APP_URL: string;
+	// Optional: scopes the session cookie to a parent domain (e.g. `.rivus.ai`) so
+	// sibling subdomains (the app and the agent) receive it. Unset → host-only.
+	COOKIE_DOMAIN?: string;
 	// AI provider keys + model overrides for duplicate-FAQ detection (all optional;
 	// when none is set the check degrades to a no-op).
 	OPENAI_API_KEY?: string;
@@ -40,6 +43,7 @@ export class ApiContainer extends Container<Env> {
 		...(this.env.MONGODB_URI ? { MONGODB_URI: this.env.MONGODB_URI } : {}),
 		...(this.env.JWT_SECRET ? { JWT_SECRET: this.env.JWT_SECRET } : {}),
 		...(this.env.CORS_ORIGIN ? { CORS_ORIGIN: this.env.CORS_ORIGIN } : {}),
+		...(this.env.COOKIE_DOMAIN ? { COOKIE_DOMAIN: this.env.COOKIE_DOMAIN } : {}),
 		...(this.env.RESEND_API_KEY ? { RESEND_API_KEY: this.env.RESEND_API_KEY } : {}),
 		...(this.env.EMAIL_FROM ? { EMAIL_FROM: this.env.EMAIL_FROM } : {}),
 		...(this.env.APP_URL ? { APP_URL: this.env.APP_URL } : {}),

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -36,10 +36,16 @@
 			"name": "rivus-api-dev",
 			"routes": [{ "pattern": "dev-api.rivus.ai", "custom_domain": true }],
 			"vars": {
-				// The container runs NODE_ENV=production, where credentialed CORS
-				// forbids a `*` wildcard (it would authorize every origin). Restrict to
-				// Rivus subdomains, which covers dev-app.rivus.ai.
-				"CORS_ORIGIN": "*.rivus.ai",
+				// The container runs NODE_ENV=production, where credentialed CORS forbids
+				// a `*` wildcard. List the exact dev origins that call the API from a
+				// browser (the app and the marketing site) rather than a `*.rivus.ai`
+				// wildcard — with a parent-domain session cookie, any subdomain a wildcard
+				// allowed could otherwise read cookie-authenticated responses.
+				"CORS_ORIGIN": "https://dev-app.rivus.ai,https://dev.rivus.ai",
+				// Scope the session cookie to the shared parent domain so it reaches the
+				// app and the agent (dev-app/dev-agent.rivus.ai). Only the app origin is
+				// granted credentialed CORS, so siblings can't read authenticated data.
+				"COOKIE_DOMAIN": ".rivus.ai",
 				// Base URL for the accept-invite / sign-in-code links in emails.
 				"APP_URL": "https://dev-app.rivus.ai"
 			},
@@ -58,12 +64,17 @@
 		"production": {
 			"name": "rivus-api",
 			"routes": [{ "pattern": "api.rivus.ai", "custom_domain": true }],
-			// Restrict cross-origin requests to Rivus origins: the apex
-			// `https://rivus.ai` plus any `*.rivus.ai` subdomain over http/https.
-			// The API parses this (see src/config.ts `parseCorsOrigin`) into an
-			// exact origin and a regex.
+			// Restrict cross-origin requests to the exact Rivus origins that call the
+			// API from a browser: the app plus the marketing site (apex + www). A
+			// `*.rivus.ai` wildcard is intentionally avoided — with a parent-domain
+			// session cookie, any subdomain it allowed could read cookie-authenticated
+			// responses. Only the app origin (APP_URL) is granted credentialed CORS.
 			"vars": {
-				"CORS_ORIGIN": "https://rivus.ai,*.rivus.ai",
+				"CORS_ORIGIN": "https://app.rivus.ai,https://rivus.ai,https://www.rivus.ai",
+				// Scope the session cookie to the shared parent domain so it reaches the
+				// app and the agent (app/agent.rivus.ai), enabling web chat with an
+				// authenticated agent.
+				"COOKIE_DOMAIN": ".rivus.ai",
 				// Base URL for the accept-invite / sign-in-code links in emails.
 				"APP_URL": "https://app.rivus.ai"
 			},

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -130,8 +130,14 @@ function Gate() {
 
 function Shell() {
 	const { width } = useWindowDimensions();
-	const { isStaff } = useAuth();
+	const { isStaff, session } = useAuth();
 	const wide = width >= SIDEBAR_BREAKPOINT;
+
+	// Remount the agent chat when the active account changes (a staff "switch
+	// company" swaps the session in place). Its transcript and answers are
+	// tenant-specific, so keying on the account id discards one company's
+	// conversation instead of leaking it — or re-sending it — into the next.
+	const chatKey = session?.account.id;
 
 	if (wide) {
 		return (
@@ -143,7 +149,7 @@ function Shell() {
 						<Slot />
 					</View>
 				</View>
-				<RivusChat />
+				<RivusChat key={chatKey} />
 			</View>
 		);
 	}
@@ -161,7 +167,7 @@ function Shell() {
 			<View style={styles.content}>
 				<Slot />
 			</View>
-			<RivusChat />
+			<RivusChat key={chatKey} />
 		</View>
 	);
 }

--- a/packages/app/src/agent/client.test.ts
+++ b/packages/app/src/agent/client.test.ts
@@ -47,4 +47,28 @@ describe('createAgentClient', () => {
 
 		await expect(client.chat([])).rejects.toThrow();
 	});
+
+	it('forwards a bearer token when one is provided (native)', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(jsonResponse({ reply: 'hi' }));
+		const client = createAgentClient(ENDPOINT, fetch);
+
+		await client.chat([{ role: 'user', content: 'hi' }], 'jwt-token');
+
+		const init = fetch.mock.calls[0][1];
+		expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer jwt-token');
+		// Bearer mode doesn't send cookies.
+		expect(init?.credentials).toBeUndefined();
+	});
+
+	it('omits the Authorization header when no token is given (web cookie mode)', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(jsonResponse({ reply: 'hi' }));
+		const client = createAgentClient(ENDPOINT, fetch, { withCredentials: true });
+
+		await client.chat([{ role: 'user', content: 'hi' }], '');
+
+		const init = fetch.mock.calls[0][1];
+		expect((init?.headers as Record<string, string>).Authorization).toBeUndefined();
+		// Cookie mode sends credentials so the session cookie rides along.
+		expect(init?.credentials).toBe('include');
+	});
 });

--- a/packages/app/src/agent/client.ts
+++ b/packages/app/src/agent/client.ts
@@ -33,22 +33,51 @@ export type FetchLike = typeof globalThis.fetch;
 export interface RivusAgentClient {
 	/** The absolute endpoint this client posts to. */
 	readonly endpoint: string;
-	/** Send a conversation and resolve the agent's reply. */
-	chat(messages: ChatMessage[]): Promise<ChatReply>;
+	/**
+	 * Send a conversation and resolve the agent's reply. When the user is signed
+	 * in, pass their session `token` (native) so the agent can act on their behalf;
+	 * web clients leave it empty and rely on the `rivus_session` cookie instead
+	 * (see `withCredentials`).
+	 */
+	chat(messages: ChatMessage[], token?: string): Promise<ChatReply>;
+}
+
+/** Optional knobs for {@link createAgentClient}. */
+export interface AgentClientOptions {
+	/**
+	 * Send cookies with every request (`credentials: 'include'`). Web clients use
+	 * this so the API's HttpOnly `rivus_session` cookie rides along to the agent —
+	 * the same mechanism the API client uses. Native clients leave it off and
+	 * authenticate with the bearer token passed to `chat`.
+	 */
+	withCredentials?: boolean;
 }
 
 export function createAgentClient(
 	endpoint: string = getAgentEndpoint(),
 	fetchImpl: FetchLike = fetch,
+	options: AgentClientOptions = {},
 ): RivusAgentClient {
+	const credentials: RequestCredentials | undefined = options.withCredentials
+		? 'include'
+		: undefined;
+
 	return {
 		endpoint,
 
-		async chat(messages: ChatMessage[]): Promise<ChatReply> {
+		async chat(messages: ChatMessage[], token?: string): Promise<ChatReply> {
+			const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+			// Only attach a bearer header when there's actually a token. In web cookie
+			// mode the token is empty; sending `Authorization: Bearer ` (malformed) would
+			// stop the agent from falling back to the session cookie.
+			if (token) {
+				headers.Authorization = `Bearer ${token}`;
+			}
 			const response = await fetchImpl(endpoint, {
 				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
+				headers,
 				body: JSON.stringify({ messages }),
+				...(credentials ? { credentials } : {}),
 			});
 
 			const raw = await response.text();

--- a/packages/app/src/components/RivusChat.tsx
+++ b/packages/app/src/components/RivusChat.tsx
@@ -13,10 +13,15 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { type ChatMessage, createAgentClient } from '@/src/agent/client';
+import { useAuth } from '@/src/auth/AuthContext';
 import { RivusSymbol } from '@/src/brand/RivusLogo';
 import { colors, font, radii, shadowSoft } from '@/src/theme/tokens';
 import { BrandGradient } from './Gradient';
 import { Dot, Txt } from './ui';
+
+// Web keeps the session in the HttpOnly cookie (sent with credentials), so the
+// token is empty there; native holds the bearer token in memory and sends it.
+const IS_WEB = Platform.OS === 'web';
 
 type Status = 'idle' | 'sending' | 'error';
 
@@ -35,13 +40,22 @@ export function RivusChat() {
 	const insets = useSafeAreaInsets();
 	const { width, height } = useWindowDimensions();
 
+	const { session } = useAuth();
+	// Web authenticates the agent via the shared session cookie; native forwards
+	// the in-memory bearer token. Either way the agent recognises the signed-in
+	// user and can answer from their company + knowledge base.
+	const token = session?.token ?? '';
+
 	const [open, setOpen] = useState(false);
 	const [greeted, setGreeted] = useState(false);
 	const [messages, setMessages] = useState<DisplayMessage[]>([]);
 	const [draft, setDraft] = useState('');
 	const [status, setStatus] = useState<Status>('idle');
 
-	const client = useMemo(() => createAgentClient(), []);
+	const client = useMemo(
+		() => createAgentClient(undefined, undefined, { withCredentials: IS_WEB }),
+		[],
+	);
 	const scrollRef = useRef<ScrollView>(null);
 	const seq = useRef(0);
 
@@ -53,14 +67,14 @@ export function RivusChat() {
 			setStatus('sending');
 			try {
 				const wire = history.map(({ role, content }) => ({ role, content }));
-				const { reply } = await client.chat(wire);
+				const { reply } = await client.chat(wire, token);
 				setMessages([...history, { id: seq.current++, role: 'assistant', content: reply }]);
 				setStatus('idle');
 			} catch {
 				setStatus('error');
 			}
 		},
-		[client],
+		[client, token],
 	);
 
 	// The first time the panel opens, ask the agent to say hello.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
 
   packages/agent:
     dependencies:
+      '@rivus/core':
+        specifier: workspace:*
+        version: link:../core
       agents:
         specifier: ^0.16.1
         version: 0.16.2(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@cloudflare/workers-types@4.20260616.1)(ai@6.0.208(zod@4.4.3))(react@19.2.7)(rolldown@1.1.1)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(zod@4.4.3)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — adds JWT/cookie authentication to the Rivus agent and gives it its first real capabilities.

---

### What it does

The agent now verifies the **same session JWT that `@rivus/api` issues**, presented either as an `Authorization: Bearer` header (native app) or the `rivus_session` cookie (web app). Once a request is authenticated, the agent can answer from the signed-in user's own account:

- **Company context** — e.g. _"what's our website?"_, _"what's our phone number?"_, or _"tell me about my business"_ reads the account record.
- **Knowledge base** — search, list, update, and add FAQs (e.g. _"find FAQs about refunds"_, _"update the FAQ about returns to say …"_).

Anonymous callers still get a friendly greeting and a nudge to sign in. The chat endpoint never returns a 500 — every failure path becomes a clear sentence.

### How it works

- **Local verification, API authority.** The agent verifies the token locally with HMAC‑SHA256 (Web Crypto) against a shared `JWT_SECRET`, so it can recognise a session and reject `alg:none` / algorithm‑confusion / bad‑signature / expired tokens without a network round‑trip. A valid signature isn't the authority on *live* membership/permissions, so for any data access the agent **forwards the user's token to the Rivus API** and lets the API enforce tenancy (account scoping) and role permissions exactly as it does for the app. Any `401`/`403` is surfaced plainly.
- **Deterministic understanding.** A small, pure, fully unit‑tested `intent.ts` routes asks. It's deliberately rule‑based (predictable + testable); swapping in a model later means changing only that one function.

### Changes by package

- **`@rivus/agent`** — `auth.ts` (token extraction + HS256 verify), `intent.ts` (intent parser), `api.ts` (Rivus API client used on the user's behalf, Zod‑validated), `assistant.ts` (verify → intent → API → formatted reply); credentialed CORS (allows `Authorization`, origin allowlist via `ALLOWED_ORIGINS`, never reflects an unlisted origin with credentials); `RIVUS_API_URL`/`JWT_SECRET` wiring in `wrangler.jsonc` and `Env`; adds `@rivus/core` as a workspace dependency; README.
- **`@rivus/api`** — optional `COOKIE_DOMAIN` scopes the session cookie to the shared parent domain (e.g. `.rivus.ai`) so the agent subdomain receives it on web. Unset by default → host‑only cookie (no behavior change).
- **`@rivus/app`** — the floating Rivus chat forwards the bearer token (native) or sends the cookie via `credentials: 'include'` (web).

### Deployment notes

- Set `JWT_SECRET` on the agent Worker to **the same value as the API** (`wrangler secret put JWT_SECRET`).
- `RIVUS_API_URL` and `ALLOWED_ORIGINS` are set per environment in `wrangler.jsonc` (`ALLOWED_ORIGINS` must be the app's exact origin in deployed environments — credentialed CORS can't use a wildcard).
- For web cookie auth across subdomains, set `COOKIE_DOMAIN=.rivus.ai` on the API.

### Testing

`pnpm lint && pnpm type-check && pnpm test` all pass. Added 105 agent tests (auth, intent, API client, assistant orchestration, HTTP/CORS) plus app‑client and API cookie‑domain tests; agent coverage stays above its thresholds. The agent Worker also builds via `wrangler deploy --dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeUmAe9zEnA96GhhKhZPp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01LeUmAe9zEnA96GhhKhZPp7)_