### PR TITLE
feat(app): use chat bubble icon for chat launcher

### DIFF
--- a/packages/app/src/components/RivusChat.tsx
+++ b/packages/app/src/components/RivusChat.tsx
@@ -190,7 +190,7 @@ export function RivusChat() {
 					{open ? (
 						<Feather name="chevron-down" size={24} color="#fff" />
 					) : (
-						<RivusSymbol size={28} />
+						<Feather name="message-circle" size={26} color="#fff" />
 					)}
 				</BrandGradient>
 			</Pressable>


### PR DESCRIPTION
The floating chat launcher in the app rendered the Rivus brand symbol (`RivusSymbol`), which reads as branding rather than an affordance to chat. This swaps it for a recognizable chat bubble so users immediately understand it opens a conversation.

### What changed
- In `packages/app/src/components/RivusChat.tsx`, the launcher FAB (closed state) now renders Feather's `message-circle` bubble instead of `RivusSymbol`.
- It uses the same icon set (`@expo/vector-icons` Feather) and white tint already used by the launcher's `chevron-down` / send `arrow-up` icons, so it sits correctly inside the signature brand gradient.
- The Rivus mark is kept in the chat panel **header** (next to the "Rivus" title) for brand identity — only the launcher affordance changed.

### Before / after
- **Before:** closed launcher → Rivus logo. Open → chevron-down.
- **After:** closed launcher → chat bubble. Open → chevron-down (unchanged).

---

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
  - This is a one-line presentational icon swap with no behavioral logic; `RivusChat` has no existing unit tests. `pnpm lint`, `pnpm type-check`, and `pnpm test` (548 tests across all packages) all pass.

**What kind of change does this PR introduce?**

Feature / UI polish — replaces the chat launcher's brand logo with an actual chat-bubble icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmFdBthQS2XATbD1cYFhfs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmFdBthQS2XATbD1cYFhfs)_