### PR TITLE
fix(agent): parse natural FAQ-create phrasing (quoted titles + Q/A)

### DIFF
--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -446,6 +446,38 @@ describe('respond — knowledge base writes', () => {
 		expect(reply).toMatch(/warranty/i);
 	});
 
+	it('creates an FAQ from a quoted title and a trailing-sentence answer', async () => {
+		// The phrasing a user actually typed: a quoted title plus a follow-on
+		// sentence as the answer — previously this fell through to "tell me both".
+		const reply = await ask(
+			'add this FAQ. "Our Cancelation Policy". It needs to be 24 hour in advance',
+			{
+				token: TOKEN,
+				fetchImpl: router([
+					{ when: onSimilarFaq, body: noSimilarFaq },
+					{
+						when: onCreateFaq,
+						body: makeFaq({
+							question: 'Our Cancelation Policy',
+							answer: 'It needs to be 24 hour in advance',
+						}),
+					},
+				]),
+			},
+		);
+		expect(reply).toMatch(/Added a new FAQ/i);
+		expect(reply).toContain('Our Cancelation Policy');
+	});
+
+	it('asks only for the answer when a quoted title arrives without one', async () => {
+		const reply = await ask('add a faq "Do you deliver?"', {
+			token: TOKEN,
+			fetchImpl: router([]),
+		});
+		expect(reply).toMatch(/in one message/i);
+		expect(reply).toContain('Do you deliver?');
+	});
+
 	it('searches every page of a large knowledge base before reporting a miss', async () => {
 		// Page 1 is full and signals more; the match lives on page 2. A single-page
 		// scan would wrongly report "nothing found".

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -251,4 +251,40 @@ describe('parseIntent — natural FAQ create', () => {
 			answer: null,
 		});
 	});
+
+	it('strips a leading "question:" label so it never leaks into the question', () => {
+		// "question:" is command syntax, not part of the question text.
+		expect(parseIntent('add an FAQ question: Do you deliver? yes')).toEqual({
+			kind: 'faq_create',
+			question: 'Do you deliver?',
+			answer: 'yes',
+		});
+	});
+
+	it('does not treat "to the knowledge base" command boilerplate as the answer', () => {
+		expect(parseIntent('add a faq "Returns" to the knowledge base')).toEqual({
+			kind: 'faq_create',
+			question: 'Returns',
+			answer: null,
+		});
+	});
+
+	it('ignores a quoted phrase that sits before the add-FAQ command', () => {
+		// The quoted "Returns" is page context; the real command follows it.
+		expect(parseIntent('On the "Returns" page, add an FAQ: Do you accept returns? Yes')).toEqual({
+			kind: 'faq_create',
+			question: 'Do you accept returns?',
+			answer: 'Yes',
+		});
+	});
+
+	it('still extracts a quoted title when no add-FAQ command marker is found', () => {
+		// "knowledge" (no "base") matches the KB context but not the command marker,
+		// so the payload falls back to the whole message and the quote still wins.
+		expect(parseIntent('add to my knowledge "Hours" we open at 9')).toEqual({
+			kind: 'faq_create',
+			question: 'Hours',
+			answer: 'we open at 9',
+		});
+	});
 });

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -164,3 +164,83 @@ describe('parseIntent — knowledge base', () => {
 		});
 	});
 });
