### PR TITLE
feat(agent): answer any question from the knowledge base with AI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,10 +22,12 @@ NODE_ENV=development
 EMAIL_FROM=Rivus <hello@rivus.ai>
 # Base URL of the app; used to build the accept link in invitation emails.
 APP_URL=https://app.rivus.ai
-# AI duplicate-FAQ check (knowledge base). Runs through the AI SDK, so any
-# provider whose key is set can serve it — OpenAI is the primary, the rest are
-# backups (tried in order). When no key is set the check is a no-op, so the
-# "Add FAQ" flow simply never reports a duplicate.
+# AI knowledge-base features: the duplicate-FAQ check (run before "Add FAQ") and
+# answering visitors' questions from the FAQs (the agent's catch-all). Both run
+# through the AI SDK, so any provider whose key is set can serve them — OpenAI is
+# the primary, the rest are backups (tried in order). When no key is set, the
+# duplicate check is a no-op and question-answering degrades to a deterministic
+# keyword match over the FAQs.
 # OPENAI_API_KEY=sk-...
 # OPENAI_MODEL=gpt-5.4-mini
 # GOOGLE_GENERATIVE_AI_API_KEY=...

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -8,6 +8,10 @@ function call.
 It greets anyone who opens it, and — once a request is **authenticated** — it can
 answer from the signed-in user's own Rivus account: their company details (e.g.
 "what's our website?") and their knowledge base (search, update, and add FAQs).
+Any other question is treated as a general ask and answered from the knowledge
+base: the agent forwards it to the API's AI-backed `/v1/faqs/answer` endpoint,
+which finds the relevant FAQs and composes a grounded reply (so "what's our best
+price?" is answered by a differently-worded "cost" FAQ), and cites the source FAQ.
 The reply logic is still a set of small, pure, unit-tested functions, so turning
 the deterministic understanding layer (`intent.ts`) into a real model-backed
 assistant later means changing only that one place.

--- a/packages/agent/src/api.test.ts
+++ b/packages/agent/src/api.test.ts
@@ -139,6 +139,26 @@ describe('createRivusApiClient', () => {
 		expect(init?.body).toBe(JSON.stringify({ question: 'Do you offer refunds?', answer: '' }));
 	});
 
+	it('answers a question from the knowledge base', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+			jsonResponse({
+				answered: true,
+				answer: 'Our standard rate is $125 an hour, and $85 on weekends.',
+				sources: [{ id: 'faq_1', question: 'How much does your service cost?' }],
+			}),
+		);
+		const client = createRivusApiClient(BASE, TOKEN, fetch);
+
+		const result = await client.answerFromKnowledge({ question: "what's our best price?" });
+		expect(result.answered).toBe(true);
+		expect(result.answer).toContain('$125');
+		expect(result.sources[0]?.question).toBe('How much does your service cost?');
+		const { url, init } = nthCall(fetch, 0);
+		expect(url).toBe(`${BASE}/v1/faqs/answer`);
+		expect(init?.method).toBe('POST');
+		expect(init?.body).toBe(JSON.stringify({ question: "what's our best price?" }));
+	});
+
 	it('throws AgentApiError carrying the status and API message on non-2xx', async () => {
 		const fetch = vi
 			.fn<typeof globalThis.fetch>()

--- a/packages/agent/src/api.ts
+++ b/packages/agent/src/api.ts
@@ -106,6 +106,13 @@ const faqSimilaritySchema = z.object({
 });
 export type FaqSimilarityResult = z.infer<typeof faqSimilaritySchema>;
 
+const faqAnswerSchema = z.object({
+	answered: z.boolean(),
+	answer: z.string(),
+	sources: z.array(z.object({ id: branded<FaqId>(), question: z.string() })),
+});
+export type FaqAnswerResult = z.infer<typeof faqAnswerSchema>;
+
 const errorBodySchema = z.object({
 	error: z.string().optional(),
 	message: z.string().optional(),
@@ -133,6 +140,12 @@ export interface RivusApiClient {
 	 * always, when the API has no AI provider configured.
 	 */
 	findSimilarFaq(input: { question: string; answer?: string }): Promise<FaqSimilarityResult>;
+	/**
+	 * Answer a free-text question from the account's knowledge base (AI-assisted).
+	 * Returns `{ answered: false }` when the FAQs don't cover the question, so the
+	 * agent can fall back to a friendly nudge instead of guessing.
+	 */
+	answerFromKnowledge(input: { question: string }): Promise<FaqAnswerResult>;
 }
 
 /** Strip a single trailing slash so `${base}${path}` never doubles up. */
@@ -214,6 +227,13 @@ export function createRivusApiClient(
 			return request('/v1/faqs/similar', faqSimilaritySchema, {
 				method: 'POST',
 				body: JSON.stringify({ question: input.question, answer: input.answer ?? '' }),
+			});
+		},
+
+		answerFromKnowledge(input: { question: string }) {
+			return request('/v1/faqs/answer', faqAnswerSchema, {
+				method: 'POST',
+				body: JSON.stringify({ question: input.question }),
 			});
 		},
 	};

--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -131,6 +131,11 @@ const onUpdateFaq: Route['when'] = (_url, method) => method === 'PATCH';
 const onSimilarFaq: Route['when'] = (url, method) =>
 	method === 'POST' && url.endsWith('/v1/faqs/similar');
 const onCreateFaq: Route['when'] = (url, method) => method === 'POST' && url.endsWith('/v1/faqs');
+const onAnswerFaq: Route['when'] = (url, method) =>
+	method === 'POST' && url.endsWith('/v1/faqs/answer');
+
+/** The "knowledge base doesn't cover it" response from /v1/faqs/answer. */
+const noAnswer = { answered: false, answer: '', sources: [] };
 
 /** The "no duplicate found" response from /v1/faqs/similar (the common case). */
 const noSimilarFaq = { match: null, reason: '', merged: null };
@@ -189,8 +194,69 @@ describe('respond — conversational', () => {
 		const anon = await ask('what is the meaning of life');
 		expect(anon).toContain(GREETING);
 
-		const authed = await ask('what is the meaning of life', { token: TOKEN });
+		// Signed in, the agent tries the knowledge base first; when it doesn't cover
+		// the question it falls back to the same friendly nudge.
+		const authed = await ask('what is the meaning of life', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onAnswerFaq, body: noAnswer }]),
+		});
 		expect(authed).toMatch(/not sure how to help/i);
+	});
+});
+
+describe('respond — knowledge base answering', () => {
+	it('answers a general question from the knowledge base and cites the FAQ', async () => {
+		// "best price" matches a differently-worded pricing FAQ — the kind of semantic
+		// match the AI handles and plain keyword routing misses.
+		const reply = await ask("what's our best price?", {
+			token: TOKEN,
+			fetchImpl: router([
+				{
+					when: onAnswerFaq,
+					body: {
+						answered: true,
+						answer: 'Our standard rate is $125 an hour, and $85 on weekends.',
+						sources: [{ id: 'faq_1', question: 'How much does your service cost?' }],
+					},
+				},
+			]),
+		});
+		expect(reply).toContain('$125 an hour');
+		expect(reply).toContain('How much does your service cost?');
+	});
+
+	it('returns just the answer when no source FAQ is given', async () => {
+		const reply = await ask('do you charge for travel?', {
+			token: TOKEN,
+			fetchImpl: router([
+				{ when: onAnswerFaq, body: { answered: true, answer: 'No travel fees.', sources: [] } },
+			]),
+		});
+		expect(reply).toBe('No travel fees.');
+	});
+
+	it('falls back to the nudge when the knowledge base has no answer', async () => {
+		const reply = await ask('what is the airspeed of a swallow?', {
+			token: TOKEN,
+			fetchImpl: router([{ when: onAnswerFaq, body: noAnswer }]),
+		});
+		expect(reply).toMatch(/not sure how to help/i);
+	});
+
+	it('nudges an anonymous caller to sign in instead of hitting the API', async () => {
+		// No fetch route is provided: a signed-out general question must never call the
+		// answer endpoint, so it resolves purely from the brush-off path.
+		const reply = await ask("what's our best price?");
+		expect(reply).toContain(GREETING);
+		expect(reply).toMatch(/signed in/i);
+	});
+
+	it('surfaces an API failure during answering', async () => {
+		const reply = await ask("what's our best price?", {
+			token: TOKEN,
+			fetchImpl: router([{ when: onAnswerFaq, body: { message: 'boom' }, status: 500 }]),
+		});
+		expect(reply).toMatch(/couldn’t reach your Rivus data/i);
 	});
 });
 

