### PR TITLE
feat(app): move mobile navigation to a bottom tab bar

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -112,6 +112,23 @@ Supporting gradients:
 
 ---
 
+## Layout & breakpoints
+
+The app shell is responsive around a single breakpoint.
+
+| Token                 | Value   | Use                                                                                          |
+| --------------------- | ------- | -------------------------------------------------------------------------------------------- |
+| Sidebar breakpoint    | `880px` | At/above, the persistent left sidebar shows; below, the mobile layout with a bottom tab bar   |
+| Sidebar width         | `244px` | Width of the persistent left sidebar                                                          |
+| Mobile tab bar height | `56px`  | Height of the bottom tab bar, excluding the safe-area inset padded below it                   |
+
+In the shared theme these are `SIDEBAR_BREAKPOINT`, `SIDEBAR_WIDTH`, and
+`MOBILE_TABBAR_HEIGHT`. The tab bar has no fixed height (it grows with larger
+text settings), so surfaces that anchor to it should measure the rendered bar
+rather than assume the constant.
+
+---
+
 ## Components
 
 These are the shared, reusable building blocks. Match their structure and props
@@ -163,6 +180,20 @@ A single dashboard metric.
 - **Secondary:** white with a `1px` hairline (`#e9eaf0`) border.
 - Both stay **inline** — there is no shared button design component; build per
   platform using these recipes.
+
+### Navigation
+
+The primary app navigation adapts to width (see **Layout & breakpoints**):
+
+- **Wide (≥ 880px):** a persistent left **sidebar** lists every destination; the
+  active item is marked with the signature gradient.
+- **Narrow (< 880px):** a fixed **bottom tab bar** — the mobile convention. The
+  primary destinations sit on the bar as icon-over-label tabs; the remaining
+  destinations fold into a **"More"** tab that opens a sheet (which also holds
+  sign-out). The active tab uses a gradient indicator with a violet icon + label.
+
+Active nav is one of the few places the signature gradient is allowed (see
+**Signature gradient**).
 
 ---
 

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -131,8 +131,15 @@ function Gate() {
 
 function Shell() {
 	const { width } = useWindowDimensions();
+	const insets = useSafeAreaInsets();
 	const { isStaff, session } = useAuth();
 	const wide = width >= SIDEBAR_BREAKPOINT;
+
+	// Measured height of the bottom tab bar (it has no fixed height, so larger
+	// text settings or a wrapped label can grow it). The chat button and the
+	// "More" sheet anchor to this so they always clear the real bar; the constant
+	// is just the pre-measurement default.
+	const [tabBarHeight, setTabBarHeight] = useState(MOBILE_TABBAR_HEIGHT + insets.bottom);
 
 	// Remount the agent chat when the active account changes (a staff "switch
 	// company" swaps the session in place). Its transcript and answers are
@@ -169,10 +176,10 @@ function Shell() {
 			</View>
 			{/* Render the chat button before the tab bar so the "More" sheet and its
 			    backdrop layer above — and dim — the chat button while the sheet is open.
-			    The button is lifted by MOBILE_TABBAR_HEIGHT so the two never overlap when
-			    the sheet is closed. */}
-			<RivusChat key={chatKey} bottomOffset={MOBILE_TABBAR_HEIGHT} />
-			<BottomTabBar />
+			    The button is lifted by the measured bar height so the two never overlap
+			    when the sheet is closed. */}
+			<RivusChat key={chatKey} bottomOffset={tabBarHeight} />
+			<BottomTabBar height={tabBarHeight} onHeight={setTabBarHeight} />
 		</View>
 	);
 }
@@ -292,7 +299,7 @@ const PRIMARY_TAB_COUNT = 4;
  * Shows the primary destinations as tabs and folds the rest behind a "More"
  * tab that opens a sheet just above the bar.
  */