+
+describe('parseIntent — natural FAQ create', () => {
+	it('extracts a quoted title and a trailing-sentence answer (the reported case)', () => {
+		expect(
+			parseIntent('add this FAQ. "Our Cancelation Policy". It needs to be 24 hour in advance'),
+		).toEqual({
+			kind: 'faq_create',
+			question: 'Our Cancelation Policy',
+			answer: 'It needs to be 24 hour in advance',
+		});
+	});
+
+	it('handles smart (curly) quotes from a phone keyboard', () => {
+		expect(parseIntent('add a faq “Our Hours”. We open at 9am')).toEqual({
+			kind: 'faq_create',
+			question: 'Our Hours',
+			answer: 'We open at 9am',
+		});
+	});
+
+	it('takes a quoted title alone as the question and asks for the answer next', () => {
+		expect(parseIntent('add a faq "Do you deliver?"')).toEqual({
+			kind: 'faq_create',
+			question: 'Do you deliver?',
+			answer: null,
+		});
+	});
+
+	it('strips a stray "answer:" label that trails a quoted title', () => {
+		expect(parseIntent('add a faq "Returns" answer: 30 days')).toEqual({
+			kind: 'faq_create',
+			question: 'Returns',
+			answer: '30 days',
+		});
+	});
+
+	it('splits a natural "<question>? <answer>" with no quotes', () => {
+		expect(parseIntent('add an FAQ: do you deliver? yes, city-wide')).toEqual({
+			kind: 'faq_create',
+			question: 'do you deliver?',
+			answer: 'yes, city-wide',
+		});
+	});
+
+	it('treats a lone question (ending in ?) as the question and asks for the answer', () => {
+		expect(parseIntent('add an faq: how do I cancel?')).toEqual({
+			kind: 'faq_create',
+			question: 'how do I cancel?',
+			answer: null,
+		});
+	});
+
+	it('does not mistake an apostrophe for an opening quote', () => {
+		// No double-quoted title and no "?" → nothing reliable to extract, so it asks
+		// for both parts rather than splitting on the apostrophe in "it's".
+		expect(parseIntent("add a faq it's our policy")).toEqual({
+			kind: 'faq_create',
+			question: null,
+			answer: null,
+		});
+	});
+
+	it('does not split on a "?" that ends the request rather than the FAQ', () => {
+		// The "?" closes "…to our FAQ?", so it must not be taken as the FAQ's
+		// question with the trailing sentence as its answer.
+		expect(parseIntent('Can you add this to our FAQ? It really matters')).toEqual({
+			kind: 'faq_create',
+			question: null,
+			answer: null,
+		});
+	});
+
+	it('does not invent a question from punctuation alone', () => {
+		expect(parseIntent('add a faq : ?')).toEqual({
+			kind: 'faq_create',
+			question: null,
+			answer: null,
+		});
+	});
+});

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -184,6 +184,14 @@ describe('parseIntent — natural FAQ create', () => {
 		});
 	});
 