--- a/packages/agent/src/assistant.ts
+++ b/packages/agent/src/assistant.ts
@@ -56,26 +56,28 @@ const FIELD_LABEL: Record<CompanyField, string> = {
 /** Produce the agent's reply to the most recent user turn. */
 export async function respond(deps: RespondDeps): Promise<string> {
 	const { env, request, messages, fetchImpl } = deps;
-	const intent = parseIntent(lastUserMessage(messages) ?? '');
+	const question = lastUserMessage(messages) ?? '';
+	const intent = parseIntent(question);
 	const session = await authenticate(request, env.JWT_SECRET);
+	const claims = session?.claims ?? null;
 
 	// Conversational intents need no data and work signed in or out.
 	if (intent.kind === 'greeting') {
-		return greetingReply(session?.claims ?? null);
+		return greetingReply(claims);
 	}
 	if (intent.kind === 'help') {
-		return helpReply(session?.claims ?? null);
-	}
-	if (intent.kind === 'unknown') {
-		return unknownReply(session?.claims ?? null);
+		return helpReply(claims);
 	}
 
-	// Everything below is gated on a valid session.
+	// Everything below needs a session and a configured API. A general question
+	// (`unknown`) is the catch-all: rather than brushing it off, we try to answer it
+	// from the knowledge base with AI. It still degrades to a friendly nudge — not
+	// the sign-in / not-configured errors — when we can't reach the data.
 	if (!session) {
-		return SIGN_IN_REQUIRED;
+		return intent.kind === 'unknown' ? unknownReply(null) : SIGN_IN_REQUIRED;
 	}
 	if (!env.RIVUS_API_URL) {
-		return NOT_CONFIGURED;
+		return intent.kind === 'unknown' ? unknownReply(claims) : NOT_CONFIGURED;
 	}
 	const api = createRivusApiClient(env.RIVUS_API_URL, session.token, fetchImpl);
 
@@ -91,6 +93,8 @@ export async function respond(deps: RespondDeps): Promise<string> {
 				return await faqUpdateReply(api, intent);
 			case 'faq_create':
 				return await faqCreateReply(api, intent);
+			case 'unknown':
+				return await knowledgeAnswerReply(api, question, claims);
 		}
 	} catch (error) {
 		return apiErrorReply(error);
@@ -126,6 +130,31 @@ function unknownReply(claims: SessionClaims | null): string {
 		return `${GREETING} I can help with your company details and your knowledge base once you’re signed in. Try “what’s our website?” or “search the FAQ for pricing.”`;
 	}
 	return 'I’m not sure how to help with that yet. I can tell you your company details (like your website) or search and update your knowledge base — try “what’s our phone number?” or “find FAQs about pricing.”';
+}
+
+/**
+ * Answer a general question from the account's knowledge base. The API does the AI
+ * work — it retrieves the relevant FAQs and composes an answer grounded strictly in
+ * them — so the agent just forwards the question and formats the result, citing the
+ * source FAQ so the user can see it came from their own knowledge base. When the
+ * knowledge base doesn't cover the question, we fall back to the same friendly nudge
+ * as any other unrecognized ask rather than guessing.
+ */
+async function knowledgeAnswerReply(
+	api: RivusApiClient,
+	question: string,
+	claims: SessionClaims | null,
+): Promise<string> {
+	const { answered, answer, sources } = await api.answerFromKnowledge({ question });
+	const text = answer.trim();
+	if (!answered || text === '') {
+		return unknownReply(claims);
+	}
+	const [source] = sources;
+	if (source) {
+		return `${text}\n\n(From your FAQ “${source.question}”.)`;
+	}
+	return text;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1717,6 +1717,71 @@
         }
       }
     },