-function BottomTabBar() {
+function BottomTabBar({ height, onHeight }: { height: number; onHeight: (h: number) => void }) {
 	const pathname = usePathname();
 	const router = useRouter();
 	const insets = useSafeAreaInsets();
@@ -314,14 +321,13 @@ function BottomTabBar() {
 	return (
 		<>
 			{moreOpen && overflow.length > 0 ? (
-				<MoreSheet
-					items={overflow}
-					bottomInset={insets.bottom}
-					onClose={() => setMoreOpen(false)}
-				/>
+				<MoreSheet items={overflow} barHeight={height} onClose={() => setMoreOpen(false)} />
 			) : null}
 
-			<View style={[styles.tabbar, { paddingBottom: insets.bottom + 6 }]}>
+			<View
+				style={[styles.tabbar, { paddingBottom: insets.bottom + 6 }]}
+				onLayout={(event) => onHeight(event.nativeEvent.layout.height)}
+			>
 				{primary.map((item) => (
 					<TabButton
 						key={item.href}
@@ -388,11 +394,11 @@ function TabButton({
 /** Overflow destinations (and sign-out) for the bottom bar's "More" tab. */
 function MoreSheet({
 	items,
-	bottomInset,
+	barHeight,
 	onClose,
 }: {
 	items: NavItem[];
-	bottomInset: number;
+	barHeight: number;
 	onClose: () => void;
 }) {
 	const pathname = usePathname();
@@ -409,7 +415,7 @@ function MoreSheet({
 				accessibilityRole="button"
 				accessibilityLabel="Close menu"
 			/>
-			<View style={[styles.sheet, { bottom: MOBILE_TABBAR_HEIGHT + bottomInset }]}>
+			<View style={[styles.sheet, { bottom: barHeight }]}>
 				<View style={styles.sheetHandle} />
 				{items.map((item) => {
 					const active = isActive(pathname, item.href);

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -9,15 +9,8 @@ import {
 } from '@expo-google-fonts/montserrat';
 import { Redirect, Slot, usePathname, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import { useEffect } from 'react';
-import {
-	ActivityIndicator,
-	Pressable,
-	ScrollView,
-	StyleSheet,
-	useWindowDimensions,
-	View,
-} from 'react-native';
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AuthProvider, initialsOf, roleLabel, useAuth } from '@/src/auth/AuthContext';
 import { AuthScreen } from '@/src/auth/AuthScreen';
@@ -27,7 +20,15 @@ import { BrandGradient } from '@/src/components/Gradient';
 import { RivusChat } from '@/src/components/RivusChat';
 import { Avatar, Dot, Icon, RivusStatusChip, Txt } from '@/src/components/ui';
 import { installFocusRing } from '@/src/theme/focusRing';
-import { colors, font, radii, SIDEBAR_BREAKPOINT, SIDEBAR_WIDTH } from '@/src/theme/tokens';
+import {
+	colors,
+	font,
+	MOBILE_TABBAR_HEIGHT,
+	radii,
+	SIDEBAR_BREAKPOINT,
+	SIDEBAR_WIDTH,
+	shadowSoft,
+} from '@/src/theme/tokens';
 
 type FeatherName = React.ComponentProps<typeof Feather>['name'];
 type NavItem = {
@@ -163,11 +164,12 @@ function Shell() {
 					<CompanySwitcher />
 				</View>
 			) : null}
-			<NavStrip />
 			<View style={styles.content}>
 				<Slot />
 			</View>
-			<RivusChat key={chatKey} />
+			<BottomTabBar />
+			{/* Lift the chat button clear of the bottom tab bar so they don't overlap. */}
+			<RivusChat key={chatKey} bottomOffset={MOBILE_TABBAR_HEIGHT} />
 		</View>
 	);
 }
@@ -278,44 +280,186 @@ function CompactBar() {
 	);
 }
 
-function NavStrip() {
+// How many destinations sit directly on the bar; the rest fold into "More".
+// Four primary tabs + More keeps the bar within the ~5-slot mobile convention.
+const PRIMARY_TAB_COUNT = 4;
+
+/**
+ * Fixed bottom tab bar — the narrow-layout counterpart to the wide Sidebar.
+ * Shows the primary destinations as tabs and folds the rest behind a "More"
+ * tab that opens a sheet just above the bar.
+ */
+function BottomTabBar() {
 	const pathname = usePathname();
 	const router = useRouter();
+	const insets = useSafeAreaInsets();
 	const { session } = useAuth();
+	const [moreOpen, setMoreOpen] = useState(false);
+
+	const items = navFor(session?.role);
+	const primary = items.slice(0, PRIMARY_TAB_COUNT);
+	const overflow = items.slice(PRIMARY_TAB_COUNT);
+
+	const overflowActive = overflow.some((item) => isActive(pathname, item.href));
+	const overflowHasBadge = overflow.some((item) => item.badge);
+
+	function go(href: string) {
+		setMoreOpen(false);
+		router.push(href);
+	}
+
 	return (
-		<View style={styles.navStripWrap}>
-			<ScrollView
-				horizontal
-				showsHorizontalScrollIndicator={false}
-				contentContainerStyle={styles.navStrip}
-			>
-				{navFor(session?.role).map((item) => {
+		<>
+			{moreOpen && overflow.length > 0 ? (
+				<MoreSheet
+					items={overflow}
+					bottomInset={insets.bottom}
+					onClose={() => setMoreOpen(false)}
+				/>
+			) : null}
+
+			<View style={[styles.tabbar, { paddingBottom: insets.bottom + 6 }]}>
+				{primary.map((item) => (
+					<TabButton
+						key={item.href}
+						icon={item.icon}
+						label={item.label}
+						badge={item.badge}
+						active={isActive(pathname, item.href)}
+						onPress={() => go(item.href)}
+					/>
+				))}
+				{overflow.length > 0 ? (
+					<TabButton
+						icon="more-horizontal"
+						label="More"
+						active={overflowActive || moreOpen}
+						dot={overflowHasBadge}
+						onPress={() => setMoreOpen((open) => !open)}
+					/>
+				) : null}
+			</View>
+		</>
+	);
+}
+
+function TabButton({
+	icon,
+	label,
+	active,
+	badge,
+	dot,
+	onPress,
+}: {
+	icon: FeatherName;
+	label: string;
+	active: boolean;
+	badge?: string;
+	dot?: boolean;
+	onPress: () => void;
+}) {
+	return (
+		<Pressable
+			style={styles.tab}
+			onPress={onPress}
+			accessibilityRole="button"
+			accessibilityState={{ selected: active }}
+			accessibilityLabel={label}
+		>
+			{active ? <BrandGradient style={styles.tabIndicator} /> : null}
+			<View>
+				<Feather name={icon} size={22} color={active ? colors.brandPurple : colors.textMuted} />
+				{badge ? (
+					<View style={styles.tabBadge}>
+						<Txt style={styles.tabBadgeTxt}>{badge}</Txt>
+					</View>
+				) : dot ? (
+					<View style={styles.tabDot} />
+				) : null}
+			</View>
+			<Txt style={[styles.tabLabel, active && styles.tabLabelActive]}>{label}</Txt>
+		</Pressable>
+	);
+}
+
+/** Overflow destinations (and sign-out) for the bottom bar's "More" tab. */
+function MoreSheet({
+	items,
+	bottomInset,
+	onClose,
+}: {
+	items: NavItem[];
+	bottomInset: number;
+	onClose: () => void;
+}) {
+	const pathname = usePathname();
+	const router = useRouter();
+	const { session, signOut } = useAuth();
+	const userName = session?.user.name ?? '';
+	const role = session ? roleLabel(session.role) : '';
+
+	return (
+		<>
+			<Pressable
+				style={styles.sheetBackdrop}
+				onPress={onClose}
+				accessibilityRole="button"
+				accessibilityLabel="Close menu"
+			/>
+			<View style={[styles.sheet, { bottom: MOBILE_TABBAR_HEIGHT + bottomInset }]}>
+				<View style={styles.sheetHandle} />
+				{items.map((item) => {
 					const active = isActive(pathname, item.href);
-					const content = (
-						<>
-							<Feather name={item.icon} size={15} color={active ? '#fff' : colors.textSub} />
-							<Txt style={[styles.chipTxt, active && styles.chipTxtActive]}>{item.label}</Txt>
-							{item.badge ? (
-								<View style={[styles.chipBadge, active && styles.chipBadgeActive]}>
-									<Txt style={[styles.chipBadgeTxt, active && styles.chipBadgeTxtActive]}>
-										{item.badge}
-									</Txt>
-								</View>
-							) : null}
-						</>
-					);
 					return (
-						<Pressable key={item.href} onPress={() => router.push(item.href)}>
-							{active ? (
-								<BrandGradient style={styles.chip}>{content}</BrandGradient>
-							) : (
-								<View style={[styles.chip, styles.chipInactive]}>{content}</View>
-							)}
+						<Pressable
+							key={item.href}
+							style={[styles.sheetRow, active && styles.sheetRowActive]}
+							onPress={() => {
+								onClose();
+								router.push(item.href);
+							}}
+							accessibilityRole="button"
+							accessibilityState={{ selected: active }}
+						>
+							<Feather
+								name={item.icon}
+								size={18}
+								color={active ? colors.brandPurple : colors.textSub}
+							/>
+							<Txt style={[styles.sheetLabel, active && styles.sheetLabelActive]}>{item.label}</Txt>
+							{item.badge ? (
+								<BrandGradient style={styles.sheetBadge}>
+									<Txt style={styles.sheetBadgeTxt}>{item.badge}</Txt>
+								</BrandGradient>
+							) : null}
 						</Pressable>
 					);
 				})}
-			</ScrollView>
-		</View>
+
+				<View style={styles.sheetDivider} />
+				<Pressable
+					style={styles.sheetUser}
+					onPress={() => {
+						onClose();
+						signOut();
+					}}
+					accessibilityRole="button"
+					accessibilityLabel="Sign out"
+				>
+					<Avatar
+						initials={userName ? initialsOf(userName) : '–'}
+						size={32}
+						background={colors.avatarBg}
+						color={colors.avatarText}
+					/>
+					<View style={{ flex: 1 }}>
+						<Txt style={styles.sheetUserName}>{userName}</Txt>
+						<Txt style={styles.sheetUserRole}>{role}</Txt>
+					</View>
+					<Feather name="log-out" size={16} color={colors.textMuted} />
+				</Pressable>
+			</View>
+		</>
 	);
 }
 
@@ -522,51 +666,149 @@ const styles = StyleSheet.create({
 		paddingHorizontal: 18,
 		paddingVertical: 10,
 	},
-	navStripWrap: {
-		backgroundColor: colors.surface,
-		borderBottomWidth: 1,
-		borderBottomColor: colors.border,
-	},
-	navStrip: {
+	// Bottom tab bar (narrow layout)
+	tabbar: {
 		flexDirection: 'row',
-		gap: 8,
-		paddingHorizontal: 16,
-		paddingVertical: 11,
+		alignItems: 'flex-start',
+		justifyContent: 'space-around',
+		backgroundColor: colors.surface,
+		borderTopWidth: 1,
+		borderTopColor: colors.border,
+		paddingTop: 8,
+		paddingHorizontal: 6,
 	},
-	chip: {
+	tab: {
+		flex: 1,
+		alignItems: 'center',
+		gap: 4,
+		paddingVertical: 2,
+	},
+	tabIndicator: {
+		position: 'absolute',
+		top: -8,
+		width: 26,
+		height: 3,
+		borderBottomLeftRadius: 3,
+		borderBottomRightRadius: 3,
+	},
+	tabLabel: {
+		fontFamily: font.semibold,
+		fontSize: 10.5,
+		color: colors.textMuted,
+	},
+	tabLabelActive: {
+		color: colors.brandPurple,
+	},
+	tabBadge: {
+		position: 'absolute',
+		top: -5,
+		right: -10,
+		minWidth: 16,
+		height: 16,
+		paddingHorizontal: 4,
+		borderRadius: radii.pill,
+		backgroundColor: colors.red,
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	tabBadgeTxt: {
+		fontFamily: font.semibold,
+		fontSize: 10,
+		color: '#fff',
+	},
+	tabDot: {
+		position: 'absolute',
+		top: -2,
+		right: -6,
+		width: 8,
+		height: 8,
+		borderRadius: 4,
+		backgroundColor: colors.red,
+	},
+
+	// "More" overflow sheet
+	sheetBackdrop: {
+		position: 'absolute',
+		top: 0,
+		left: 0,
+		right: 0,
+		bottom: 0,
+		backgroundColor: 'rgba(16,16,25,0.35)',
+	},
+	sheet: {
+		position: 'absolute',
+		left: 0,
+		right: 0,
+		backgroundColor: colors.surface,
+		borderTopLeftRadius: radii.card,
+		borderTopRightRadius: radii.card,
+		borderTopWidth: 1,
+		borderColor: colors.border,
+		paddingHorizontal: 14,
+		paddingTop: 8,
+		paddingBottom: 10,
+		...shadowSoft,
+	},
+	sheetHandle: {
+		alignSelf: 'center',
+		width: 38,
+		height: 4,
+		borderRadius: radii.pill,
+		backgroundColor: colors.border,
+		marginBottom: 8,
+	},
+	sheetRow: {
 		flexDirection: 'row',
 		alignItems: 'center',
-		gap: 7,
-		paddingVertical: 8,
-		paddingHorizontal: 13,
-		borderRadius: radii.pill,
+		gap: 12,
+		paddingVertical: 11,
+		paddingHorizontal: 8,
+		borderRadius: radii.md,
 	},
-	chipInactive: {
+	sheetRowActive: {
 		backgroundColor: colors.chipBg,
 	},
-	chipTxt: {
+	sheetLabel: {
+		flex: 1,
+		fontFamily: font.medium,
+		fontSize: 14,
+		color: colors.text,
+	},
+	sheetLabelActive: {
 		fontFamily: font.semibold,
-		fontSize: 12.5,
-		color: colors.textSub,
+		color: colors.brandPurple,
 	},
-	chipTxtActive: {
-		color: '#fff',
-	},
-	chipBadge: {
-		paddingVertical: 0,
-		paddingHorizontal: 6,
+	sheetBadge: {
+		paddingVertical: 1,
+		paddingHorizontal: 7,
 		borderRadius: radii.pill,
-		backgroundColor: 'rgba(255,255,255,0.3)',
 	},
-	chipBadgeActive: {
-		backgroundColor: 'rgba(255,255,255,0.3)',
-	},
-	chipBadgeTxt: {
+	sheetBadgeTxt: {
 		fontFamily: font.semibold,
 		fontSize: 11,
-		color: colors.textSub,
-	},
-	chipBadgeTxtActive: {
 		color: '#fff',
+	},
+	sheetDivider: {
+		height: 1,
+		backgroundColor: colors.border,
+		marginVertical: 6,
+	},
+	sheetUser: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 12,
+		paddingVertical: 8,
+		paddingHorizontal: 8,
+		borderRadius: radii.md,
+	},
+	sheetUserName: {
+		fontFamily: font.semibold,
+		fontSize: 13,
+		color: colors.text,
+	},
+	sheetUserRole: {
+		fontFamily: font.regular,
+		fontSize: 11,
+		color: colors.textMuted,
 	},
 });

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -167,9 +167,12 @@ function Shell() {
 			<View style={styles.content}>
 				<Slot />
 			</View>
-			<BottomTabBar />
-			{/* Lift the chat button clear of the bottom tab bar so they don't overlap. */}
+			{/* Render the chat button before the tab bar so the "More" sheet and its
+			    backdrop layer above — and dim — the chat button while the sheet is open.
+			    The button is lifted by MOBILE_TABBAR_HEIGHT so the two never overlap when
+			    the sheet is closed. */}
 			<RivusChat key={chatKey} bottomOffset={MOBILE_TABBAR_HEIGHT} />
+			<BottomTabBar />
 		</View>
 	);
 }

--- a/packages/app/src/components/RivusChat.tsx
+++ b/packages/app/src/components/RivusChat.tsx
@@ -36,7 +36,7 @@ interface DisplayMessage extends ChatMessage {
  * agent service (`@rivus/agent`). On first open it greets you — the end-to-end
  * proof that the app can reach the agent and get a reply back.
  */
-export function RivusChat() {
+export function RivusChat({ bottomOffset = 0 }: { bottomOffset?: number }) {
 	const insets = useSafeAreaInsets();
 	const { width, height } = useWindowDimensions();
 
@@ -100,7 +100,7 @@ export function RivusChat() {
 	}
 
 	const panelWidth = Math.min(360, width - 24);
-	const panelHeight = Math.min(460, height - insets.top - insets.bottom - 96);
+	const panelHeight = Math.min(460, height - insets.top - insets.bottom - bottomOffset - 96);
 
 	return (
 		<KeyboardAvoidingView
@@ -109,7 +109,7 @@ export function RivusChat() {
 			// to avoid, so the behavior is iOS-only.
 			behavior={Platform.OS === 'ios' ? 'padding' : undefined}
 			pointerEvents="box-none"
-			style={[styles.layer, { right: 18, bottom: insets.bottom + 18 }]}
+			style={[styles.layer, { right: 18, bottom: insets.bottom + 18 + bottomOffset }]}
 		>
 			{open ? (
 				<View style={[styles.panel, { width: panelWidth, height: panelHeight }]}>

--- a/packages/app/src/components/RivusChat.tsx
+++ b/packages/app/src/components/RivusChat.tsx
@@ -36,9 +36,15 @@ interface DisplayMessage extends ChatMessage {
  * agent service (`@rivus/agent`). On first open it greets you — the end-to-end
  * proof that the app can reach the agent and get a reply back.
  */
+/**
+ * @param bottomOffset Height of bottom chrome the launcher must clear (e.g. the
+ * mobile tab bar). It already includes the safe-area inset, so we reserve the
+ * larger of it and the raw inset rather than summing the two.
+ */
 export function RivusChat({ bottomOffset = 0 }: { bottomOffset?: number }) {
 	const insets = useSafeAreaInsets();
 	const { width, height } = useWindowDimensions();
+	const bottomReserve = Math.max(insets.bottom, bottomOffset);
 
 	const { session } = useAuth();
 	// Web authenticates the agent via the shared session cookie; native forwards
@@ -100,7 +106,7 @@ export function RivusChat({ bottomOffset = 0 }: { bottomOffset?: number }) {
 	}
 
 	const panelWidth = Math.min(360, width - 24);
-	const panelHeight = Math.min(460, height - insets.top - insets.bottom - bottomOffset - 96);
+	const panelHeight = Math.min(460, height - insets.top - bottomReserve - 96);
 
 	return (
 		<KeyboardAvoidingView
@@ -109,7 +115,7 @@ export function RivusChat({ bottomOffset = 0 }: { bottomOffset?: number }) {
 			// to avoid, so the behavior is iOS-only.
 			behavior={Platform.OS === 'ios' ? 'padding' : undefined}
 			pointerEvents="box-none"
-			style={[styles.layer, { right: 18, bottom: insets.bottom + 18 + bottomOffset }]}
+			style={[styles.layer, { right: 18, bottom: bottomReserve + 18 }]}
 		>
 			{open ? (
 				<View style={[styles.panel, { width: panelWidth, height: panelHeight }]}>

--- a/packages/app/src/theme/tokens.ts
+++ b/packages/app/src/theme/tokens.ts
@@ -106,6 +106,11 @@ export const shadowSoft = {
 	elevation: 2,
 } as const;
 
-// Width below which the persistent sidebar collapses to a top nav.
+// Width below which the persistent sidebar collapses to the narrow (mobile)
+// layout with a bottom tab bar.
 export const SIDEBAR_BREAKPOINT = 880;
 export const SIDEBAR_WIDTH = 244;
+
+// Height of the narrow-layout bottom tab bar, excluding the safe-area inset that
+// is padded on below it. Shared so the floating chat button can clear the bar.
+export const MOBILE_TABBAR_HEIGHT = 56;


### PR DESCRIPTION
## Summary

In the narrow (mobile) layout of `@rivus/app`, the dashboard navigation was a **horizontally-scrolling pill strip pinned under the header** (`NavStrip`). It's easy to miss and unlike the bottom tab bar most mobile apps — and our own staff admin console (`AdminBottomNav`) — use.

This moves it to a **fixed bottom tab bar**:

- Primary destinations (Home, Inbox, Schedule, Customers) sit on the bar as tabs, with a **"More"** tab that opens a sheet for the remaining destinations and sign-out — keeping the bar within the ~5-slot mobile convention even though Owners have up to 9 destinations.
- Icon-over-label tabs with a gradient active indicator, mirroring the wide `Sidebar`'s active treatment and using existing design-system tokens (no new colors/sizes).
- The floating Rivus chat button is lifted above the bar so they don't overlap, via a new `bottomOffset` prop on `RivusChat` and a shared `MOBILE_TABBAR_HEIGHT` token.
- Bottom inset (`safe-area`) is respected so the bar clears the home indicator.

The wide (≥880px) sidebar layout is unchanged.

### Files changed
- `packages/app/app/_layout.tsx` — replace `NavStrip` (top) with `BottomTabBar` + `TabButton` + `MoreSheet` (bottom); pass `bottomOffset` to `RivusChat`.
- `packages/app/src/components/RivusChat.tsx` — accept `bottomOffset` so the FAB clears the tab bar.
- `packages/app/src/theme/tokens.ts` — add `MOBILE_TABBAR_HEIGHT`.

---

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
  - This is a presentational layout change. The app's coverage config instruments only `src/api/**` and `src/agent/**`, and the suite has no UI render tests, so the touched files (`app/_layout.tsx`, `src/components/RivusChat.tsx`) are outside coverage scope. Verified via `pnpm lint` (clean), `pnpm --filter @rivus/app type-check` (clean), and `pnpm --filter @rivus/app test` (103 passing).

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature / UX improvement — relocates the mobile navigation to a conventional bottom tab bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0167W5SDS4EMSQ6Tg4cTymKH)_