+	it('handles German-style low-high double quotes (“„…“”)', () => {
+		expect(parseIntent('add a faq „Our Hours“. We open at 9am')).toEqual({
+			kind: 'faq_create',
+			question: 'Our Hours',
+			answer: 'We open at 9am',
+		});
+	});
+
 	it('takes a quoted title alone as the question and asks for the answer next', () => {
 		expect(parseIntent('add a faq "Do you deliver?"')).toEqual({
 			kind: 'faq_create',

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -117,10 +117,12 @@ function parseFaqUpdate(text: string): { topic: string; answer: string | null } 
 /**
  * A double-quoted phrase used as the FAQ's title/question, e.g.
  * `add this FAQ. "Our Cancelation Policy". …`. Only *double* quotes (straight,
- * curly, or low) delimit a title — single quotes/apostrophes are left alone so
- * words like "don't" or "policy's" never look like an opening quote.
+ * curly, or German low-high „…“) delimit a title — single quotes/apostrophes are
+ * left alone so words like "don't" or "policy's" never look like an opening
+ * quote. Note U+201C (“) is both the English opening and the German closing
+ * quote, so it appears in both the opening and closing classes.
  */
-const QUOTED_TITLE = /["“„]([^"“”„]+)["”]/;
+const QUOTED_TITLE = /["“„]([^"“”„]+)["”“]/;
 
 /** Strip the leading "add/create/make … faq" preamble, leaving just the content. */
 function stripCreatePreamble(text: string): string {
@@ -134,7 +136,7 @@ function cleanAnswer(value: string): string {
 	return value
 		.replace(/^[\s,.:;()\-–—"“„]+/, '')
 		.replace(/^answer\s*[:=-]\s*/i, '')
-		.replace(/["”]+$/, '')
+		.replace(/["”“]+$/, '')
 		.replace(/[.!?]+\s*$/, '')
 		.replace(/\s+/g, ' ')
 		.trim();

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -124,22 +124,48 @@ function parseFaqUpdate(text: string): { topic: string; answer: string | null } 
  */
 const QUOTED_TITLE = /["“„]([^"“”„]+)["”“]/;
 
-/** Strip the leading "add/create/make … faq" preamble, leaving just the content. */
-function stripCreatePreamble(text: string): string {
-	return text
-		.replace(/^[\s,.:;'"“”-]*(?:add|create|new|make|insert)\b[^?]*?\bfaqs?\b[\s,:.;-]*/i, '')
-		.trim();
+/** The FAQ noun a create command names, plus optional separators that follow it. */
+const FAQ_COMMAND =
+	/(?:add|create|new|make|insert)\b[^?]*?\b(?:faqs?|knowledge[ -]?base|kb)\b[\s:,.-]*/i;
+
+/**
+ * The FAQ "payload" — the text after the `add … faq` command, where the actual
+ * question/answer live. Scoping extraction to this (rather than the whole
+ * message) keeps quoted context or a "?" that appears *before* the command —
+ * `On the "Returns" page, add an FAQ: …` — from being mistaken for FAQ content.
+ * `hadCommand` is false when no command marker is found (then payload is the
+ * whole message).
+ */
+function faqPayload(text: string): { payload: string; hadCommand: boolean } {
+	const match = FAQ_COMMAND.exec(text);
+	if (!match) {
+		return { payload: text, hadCommand: false };
+	}
+	return { payload: text.slice(match.index + match[0].length).trim(), hadCommand: true };
+}
+
+/** Drop a leading `question:` / `q:` label so it never leaks into the question text. */
+function stripQuestionLabel(value: string): string {
+	return value.replace(/^(?:question|q)\s*[:=-]\s*/i, '').trim();
+}
+
+/** True when a candidate answer is really just "…to the/our knowledge base" command boilerplate. */
+function isDestinationBoilerplate(value: string): boolean {
+	return /^(?:to|into|in)\s+(?:the|our|my)\s+(?:knowledge[ -]?base|kb|faqs?)$/i.test(value);
 }
 
 /** Tidy an extracted answer: drop wrapping punctuation/quotes, an "answer:" label, trailing stops. */
 function cleanAnswer(value: string): string {
-	return value
+	const cleaned = value
 		.replace(/^[\s,.:;()\-–—"“„]+/, '')
 		.replace(/^answer\s*[:=-]\s*/i, '')
 		.replace(/["”“]+$/, '')
 		.replace(/[.!?]+\s*$/, '')
 		.replace(/\s+/g, ' ')
 		.trim();
+	// "add a faq \"Returns\" to the knowledge base" leaves "to the knowledge base"
+	// after the title — that's where to put it, not the answer, so don't keep it.
+	return isDestinationBoilerplate(cleaned) ? '' : cleaned;
 }
 
 /** Parse an FAQ-create ask into a question/answer pair, extracting as much as the user gave. */
@@ -151,26 +177,27 @@ function parseFaqCreate(text: string): { question: string | null; answer: string
 	if (qa?.[1] && qa[2]) {
 		return { question: qa[1].trim(), answer: qa[2].trim() };
 	}
+	// Everything below works on the FAQ payload — the content *after* the
+	// `add … faq` command — so quoted context or a "?" before the command is ignored.
+	const { payload, hadCommand } = faqPayload(text);
 	// 2. A double-quoted phrase is the question/title; whatever follows the closing
 	// quote is the answer. Covers the natural phrasing people actually type, e.g.
 	// `add this FAQ. "Our Cancelation Policy". It needs to be 24 hours in advance`.
-	const quoted = QUOTED_TITLE.exec(text);
+	const quoted = QUOTED_TITLE.exec(payload);
 	const title = quoted?.[1]?.trim();
 	if (quoted && title) {
-		const answer = cleanAnswer(text.slice(quoted.index + quoted[0].length));
+		const answer = cleanAnswer(payload.slice(quoted.index + quoted[0].length));
 		return { question: title, answer: answer.length > 0 ? answer : null };
 	}
 	// 3. A natural "<question>? <answer>" split — e.g. `add an FAQ: do you deliver?
-	// yes, city-wide`. Only trust the "?" when the message is actually framed as an
-	// add-FAQ command (the "add … faq" preamble was found and removed); otherwise a
-	// "?" in the *request* itself — "Can you add this to our FAQ? …" — would be
-	// mistaken for the FAQ's question.
-	const body = stripCreatePreamble(text);
-	const mark = body.indexOf('?');
-	if (body.length > 0 && body !== text && mark >= 0) {
-		const question = body.slice(0, mark + 1).trim();
+	// yes, city-wide`. Only trust the "?" when the message is framed as an add-FAQ
+	// command, so a "?" in the *request* itself ("Can you add this to our FAQ? …")
+	// isn't mistaken for the FAQ's question.
+	const mark = payload.indexOf('?');
+	if (hadCommand && payload.length > 0 && mark >= 0) {
+		const question = stripQuestionLabel(payload.slice(0, mark + 1));
 		if (/[\p{L}\p{N}]/u.test(question)) {
-			const answer = cleanAnswer(body.slice(mark + 1));
+			const answer = cleanAnswer(payload.slice(mark + 1));
 			return { question, answer: answer.length > 0 ? answer : null };
 		}
 	}

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -114,16 +114,65 @@ function parseFaqUpdate(text: string): { topic: string; answer: string | null } 
 	return { topic: topic ?? '', answer: null };
 }
 
-/** Parse an FAQ-create ask into an explicit question/answer pair when supplied. */
+/**
+ * A double-quoted phrase used as the FAQ's title/question, e.g.
+ * `add this FAQ. "Our Cancelation Policy". …`. Only *double* quotes (straight,
+ * curly, or low) delimit a title — single quotes/apostrophes are left alone so
+ * words like "don't" or "policy's" never look like an opening quote.
+ */
+const QUOTED_TITLE = /["“„]([^"“”„]+)["”]/;
+
+/** Strip the leading "add/create/make … faq" preamble, leaving just the content. */
+function stripCreatePreamble(text: string): string {
+	return text
+		.replace(/^[\s,.:;'"“”-]*(?:add|create|new|make|insert)\b[^?]*?\bfaqs?\b[\s,:.;-]*/i, '')
+		.trim();
+}
+
+/** Tidy an extracted answer: drop wrapping punctuation/quotes, an "answer:" label, trailing stops. */
+function cleanAnswer(value: string): string {
+	return value
+		.replace(/^[\s,.:;()\-–—"“„]+/, '')
+		.replace(/^answer\s*[:=-]\s*/i, '')
+		.replace(/["”]+$/, '')
+		.replace(/[.!?]+\s*$/, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/** Parse an FAQ-create ask into a question/answer pair, extracting as much as the user gave. */
 function parseFaqCreate(text: string): { question: string | null; answer: string | null } {
-	// "question: ... answer: ..." (or "q: ..."). Only the full word "answer" marks
-	// the split — a bare single-letter "a" would match a stray "a-" / "a:" inside
-	// the question text (e.g. "a-la-carte") and truncate it.
+	// 1. Explicit "question: ... answer: ..." (or "q: ..."). Only the full word
+	// "answer" marks the split — a bare single-letter "a" would match a stray
+	// "a-" / "a:" inside the question text (e.g. "a-la-carte") and truncate it.
 	const qa = /\b(?:question|q)\s*[:-]\s*(.+?)\s+answer\s*[:-]\s*(.+)$/i.exec(text);
 	if (qa?.[1] && qa[2]) {
 		return { question: qa[1].trim(), answer: qa[2].trim() };
 	}
-	// Otherwise treat any "about <topic>" as the question and ask for the answer.
+	// 2. A double-quoted phrase is the question/title; whatever follows the closing
+	// quote is the answer. Covers the natural phrasing people actually type, e.g.
+	// `add this FAQ. "Our Cancelation Policy". It needs to be 24 hours in advance`.
+	const quoted = QUOTED_TITLE.exec(text);
+	const title = quoted?.[1]?.trim();
+	if (quoted && title) {
+		const answer = cleanAnswer(text.slice(quoted.index + quoted[0].length));
+		return { question: title, answer: answer.length > 0 ? answer : null };
+	}
+	// 3. A natural "<question>? <answer>" split — e.g. `add an FAQ: do you deliver?
+	// yes, city-wide`. Only trust the "?" when the message is actually framed as an
+	// add-FAQ command (the "add … faq" preamble was found and removed); otherwise a
+	// "?" in the *request* itself — "Can you add this to our FAQ? …" — would be
+	// mistaken for the FAQ's question.
+	const body = stripCreatePreamble(text);
+	const mark = body.indexOf('?');
+	if (body.length > 0 && body !== text && mark >= 0) {
+		const question = body.slice(0, mark + 1).trim();
+		if (/[\p{L}\p{N}]/u.test(question)) {
+			const answer = cleanAnswer(body.slice(mark + 1));
+			return { question, answer: answer.length > 0 ? answer : null };
+		}
+	}
+	// 4. Otherwise treat any "about <topic>" as the question and ask for the answer.
 	const topic = afterPreposition(text);
 	return { question: topic, answer: null };
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix — making the agent's FAQ-create flow robust to natural phrasing.

### The problem

A user typed:

> add this FAQ. "Our Cancelation Policy". It needs to be 24 hour in advance

…and instead of creating the FAQ, the agent replied *"Sure — what question should the FAQ answer, and what's the answer?"*.

The agent's understanding layer (`packages/agent/src/intent.ts`) is **rule-based, not an LLM**. `parseFaqCreate` only recognised an FAQ's question/answer when the user used a rigid `question: … answer: …` format or an `about <topic>` preposition. The quoted title and the trailing-sentence answer matched neither, so the parser returned `{ question: null, answer: null }` and the assistant fell back to asking the user to restate it in the example format.

### The fix

`parseFaqCreate` now extracts as much as the user actually gave, in precedence order:

1. Explicit `question: … answer: …` / `q: …` (unchanged).
2. **A double-quoted phrase is the question/title; the text after the closing quote is the answer.** Handles straight, curly, and low double quotes. Single quotes/apostrophes are deliberately ignored so words like `don't` or `policy's` never look like an opening quote.
3. **A natural `<question>? <answer>` split** — but only once the `add … faq` preamble has actually been stripped, so a `?` that ends the *request itself* (`Can you add this to our FAQ? …`) is not mistaken for the FAQ's question.
4. The existing `about <topic>` fallback (unchanged).

The reported message now parses to `{ question: 'Our Cancelation Policy', answer: 'It needs to be 24 hour in advance' }` and the FAQ is created. The parser stays pure and rule-based, so it remains hermetically unit-tested with no new dependencies — and is still the single function to swap if/when an LLM is introduced.

### Tests

- `intent.test.ts` — 9 new cases: the reported case, curly quotes, quoted-title-only, stray `answer:` label, the `?` split, lone-question, plus regression guards that an apostrophe isn't a quote, a request-level `?` isn't split on, and punctuation alone doesn't invent a question.
- `assistant.test.ts` — 2 end-to-end cases: a quoted title + trailing answer creates the FAQ; a quoted title alone echoes the question and asks for the answer.
- `intent.ts` stays at 100% line/function coverage. All gates pass locally: `pnpm lint && pnpm type-check && pnpm test` (core 79, agent 129, api 205, app 103, website 43).

### Out of scope / follow-up

This keeps the parser rule-based. Some realistic phrasings still aren't covered by rules — dash-delimited `Q - A`, `A:` answer-label shorthand, statement-style bodies that the `about/on/for` fallback mis-grabs. Those are the limit of a regex approach; the durable path to robustness here is to replace `parseIntent`/`parseFaqCreate` with an LLM-backed classifier (the module is already designed so that's a single-function swap). Happy to follow up with that if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2gzsjQF9qvw7zHUZpVo5o

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2gzsjQF9qvw7zHUZpVo5o)_