+    "/v1/faqs/answer": {
+      "post": {
+        "summary": "Answer a question from the knowledge base (AI-assisted)",
+        "tags": [
+          "faqs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  }
+                },
+                "required": [
+                  "question"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FaqAnswer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/faqs/{id}": {
       "get": {
         "summary": "Fetch one of your FAQs",

--- a/packages/api/src/http-schemas.ts
+++ b/packages/api/src/http-schemas.ts
@@ -189,6 +189,19 @@ export const faqSimilarityResponseSchema = z
 	})
 	.meta({ id: 'FaqSimilarity' });
 
+/**
+ * Result of answering a question from the knowledge base (AI-assisted). `answered`
+ * is false when the FAQs don't cover the question; `answer` is then empty. `sources`
+ * lists the FAQ(s) the answer draws on so the client can cite where it came from.
+ */
+export const faqAnswerResponseSchema = z
+	.object({
+		answered: z.boolean(),
+		answer: z.string(),
+		sources: z.array(z.object({ id: z.string(), question: z.string() })),
+	})
+	.meta({ id: 'FaqAnswer' });
+
 /** A page of companies (accounts) for the staff company switcher. */
 export const accountListResponseSchema = z
 	.object({

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -4,6 +4,7 @@ import { buildApp } from './app';
 import { loadConfig } from './config';
 import { createInMemoryRepositories } from './repositories/memory';
 import { NoopMailer } from './services/email';
+import { NoopFaqAnswerService } from './services/faq-answer';
 import { NoopFaqSimilarityService } from './services/faq-similarity';
 
 /**
@@ -37,6 +38,7 @@ async function main(): Promise<void> {
 		verificationCodes,
 		mailer: new NoopMailer(),
 		faqSimilarity: new NoopFaqSimilarityService(),
+		faqAnswer: new NoopFaqAnswerService(),
 		ping: async () => ({ ready: true }),
 	});
 

--- a/packages/api/src/routes/faqs.ts
+++ b/packages/api/src/routes/faqs.ts
@@ -134,11 +134,15 @@ export const faqRoutes: FastifyPluginAsync = async (fastify) => {
 			const { question } = request.body;
 
 			// The newest page of FAQs is the knowledge base the answer is grounded in.
-			const { faqs: candidates } = await faqs.list({
+			const { faqs: page } = await faqs.list({
 				accountId,
 				page: 1,
 				pageSize: ANSWER_CANDIDATE_LIMIT,
 			});
+			// Only published FAQs are customer-facing. Drafts are staged and not yet
+			// live, so the answer must never be grounded in — or cite — draft content
+			// (e.g. unreleased pricing or policies).
+			const candidates = page.filter((faq) => faq.status === 'published');
 
 			const result = await faqAnswer.answer({ question }, candidates);
 			// Resolve the cited ids back to questions for the response, scoped to this

--- a/packages/api/src/routes/faqs.ts
+++ b/packages/api/src/routes/faqs.ts
@@ -3,6 +3,7 @@ import {
 	buildPaginationMeta,
 	createFaqSchema,
 	type FaqId,
+	faqAnswerQuerySchema,
 	faqSimilarityQuerySchema,
 	paginationQuerySchema,
 	updateFaqSchema,
@@ -12,6 +13,7 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import {
 	errorResponseSchema,
+	faqAnswerResponseSchema,
 	faqListResponseSchema,
 	faqResponseSchema,
 	faqSimilarityResponseSchema,
@@ -22,10 +24,14 @@ import {
 // single page covers exactly what the duplicate check will consider — fetching
 // more would only load rows the service discards.
 const SIMILARITY_CANDIDATE_LIMIT = 50;
+// The newest page of FAQs handed to the answering service as the knowledge base.
+// Its own cap is smaller, but a full page keeps the candidate set newest-first and
+// complete for a small business.
+const ANSWER_CANDIDATE_LIMIT = 100;
 
 export const faqRoutes: FastifyPluginAsync = async (fastify) => {
 	const app = fastify.withTypeProvider<ZodTypeProvider>();
-	const { faqs, faqSimilarity } = app.deps;
+	const { faqs, faqSimilarity, faqAnswer } = app.deps;
 
 	// Every FAQ route requires a valid JWT.
 	app.addHook('onRequest', fastify.authenticate);
@@ -104,6 +110,45 @@ export const faqRoutes: FastifyPluginAsync = async (fastify) => {
 			}
 			const merged = await faqSimilarity.mergeSuggestion({ question, answer }, existing);
 			return { match: existing, reason: match.reason, merged };
+		},
+	);
+
+	// Registered before `/:id` so the literal path isn't shadowed by the param route.
+	app.post(
+		'/answer',
+		{
+			schema: {
+				tags: ['faqs'],
+				summary: 'Answer a question from the knowledge base (AI-assisted)',
+				security: [{ bearerAuth: [] }],
+				body: faqAnswerQuerySchema,
+				response: {
+					200: faqAnswerResponseSchema,
+					400: errorResponseSchema,
+					401: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const accountId = request.user.accountId as AccountId;
+			const { question } = request.body;
+
+			// The newest page of FAQs is the knowledge base the answer is grounded in.
+			const { faqs: candidates } = await faqs.list({
+				accountId,
+				page: 1,
+				pageSize: ANSWER_CANDIDATE_LIMIT,
+			});
+
+			const result = await faqAnswer.answer({ question }, candidates);
+			// Resolve the cited ids back to questions for the response, scoped to this
+			// account's candidates — a final guard against a stray id leaking through.
+			const byId = new Map(candidates.map((faq) => [faq.id, faq]));
+			const sources = result.sources
+				.map((id) => byId.get(id))
+				.filter((faq): faq is (typeof candidates)[number] => faq !== undefined)
+				.map((faq) => ({ id: faq.id, question: faq.question }));
+			return { answered: result.answered, answer: result.answer, sources };
 		},
 	);
 

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -13,6 +13,7 @@ import {
 	MongoUserRepository,
 	MongoVerificationCodeRepository,
 } from './repositories/mongo';
+import { createFaqAnswerService } from './services/faq-answer';
 import { createFaqSimilarityService } from './services/faq-similarity';
 import { createMailer } from './services/resend-mailer';
 
@@ -34,6 +35,7 @@ export async function start(): Promise<void> {
 		verificationCodes: new MongoVerificationCodeRepository(),
 		mailer: createMailer(config),
 		faqSimilarity: createFaqSimilarityService(config),
+		faqAnswer: createFaqAnswerService(config),
 		// Real readiness: run an actual query so "connected but unauthorized" reports
 		// unready (503, with the reason) instead of falsely healthy.
 		ping: checkDatabaseReady,

--- a/packages/api/src/services/faq-answer.ts
+++ b/packages/api/src/services/faq-answer.ts
@@ -15,8 +15,13 @@ import type { Config } from '../config';
  */
 const MAX_CANDIDATES = 24;
 const MAX_OUTPUT_TOKENS = 700;
-/** Trim each FAQ answer sent in the prompt so a few long ones can't blow the budget. */
-const MAX_ANSWER_IN_PROMPT = 600;
+// Send each FAQ's full stored answer so a fact late in a long answer (the FAQ
+// field allows up to 4000 chars) is still visible to the model — truncating to a
+// short prefix could hide exactly the detail the question asks about. This equals
+// the FAQ answer field cap, so a valid answer is passed through whole (whitespace
+// collapsed); it only bounds malformed, over-long data. With MAX_CANDIDATES this
+// keeps the prompt bounded.
+const MAX_ANSWER_IN_PROMPT = 4000;
 /** Keep the composed answer chat-sized. */
 const MAX_ANSWER_LENGTH = 1200;
 

--- a/packages/api/src/services/faq-answer.ts
+++ b/packages/api/src/services/faq-answer.ts
@@ -1,0 +1,319 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createXai } from '@ai-sdk/xai';
+import type { Faq, FaqId } from '@rivus/core';
+import { generateObject, type LanguageModel } from 'ai';
+import { z } from 'zod';
+import type { Config } from '../config';
+
+/**
+ * Answering a visitor's question from the knowledge base is retrieval-augmented:
+ * we hand the model the account's FAQs and ask it to reply using only those. We
+ * cap how many FAQs we send (newest first) and how long the reply can be so the
+ * prompt and token cost stay bounded for a small business's knowledge base.
+ */
+const MAX_CANDIDATES = 24;
+const MAX_OUTPUT_TOKENS = 700;
+/** Trim each FAQ answer sent in the prompt so a few long ones can't blow the budget. */
+const MAX_ANSWER_IN_PROMPT = 600;
+/** Keep the composed answer chat-sized. */
+const MAX_ANSWER_LENGTH = 1200;
+
+/** What the model returns when asked to answer from the knowledge base. */
+const answerSchema = z.object({
+	/** True only when the FAQs actually cover the question. */
+	answered: z.boolean(),
+	/** The grounded answer (empty when `answered` is false). */
+	answer: z.string(),
+	/** Ids of the FAQ(s) the answer draws on (a subset of those we sent). */
+	faqIds: z.array(z.string()),
+});
+
+export interface FaqAnswer {
+	/** Whether the knowledge base covers the question. */
+	answered: boolean;
+	/** The answer text, grounded in the FAQs (empty when `answered` is false). */
+	answer: string;
+	/** The FAQ(s) the answer is based on, so the caller can cite its source. */
+	sources: FaqId[];
+}
+
+/** Minimal logger surface — compatible with `console` and Fastify's pino logger. */
+export interface FaqAnswerLogger {
+	warn(message: string): void;
+}
+
+export interface FaqAnswerService {
+	/**
+	 * Answer `input.question` using only `candidates` (the account's FAQs). Returns
+	 * `{ answered: false }` when the knowledge base doesn't cover it. Never throws —
+	 * a model outage degrades to a deterministic keyword match, not an error.
+	 */
+	answer(input: { question: string }, candidates: Faq[]): Promise<FaqAnswer>;
+}
+
+/**
+ * The single AI call this service makes, narrowed to what we use. Injectable so
+ * tests can drive the logic (grounding guards, fallback) without a model or the
+ * network. Defaults to the AI SDK's {@link generateObject}.
+ */
+export type GenerateObjectFn = <T>(options: {
+	model: LanguageModel;
+	schema: z.ZodType<T>;
+	schemaName?: string;
+	system?: string;
+	prompt: string;
+	maxOutputTokens?: number;
+}) => Promise<{ object: T }>;
+
+const defaultGenerateObject: GenerateObjectFn = async (options) => {
+	const { object } = await generateObject({
+		model: options.model,
+		schema: options.schema,
+		schemaName: options.schemaName,
+		system: options.system,
+		prompt: options.prompt,
+		maxOutputTokens: options.maxOutputTokens,
+	});
+	return { object };
+};
+
+const ANSWER_SYSTEM =
+	'You are Rivus, an assistant that answers questions about a business using ONLY that ' +
+	"business's knowledge base of FAQs. You are given the visitor's question and a JSON array " +
+	'of FAQs ({id, question, answer, category}). If one or more FAQs answer the question — even ' +
+	'when the wording differs (for example "what\'s our best price?" is answered by a "cost" or ' +
+	'"rate" FAQ, and "where are you?" by an "address" or "location" FAQ) — reply with a short, ' +
+	'direct, friendly answer based strictly on those FAQs, set answered=true, and list the id(s) ' +
+	'you used in faqIds. Never invent prices, facts, or details that are not in the FAQs, and ' +
+	'never answer from general knowledge. If the FAQs do not contain the answer, set ' +
+	'answered=false, leave answer empty, and return an empty faqIds. Keep the answer concise and ' +
+	'in plain language.';
+
+/**
+ * AI-backed knowledge-base answering. Tries each model in order, so callers can
+ * pass a primary plus backups from other providers; if every model fails the call
+ * degrades to a deterministic keyword match rather than throwing into the request
+ * path.
+ */
+export class AiFaqAnswerService implements FaqAnswerService {
+	private readonly models: LanguageModel[];
+	private readonly generate: GenerateObjectFn;
+	private readonly logger?: FaqAnswerLogger;
+
+	constructor(options: {
+		models: LanguageModel[];
+		generate?: GenerateObjectFn;
+		logger?: FaqAnswerLogger;
+	}) {
+		this.models = options.models;
+		this.generate = options.generate ?? defaultGenerateObject;
+		this.logger = options.logger;
+	}
+
+	async answer(input: { question: string }, candidates: Faq[]): Promise<FaqAnswer> {
+		if (candidates.length === 0) {
+			return { answered: false, answer: '', sources: [] };
+		}
+		// Newest-first from the caller; send the most recent so the whole knowledge
+		// base of a small business is considered semantically (no keyword pre-filter,
+		// which would drop matches like "best price" → a "cost" FAQ before the model
+		// ever sees them).
+		const shortlist = candidates.slice(0, MAX_CANDIDATES);
+		const ids = new Set<string>(shortlist.map((faq) => faq.id));
+		const knowledge = shortlist.map((faq) => ({
+			id: faq.id,
+			question: faq.question,
+			answer: snippet(faq.answer, MAX_ANSWER_IN_PROMPT),
+			category: faq.category,
+		}));
+
+		const result = await this.generateWithFallback({
+			schema: answerSchema,
+			schemaName: 'faq_answer',
+			system: ANSWER_SYSTEM,
+			prompt:
+				`Visitor question: ${input.question}\n\n` +
+				`Knowledge base FAQs (JSON array of {id, question, answer, category}):\n${JSON.stringify(knowledge)}`,
+		});
+
+		// Every model failed: fall back to a deterministic keyword match so the
+		// feature still answers obvious questions when the AI is unavailable.
+		if (!result) {
+			return deterministicFaqAnswer(input.question, shortlist);
+		}
+		if (!result.answered) {
+			return { answered: false, answer: '', sources: [] };
+		}
+		const answer = snippet(result.answer.trim(), MAX_ANSWER_LENGTH);
+		if (answer === '') {
+			return deterministicFaqAnswer(input.question, shortlist);
+		}
+		// Keep only cited ids we actually sent (guards a hallucinated/stale id); if
+		// the model answered but cited nothing usable, fall back to the closest FAQ.
+		const sources = result.faqIds.filter((id) => ids.has(id)) as FaqId[];
+		if (sources.length === 0) {
+			const [closest] = rankByKeyword(input.question, shortlist);
+			return { answered: true, answer, sources: closest ? [closest.id] : [] };
+		}
+		return { answered: true, answer, sources };
+	}
+
+	/** Try each model in turn; return the first success, or null if all fail. */
+	private async generateWithFallback<T>(options: {
+		schema: z.ZodType<T>;
+		schemaName: string;
+		system: string;
+		prompt: string;
+	}): Promise<T | null> {
+		for (const model of this.models) {
+			try {
+				const { object } = await this.generate({
+					model,
+					schema: options.schema,
+					schemaName: options.schemaName,
+					system: options.system,
+					prompt: options.prompt,
+					maxOutputTokens: MAX_OUTPUT_TOKENS,
+				});
+				return object;
+			} catch (error) {
+				// This provider failed — log it (so a misconfigured primary is visible in
+				// production) and fall through to the next backup model.
+				this.logger?.warn(
+					`Knowledge-base answer: ${options.schemaName} request failed, trying next provider — ${String(error)}`,
+				);
+			}
+		}
+		return null;
+	}
+}
+
+/**
+ * Deterministic answer used when no model is available (no provider key set, or
+ * every provider failed): the answer of the single most keyword-relevant FAQ,
+ * verbatim. It can't match a question to a differently-worded FAQ the way the AI
+ * can, so it returns `{ answered: false }` when nothing overlaps rather than
+ * guessing.
+ */
+export function deterministicFaqAnswer(question: string, candidates: Faq[]): FaqAnswer {
+	const [top] = rankByKeyword(question, candidates);
+	if (!top) {
+		return { answered: false, answer: '', sources: [] };
+	}
+	return {
+		answered: true,
+		answer: snippet(top.answer.trim(), MAX_ANSWER_LENGTH),
+		sources: [top.id],
+	};
+}
+
+/** A no-op-ish service: answers deterministically by keyword, with no AI. */
+export class NoopFaqAnswerService implements FaqAnswerService {
+	async answer(input: { question: string }, candidates: Faq[]): Promise<FaqAnswer> {
+		return deterministicFaqAnswer(input.question, candidates);
+	}
+}
+
+// Words too common to help a match; dropped before scoring (mirrors the agent's
+// own knowledge-base ranking).
+const STOPWORDS = new Set([
+	'the',
+	'and',
+	'for',
+	'our',
+	'you',
+	'your',
+	'what',
+	'whats',
+	'about',
+	'have',
+	'does',
+	'with',
+	'this',
+	'that',
+	'are',
+	'can',
+	'how',
+	'why',
+	'who',
+	'where',
+	'when',
+]);
+
+/** Lowercased word tokens worth matching on (short/stopword tokens dropped). */
+function tokenize(value: string): string[] {
+	return (value.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []).filter(
+		(token) => token.length > 2 && !STOPWORDS.has(token),
+	);
+}
+
+/** FAQs ranked by how many question tokens appear in them, best first, zeros dropped. */
+function rankByKeyword(question: string, faqs: Faq[]): Faq[] {
+	const tokens = tokenize(question);
+	const needle = question.trim().toLowerCase();
+	return faqs
+		.map((faq) => {
+			const haystack = `${faq.question} ${faq.answer} ${faq.category}`.toLowerCase();
+			const score =
+				tokens.length > 0
+					? tokens.reduce((sum, token) => sum + (haystack.includes(token) ? 1 : 0), 0)
+					: needle.length > 0 && haystack.includes(needle)
+						? 1
+						: 0;
+			return { faq, score };
+		})
+		.filter((entry) => entry.score > 0)
+		.sort((a, b) => b.score - a.score)
+		.map((entry) => entry.faq);
+}
+
+/** Collapse whitespace and cap text at `max` so prompts and replies stay bounded. */
+function snippet(text: string, max: number): string {
+	const clean = text.replace(/\s+/g, ' ').trim();
+	return clean.length <= max ? clean : `${clean.slice(0, max - 1).trimEnd()}…`;
+}
+
+/**
+ * Build the knowledge-base answering service from config. Reuses the same ordered
+ * provider list as the duplicate-FAQ check — OpenAI primary, then Google, xAI, and
+ * Anthropic as backups. When no key is set at all, returns a
+ * {@link NoopFaqAnswerService} so the feature degrades to deterministic keyword
+ * matching and the API still boots.
+ */
+export function createFaqAnswerService(
+	config: Pick<
+		Config,
+		| 'OPENAI_API_KEY'
+		| 'OPENAI_MODEL'
+		| 'GOOGLE_GENERATIVE_AI_API_KEY'
+		| 'GEMINI_MODEL'
+		| 'XAI_API_KEY'
+		| 'XAI_MODEL'
+		| 'ANTHROPIC_API_KEY'
+		| 'ANTHROPIC_MODEL'
+	>,
+): FaqAnswerService {
+	const models: LanguageModel[] = [];
+	if (config.OPENAI_API_KEY) {
+		models.push(createOpenAI({ apiKey: config.OPENAI_API_KEY })(config.OPENAI_MODEL));
+	}
+	if (config.GOOGLE_GENERATIVE_AI_API_KEY) {
+		models.push(
+			createGoogleGenerativeAI({ apiKey: config.GOOGLE_GENERATIVE_AI_API_KEY })(
+				config.GEMINI_MODEL,
+			),
+		);
+	}
+	if (config.XAI_API_KEY) {
+		models.push(createXai({ apiKey: config.XAI_API_KEY })(config.XAI_MODEL));
+	}
+	if (config.ANTHROPIC_API_KEY) {
+		models.push(createAnthropic({ apiKey: config.ANTHROPIC_API_KEY })(config.ANTHROPIC_MODEL));
+	}
+	if (models.length === 0) {
+		return new NoopFaqAnswerService();
+	}
+	return new AiFaqAnswerService({ models, logger: console });
+}

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -13,6 +13,7 @@ import type {
 	VerificationCodeRepository,
 } from './repositories/types';
 import type { Mailer } from './services/email';
+import type { FaqAnswerService } from './services/faq-answer';
 import type { FaqSimilarityService } from './services/faq-similarity';
 
 /** Result of a readiness check: whether dependencies are usable, and why not. */
@@ -39,6 +40,8 @@ export interface AppDeps {
 	mailer: Mailer;
 	/** AI check for near-duplicate FAQs (a no-op when no provider key is set). */
 	faqSimilarity: FaqSimilarityService;
+	/** AI answering of questions from the knowledge base (deterministic when no key is set). */
+	faqAnswer: FaqAnswerService;
 	/** Readiness check for downstream dependencies (e.g. the database). */
 	ping: () => Promise<ReadinessResult>;
 }

--- a/packages/api/test/cors.test.ts
+++ b/packages/api/test/cors.test.ts
@@ -4,6 +4,7 @@ import { buildApp } from '../src/app';
 import { loadConfig } from '../src/config';
 import { SESSION_COOKIE } from '../src/plugins/auth';
 import { createInMemoryRepositories } from '../src/repositories/memory';
+import { NoopFaqAnswerService } from '../src/services/faq-answer';
 import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
 import { authHeader, RecordingMailer, signupOwner } from './helpers';
 
@@ -19,6 +20,7 @@ function buildAppWithCors(corsOrigin: string): FastifyInstance {
 		...repos,
 		mailer: new RecordingMailer(),
 		faqSimilarity: new NoopFaqSimilarityService(),
+		faqAnswer: new NoopFaqAnswerService(),
 		ping: async () => ({ ready: true }),
 	});
 }
@@ -37,6 +39,7 @@ function buildProdApp(corsOrigin: string): FastifyInstance {
 		...repos,
 		mailer: new RecordingMailer(),
 		faqSimilarity: new NoopFaqSimilarityService(),
+		faqAnswer: new NoopFaqAnswerService(),
 		ping: async () => ({ ready: true }),
 	});
 }

