### PR TITLE
feat(app): link the logo to Home

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -14,9 +14,11 @@ import {
 	ActivityIndicator,
 	Pressable,
 	ScrollView,
+	type StyleProp,
 	StyleSheet,
 	useWindowDimensions,
 	View,
+	type ViewStyle,
 } from 'react-native';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AuthProvider, initialsOf, roleLabel, useAuth } from '@/src/auth/AuthContext';
@@ -172,6 +174,25 @@ function Shell() {
 	);
 }
 
+/**
+ * The Rivus wordmark, linking back to Home. Shared by the wide sidebar and the
+ * compact top bar so the brand mark is a consistent "return to dashboard" tap
+ * target on every breakpoint.
+ */
+function HomeLink({ height, style }: { height: number; style?: StyleProp<ViewStyle> }) {
+	const router = useRouter();
+	return (
+		<Pressable
+			style={style}
+			onPress={() => router.push('/')}
+			accessibilityRole="link"
+			accessibilityLabel="Rivus home"
+		>
+			<RivusWordmark height={height} />
+		</Pressable>
+	);
+}
+
 /* ------------------------------- Wide layout ------------------------------ */
 
 function Sidebar() {
@@ -183,9 +204,7 @@ function Sidebar() {
 
 	return (
 		<View style={styles.sidebar}>
-			<View style={styles.sidebarLogo}>
-				<RivusWordmark height={24} />
-			</View>
+			<HomeLink height={24} style={styles.sidebarLogo} />
 
 			<View style={styles.nav}>
 				{navFor(session?.role).map((item) => {
@@ -263,7 +282,7 @@ function CompactBar() {
 	const insets = useSafeAreaInsets();
 	return (
 		<View style={[styles.compactBar, { paddingTop: insets.top + 12 }]}>
-			<RivusWordmark height={20} />
+			<HomeLink height={20} />
 			<View style={styles.compactRight}>
 				<View style={styles.compactStatus}>
 					<Dot color={colors.green} size={7} />

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -187,6 +187,7 @@ function HomeLink({ height, style }: { height: number; style?: StyleProp<ViewSty
 			onPress={() => router.push('/')}
 			accessibilityRole="link"
 			accessibilityLabel="Rivus home"
+			hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
 		>
 			<RivusWordmark height={height} />
 		</Pressable>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature / UX fix — in the app, clicking the Rivus logo now takes you to the Home page.

## Summary

The Rivus wordmark renders in two places in the dashboard shell (`packages/app/app/_layout.tsx`) — the wide-layout `Sidebar` and the narrow-layout `CompactBar` — but in both it was a static, non-interactive mark. This makes it a navigation target back to Home, matching the convention users expect of a product logo.

- Added a small shared `HomeLink` component that wraps `RivusWordmark` in a `Pressable` and navigates to the dashboard root with `router.push('/')` on press — the same call the existing **Home** nav item already uses.
- Used `HomeLink` in both the sidebar (`height={24}`, keeping the existing `sidebarLogo` padding as the tap target) and the compact top bar (`height={20}`), so the behavior is identical on every breakpoint.
- Gave it `accessibilityRole="link"` and `accessibilityLabel="Rivus home"` for assistive tech and the web `role="link"` mapping.

## Testing

- `pnpm lint` — clean (221 files)
- `pnpm type-check` — passes across all packages
- `pnpm test` — full suite green (app: 103 passed)

No automated test was added: this layout lives under `packages/app/app/`, which has no React Native component-test harness (the app's hermetic tests cover the pure `src/api` and `src/agent` clients, and Vitest coverage is scoped to those). The change is a thin navigation wrapper and was verified against the existing gates above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtDHXMq4259WcpC9BbeGax

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtDHXMq4259WcpC9BbeGax)_