--- a/packages/api/test/faq-answer.test.ts
+++ b/packages/api/test/faq-answer.test.ts
@@ -1,0 +1,266 @@
+import type { AccountId, Faq, FaqId } from '@rivus/core';
+import type { LanguageModel } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	AiFaqAnswerService,
+	createFaqAnswerService,
+	deterministicFaqAnswer,
+	type FaqAnswerService,
+	type GenerateObjectFn,
+	NoopFaqAnswerService,
+} from '../src/services/faq-answer';
+
+function makeFaq(overrides: Partial<Faq> = {}): Faq {
+	const now = new Date('2026-01-01T00:00:00.000Z').toISOString();
+	return {
+		id: 'faq-1' as FaqId,
+		accountId: 'acct-1' as AccountId,
+		question: 'How much does your service cost?',
+		answer: 'Our standard rate is $125 an hour and $85 on weekends.',
+		category: 'Pricing',
+		status: 'published',
+		createdAt: now,
+		updatedAt: now,
+		...overrides,
+	};
+}
+
+/**
+ * A fake for the injected object-generator. The generic {@link GenerateObjectFn}
+ * can't be satisfied by a concrete mock (its `object` would have to be every `T`
+ * at once), so we cast at the boundary and keep the raw mock for assertions.
+ */
+function fakeGenerate(impl: (options: { model: LanguageModel; prompt: string }) => unknown) {
+	const mock = vi.fn(impl as (...args: unknown[]) => unknown);
+	return { generate: mock as unknown as GenerateObjectFn, mock };
+}
+
+// Two interchangeable placeholder models; the fake `generate` branches on them to
+// exercise provider-fallback ordering without touching a real model.
+const PRIMARY = 'primary' as unknown as LanguageModel;
+const BACKUP = 'backup' as unknown as LanguageModel;
+
+describe('AiFaqAnswerService.answer', () => {
+	it('answers a differently-worded question and cites the source FAQ', async () => {
+		const candidates = [
+			makeFaq({
+				id: 'faq-product' as FaqId,
+				question: 'What is your best product?',
+				answer: 'It is great.',
+				category: 'Product',
+			}),
+			makeFaq({ id: 'faq-price' as FaqId }),
+		];
+		const { generate, mock } = fakeGenerate(() => ({
+			object: {
+				answered: true,
+				answer: 'Our standard rate is $125 an hour, and $85 on weekends.',
+				faqIds: ['faq-price'],
+			},
+		}));
+		const service = new AiFaqAnswerService({ models: [PRIMARY], generate });
+
+		const result = await service.answer({ question: "what's our best price?" }, candidates);
+
+		expect(result.answered).toBe(true);
+		expect(result.answer).toContain('$125');
+		expect(result.sources).toEqual(['faq-price']);
+		const options = mock.mock.calls[0]?.[0] as { schemaName?: string; prompt: string };
+		expect(options.schemaName).toBe('faq_answer');
+		// The question and — unlike the similarity check — the FAQ *answers* are sent,
+		// since the model needs them to compose a grounded reply.
+		expect(options.prompt).toContain("what's our best price?");
+		expect(options.prompt).toContain('$125 an hour and $85 on weekends');
+	});
+
+	it('reports not-answered when the knowledge base does not cover the question', async () => {
+		const { generate } = fakeGenerate(() => ({
+			object: { answered: false, answer: '', faqIds: [] },
+		}));
+		const service = new AiFaqAnswerService({ models: [PRIMARY], generate });
+
+		const result = await service.answer({ question: 'what is the meaning of life?' }, [makeFaq()]);
+
+		expect(result).toEqual({ answered: false, answer: '', sources: [] });
+	});
+
+	it('short-circuits with no model call when there are no FAQs', async () => {
+		const { generate, mock } = fakeGenerate(() => ({ object: null }));
+		const service = new AiFaqAnswerService({ models: [PRIMARY], generate });
+
+		expect(await service.answer({ question: 'anything?' }, [])).toEqual({
+			answered: false,
+			answer: '',
+			sources: [],
+		});
+		expect(mock).not.toHaveBeenCalled();
+	});
+
+	it('drops hallucinated source ids and falls back to the closest FAQ', async () => {
+		const { generate } = fakeGenerate(() => ({
+			object: { answered: true, answer: 'Our rate is $125/hr.', faqIds: ['ghost-id'] },
+		}));
+		const service = new AiFaqAnswerService({ models: [PRIMARY], generate });
+
+		const result = await service.answer({ question: 'how much for a service call?' }, [makeFaq()]);
+
+		expect(result.answered).toBe(true);
+		expect(result.answer).toBe('Our rate is $125/hr.');
+		// The made-up id is rejected; the keyword-closest FAQ becomes the cited source.
+		expect(result.sources).toEqual(['faq-1']);
+	});
+
+	it('falls back to a deterministic answer when the model returns blank text', async () => {
+		const { generate } = fakeGenerate(() => ({
+			object: { answered: true, answer: '   ', faqIds: ['faq-1'] },
+		}));
+		const service = new AiFaqAnswerService({ models: [PRIMARY], generate });
+
+		const result = await service.answer({ question: 'what does a service call cost?' }, [
+			makeFaq(),
+		]);
+
+		expect(result.answered).toBe(true);
+		expect(result.answer).toBe('Our standard rate is $125 an hour and $85 on weekends.');
+		expect(result.sources).toEqual(['faq-1']);
+	});
+
+	it('falls back to a deterministic answer when every model fails', async () => {
+		const { generate } = fakeGenerate(() => {
+			throw new Error('provider down');
+		});
+		const service = new AiFaqAnswerService({ models: [PRIMARY], generate });
+
+		const result = await service.answer({ question: 'what is the service cost?' }, [makeFaq()]);
+
+		expect(result.answered).toBe(true);
+		expect(result.answer).toContain('$125');
+		expect(result.sources).toEqual(['faq-1']);
+	});
+
+	it('returns not-answered when a model outage leaves nothing keyword-relevant', async () => {
+		const { generate } = fakeGenerate(() => {
+			throw new Error('provider down');
+		});
+		const service = new AiFaqAnswerService({ models: [PRIMARY], generate });
+
+		// Nothing in the question overlaps the FAQ, so the deterministic fallback can't
+		// guess — it reports not-answered rather than returning an unrelated FAQ.
+		const result = await service.answer({ question: 'do you ship internationally?' }, [makeFaq()]);
+
+		expect(result.answered).toBe(false);
+	});
+
+	it('falls back to the next model when the primary errors', async () => {
+		const { generate, mock } = fakeGenerate(({ model }) => {
+			if (model === PRIMARY) {
+				throw new Error('primary down');
+			}
+			return { object: { answered: true, answer: 'Backup answered.', faqIds: ['faq-1'] } };
+		});
+		const service = new AiFaqAnswerService({ models: [PRIMARY, BACKUP], generate });
+
+		const result = await service.answer({ question: 'cost?' }, [makeFaq()]);
+
+		expect(result.answer).toBe('Backup answered.');
+		expect(mock).toHaveBeenCalledTimes(2);
+	});
+
+	it('caps a runaway model answer to keep replies chat-sized', async () => {
+		const { generate } = fakeGenerate(() => ({
+			object: { answered: true, answer: 'z'.repeat(5000), faqIds: ['faq-1'] },
+		}));
+		const service = new AiFaqAnswerService({ models: [PRIMARY], generate });
+
+		const result = await service.answer({ question: 'cost?' }, [makeFaq()]);
+
+		expect(result.answer.length).toBeLessThanOrEqual(1200);
+	});
+
+	it('keeps the answer but drops sources when the only cited id is unusable and nothing overlaps', async () => {
+		// The model answered and cited only a hallucinated id; the question shares no
+		// keyword with the FAQ, so there's no closest fallback — we return the answer
+		// with empty sources rather than inventing a citation.
+		const { generate } = fakeGenerate(() => ({
+			object: { answered: true, answer: 'A general reply.', faqIds: ['ghost-id'] },
+		}));
+		const service = new AiFaqAnswerService({ models: [PRIMARY], generate });
+
+		const result = await service.answer({ question: 'completely unrelated zzqqx?' }, [makeFaq()]);
+
+		expect(result).toEqual({ answered: true, answer: 'A general reply.', sources: [] });
+	});
+
+	it('logs and degrades to deterministic when a model fails', async () => {
+		const warnings: string[] = [];
+		const { generate } = fakeGenerate(() => {
+			throw new Error('boom');
+		});
+		const service = new AiFaqAnswerService({
+			models: [PRIMARY],
+			generate,
+			logger: { warn: (message) => warnings.push(message) },
+		});
+
+		const result = await service.answer({ question: 'what is the cost?' }, [makeFaq()]);
+
+		expect(result.answered).toBe(true);
+		expect(warnings[0]).toMatch(/faq_answer/);
+	});
+});
+
+describe('createFaqAnswerService', () => {
+	const baseConfig = {
+		OPENAI_MODEL: 'gpt-5.4-mini',
+		GEMINI_MODEL: 'gemini-2.5-flash',
+		XAI_MODEL: 'grok-4-fast',
+		ANTHROPIC_MODEL: 'claude-haiku-4-5',
+	};
+
+	it('returns a deterministic no-op service when no provider key is set', () => {
+		const service = createFaqAnswerService({ ...baseConfig });
+		expect(service).toBeInstanceOf(NoopFaqAnswerService);
+	});
+
+	it('returns an AI-backed service when at least one provider key is set', () => {
+		const service = createFaqAnswerService({ ...baseConfig, OPENAI_API_KEY: 'sk-test' });
+		expect(service).toBeInstanceOf(AiFaqAnswerService);
+	});
+});
+
+describe('deterministicFaqAnswer / NoopFaqAnswerService', () => {
+	it('answers with the most keyword-relevant FAQ', async () => {
+		const faqs = [
+			makeFaq({
+				id: 'faq-hours' as FaqId,
+				question: 'What are your hours?',
+				answer: '9 to 5.',
+				category: 'General',
+			}),
+			makeFaq({
+				id: 'faq-cost' as FaqId,
+				question: 'What does a service call cost?',
+				answer: 'It costs $89.',
+				category: 'Pricing',
+			}),
+		];
+		const result = deterministicFaqAnswer('how much does a service call cost?', faqs);
+
+		expect(result).toEqual({ answered: true, answer: 'It costs $89.', sources: ['faq-cost'] });
+	});
+
+	it('reports not-answered when nothing overlaps', async () => {
+		const service: FaqAnswerService = new NoopFaqAnswerService();
+		const result = await service.answer({ question: 'tell me a joke' }, [makeFaq()]);
+
+		expect(result).toEqual({ answered: false, answer: '', sources: [] });
+	});
+
+	it('reports not-answered for an empty knowledge base', () => {
+		expect(deterministicFaqAnswer('anything?', [])).toEqual({
+			answered: false,
+			answer: '',
+			sources: [],
+		});
+	});
+});

--- a/packages/api/test/faq-answer.test.ts
+++ b/packages/api/test/faq-answer.test.ts
@@ -177,6 +177,24 @@ describe('AiFaqAnswerService.answer', () => {
 		expect(result.answer.length).toBeLessThanOrEqual(1200);
 	});
 
+	it('sends the full FAQ answer to the model, not just a short prefix', async () => {
+		// A fact buried past the first several hundred characters must still reach the
+		// model — FAQ answers can be up to 4000 chars and the question may target the end.
+		const longAnswer = `${'Filler sentence. '.repeat(60)}The weekend rate is $85.`;
+		expect(longAnswer.length).toBeGreaterThan(900);
+		const { generate, mock } = fakeGenerate(() => ({
+			object: { answered: true, answer: 'The weekend rate is $85.', faqIds: ['faq-1'] },
+		}));
+		const service = new AiFaqAnswerService({ models: [PRIMARY], generate });
+
+		await service.answer({ question: 'what is the weekend rate?' }, [
+			makeFaq({ answer: longAnswer }),
+		]);
+
+		const options = mock.mock.calls[0]?.[0] as { prompt: string };
+		expect(options.prompt).toContain('The weekend rate is $85.');
+	});
+
 	it('keeps the answer but drops sources when the only cited id is unusable and nothing overlaps', async () => {
 		// The model answered and cited only a hallucinated id; the question shares no
 		// keyword with the FAQ, so there's no closest fallback — we return the answer

--- a/packages/api/test/faqs.test.ts
+++ b/packages/api/test/faqs.test.ts
@@ -483,4 +483,48 @@ describe('POST /v1/faqs/answer', () => {
 		expect(received[0]?.question).toBe('Do you offer refunds?');
 		await app.close();
 	});
+
+	it('never answers from or cites a draft FAQ', async () => {
+		let received: Faq[] = [];
+		const stub: FaqAnswerService = {
+			async answer(_input, candidates): Promise<FaqAnswer> {
+				received = candidates;
+				// Echo whatever it was given as the source, to prove drafts can't leak.
+				const [first] = candidates;
+				return first
+					? { answered: true, answer: first.answer, sources: [first.id] }
+					: { answered: false, answer: '', sources: [] };
+			},
+		};
+		const app = await buildTestApp({ faqAnswer: stub });
+		const token = (await signupOwner(app)).token;
+		// A published FAQ and a draft FAQ holding unreleased pricing.
+		await app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: { question: 'What are your hours?', answer: '9 to 5.', status: 'published' },
+		});
+		await app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: { question: 'Upcoming price?', answer: 'SECRET draft pricing.', status: 'draft' },
+		});
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/answer',
+			headers: authHeader(token),
+			payload: { question: 'price?' },
+		});
+
+		expect(response.statusCode).toBe(200);
+		// Only the published FAQ is ever handed to the answering service…
+		expect(received).toHaveLength(1);
+		expect(received[0]?.status).toBe('published');
+		// …and the draft's content never appears in the reply.
+		expect(response.json().answer).not.toContain('SECRET');
+		await app.close();
+	});
 });

--- a/packages/api/test/faqs.test.ts
+++ b/packages/api/test/faqs.test.ts
@@ -1,6 +1,7 @@
-import type { FaqId } from '@rivus/core';
+import type { Faq, FaqId } from '@rivus/core';
 import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { FaqAnswer, FaqAnswerService } from '../src/services/faq-answer';
 import type { FaqSimilarityService } from '../src/services/faq-similarity';
 import { authHeader, buildTestApp, signupOwner } from './helpers';
 
@@ -328,6 +329,158 @@ describe('POST /v1/faqs/similar', () => {
 
 		expect(response.statusCode).toBe(200);
 		expect(response.json()).toEqual({ match: null, reason: '', merged: null });
+		await app.close();
+	});
+});
+
+describe('POST /v1/faqs/answer', () => {
+	it('requires authentication', async () => {
+		const app = await buildTestApp();
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/answer',
+			payload: { question: 'How much do you charge?' },
+		});
+		expect(response.statusCode).toBe(401);
+		await app.close();
+	});
+
+	it('rejects an empty question (400)', async () => {
+		const app = await buildTestApp();
+		const token = (await signupOwner(app)).token;
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/answer',
+			headers: authHeader(token),
+			payload: { question: '' },
+		});
+		expect(response.statusCode).toBe(400);
+		await app.close();
+	});
+
+	it('answers from the knowledge base and cites the source FAQ', async () => {
+		// A stub stands in for the AI service: it answers and points at whichever FAQ
+		// id the account created, exercising the route's id → question resolution.
+		let sourceId: string | null = null;
+		const stub: FaqAnswerService = {
+			async answer(): Promise<FaqAnswer> {
+				return sourceId
+					? {
+							answered: true,
+							answer: 'Our standard rate is $125 an hour, and $85 on weekends.',
+							sources: [sourceId as FaqId],
+						}
+					: { answered: false, answer: '', sources: [] };
+			},
+		};
+		const app = await buildTestApp({ faqAnswer: stub });
+		const token = (await signupOwner(app)).token;
+		const created = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: {
+				question: 'How much does your service cost?',
+				answer: 'our standard rate is 125 an hour and 85 on weekends',
+			},
+		});
+		sourceId = created.json().id;
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/answer',
+			headers: authHeader(token),
+			payload: { question: "what's our best price?" },
+		});
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		expect(body.answered).toBe(true);
+		expect(body.answer).toContain('$125');
+		// The cited id is resolved back to its question for the client.
+		expect(body.sources).toEqual([{ id: sourceId, question: 'How much does your service cost?' }]);
+		await app.close();
+	});
+
+	it('reports not-answered when the knowledge base does not cover it', async () => {
+		const app = await buildTestApp();
+		const token = (await signupOwner(app)).token;
+		await app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: { question: 'Where are you located?', answer: 'Seattle.' },
+		});
+
+		// The default (deterministic) service finds no keyword overlap with this ask.
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/answer',
+			headers: authHeader(token),
+			payload: { question: 'tell me a joke' },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ answered: false, answer: '', sources: [] });
+		await app.close();
+	});
+
+	it('drops a cited id that does not belong to the account', async () => {
+		const stub: FaqAnswerService = {
+			async answer(): Promise<FaqAnswer> {
+				return { answered: true, answer: 'Leaked answer.', sources: ['ghost-id' as FaqId] };
+			},
+		};
+		const app = await buildTestApp({ faqAnswer: stub });
+		const token = (await signupOwner(app)).token;
+		await app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: { question: 'How much is a visit?', answer: 'It is $89.' },
+		});
+
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/answer',
+			headers: authHeader(token),
+			payload: { question: 'price?' },
+		});
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		// The answer text passes through, but the unknown id is filtered from sources.
+		expect(body.answer).toBe('Leaked answer.');
+		expect(body.sources).toEqual([]);
+		await app.close();
+	});
+
+	it('hands the account FAQs to the answering service as candidates', async () => {
+		let received: Faq[] = [];
+		const stub: FaqAnswerService = {
+			async answer(_input, candidates): Promise<FaqAnswer> {
+				received = candidates;
+				return { answered: false, answer: '', sources: [] };
+			},
+		};
+		const app = await buildTestApp({ faqAnswer: stub });
+		const token = (await signupOwner(app)).token;
+		await app.inject({
+			method: 'POST',
+			url: '/v1/faqs',
+			headers: authHeader(token),
+			payload: { question: 'Do you offer refunds?', answer: 'Yes, within 30 days.' },
+		});
+
+		await app.inject({
+			method: 'POST',
+			url: '/v1/faqs/answer',
+			headers: authHeader(token),
+			payload: { question: 'refund policy?' },
+		});
+
+		expect(received).toHaveLength(1);
+		expect(received[0]?.question).toBe('Do you offer refunds?');
 		await app.close();
 	});
 });

--- a/packages/api/test/helpers.ts
+++ b/packages/api/test/helpers.ts
@@ -5,6 +5,7 @@ import { buildApp } from '../src/app';
 import { loadConfig } from '../src/config';
 import { createInMemoryRepositories, type InMemoryRepositories } from '../src/repositories/memory';
 import type { InviteEmail, Mailer, VerificationEmail } from '../src/services/email';
+import { NoopFaqAnswerService } from '../src/services/faq-answer';
 import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
 import type { AppDeps } from '../src/types';
 
@@ -52,8 +53,9 @@ export async function buildTestApp(overrides: Partial<AppDeps> = {}): Promise<Fa
 		verificationCodes,
 		// A recording mailer by default so helpers can read back the emailed code.
 		mailer: new RecordingMailer(),
-		// Default to the no-op AI service so tests stay hermetic (no model/network).
+		// Default to the no-op AI services so tests stay hermetic (no model/network).
 		faqSimilarity: new NoopFaqSimilarityService(),
+		faqAnswer: new NoopFaqAnswerService(),
 		ping: async () => ({ ready: true }),
 		...overrides,
 	});
@@ -94,6 +96,7 @@ export async function buildTestAppWithRepos(): Promise<{
 		verificationCodes,
 		mailer: new RecordingMailer(),
 		faqSimilarity: new NoopFaqSimilarityService(),
+		faqAnswer: new NoopFaqAnswerService(),
 		ping: async () => ({ ready: true }),
 	});
 	await app.ready();

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -226,6 +226,17 @@ export const faqSimilarityQuerySchema = z.object({
 });
 export type FaqSimilarityQueryInput = z.infer<typeof faqSimilarityQuerySchema>;
 
+/**
+ * Body for the "answer this question from the knowledge base" ask. The agent
+ * forwards a visitor's free-text question (a chat turn, so it can be longer and
+ * looser than an FAQ title) and the API answers it from the account's FAQs using
+ * AI. The cap is generous but bounded so a runaway prompt can't be submitted.
+ */
+export const faqAnswerQuerySchema = z.object({
+	question: requiredText('Question', 1000),
+});
+export type FaqAnswerQueryInput = z.infer<typeof faqAnswerQuerySchema>;
+
 // --- Customers ----------------------------------------------------------------
 
 /**

--- a/packages/docs/site/openapi.json
+++ b/packages/docs/site/openapi.json
@@ -1717,6 +1717,71 @@
         }
       }
     },
+    "/v1/faqs/answer": {
+      "post": {
+        "summary": "Answer a question from the knowledge base (AI-assisted)",
+        "tags": [
+          "faqs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "question": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000
+                  }
+                },
+                "required": [
+                  "question"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FaqAnswer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/faqs/{id}": {
       "get": {
         "summary": "Fetch one of your FAQs",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — the agent can now answer any question from the knowledge base using AI.

## The problem

The agent only answered questions it could route by keyword: company fields (e.g. "what's our website?") and asks that explicitly contained "FAQ"/"knowledge base". A plain question like **"what's our best price?"** fell through to *"I'm not sure how to help with that yet"* — even though a published pricing FAQ ("our standard rate is 125 an hour and 85 on weekends") answered it. Keyword routing can't connect "best price" to a differently-worded "cost"/"rate" FAQ, which is exactly where semantic AI is needed.

## The change

Add an AI-backed, retrieval-augmented answer path, following the existing architecture (the AI SDK and provider keys live in the **API**; the agent is a thin authenticated client that already calls `/v1/faqs/similar`).

- **`@rivus/core`** — `faqAnswerQuerySchema` for the new request body.
- **`@rivus/api`** — `services/faq-answer.ts`: `AiFaqAnswerService` grounds a reply **strictly** in the account's FAQs (same OpenAI→Google→xAI→Anthropic fallback chain as the duplicate-FAQ check), returns `answered: false` when the knowledge base doesn't cover the question, and never invents facts. New `POST /v1/faqs/answer` route, `faqAnswer` dependency, `FaqAnswer` response schema, and regenerated OpenAPI. With no AI key it degrades to a deterministic keyword match so the API still boots and answers obvious questions.
- **`@rivus/agent`** — `answerFromKnowledge` API-client method and `knowledgeAnswerReply`. The `unknown` catch-all (for signed-in users) is routed through the endpoint and the grounded answer is formatted with a citation to the source FAQ; it falls back to the friendly nudge when the knowledge base has no answer, and never calls the API for signed-out callers.

The answer cites its source FAQ, so users can see it came from their own knowledge base — e.g. *"Our standard rate is $125 an hour, and $85 on weekends. (From your FAQ "How much does your service cost?".)"*

## Tests

- `packages/api/test/faq-answer.test.ts` — service unit tests: grounded answer + source citation, semantic match, not-answered, hallucinated-id rejection, blank/empty fallbacks, provider fallback ordering, answer length cap, deterministic/no-key behavior, factory wiring.
- `packages/api/test/faqs.test.ts` — `POST /v1/faqs/answer` route: auth, validation, id→question resolution, account-scoped source filtering, candidate hand-off.
- `packages/agent/src/{api,assistant}.test.ts` — client method + the full reply flow (cited answer, no-source answer, fallback nudge, signed-out path, API-error path).

`pnpm lint && pnpm type-check && pnpm test` all pass (576 tests); API and agent coverage thresholds hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMevfmwMboXerHqW9frCSu)_