### PR TITLE
feat(app): open Rivus chat full screen from the mobile top bar

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -144,10 +144,14 @@ function Shell() {
 	const wide = width >= SIDEBAR_BREAKPOINT;
 
 	// Measured height of the bottom tab bar (it has no fixed height, so larger
-	// text settings or a wrapped label can grow it). The chat button and the
-	// "More" sheet anchor to this so they always clear the real bar; the constant
-	// is just the pre-measurement default.
+	// text settings or a wrapped label can grow it). The "More" sheet anchors to
+	// this so it always clears the real bar; the constant is the pre-measure
+	// default.
 	const [tabBarHeight, setTabBarHeight] = useState(MOBILE_TABBAR_HEIGHT + insets.bottom);
+
+	// Narrow layout opens the agent chat full screen from the top bar's chat icon
+	// (there's no floating launcher on mobile), so the Shell owns the open state.
+	const [chatOpen, setChatOpen] = useState(false);
 
 	// Remount the agent chat when the active account changes (a staff "switch
 	// company" swaps the session in place). Its transcript and answers are
@@ -172,7 +176,7 @@ function Shell() {
 
 	return (
 		<View style={styles.rootColumn}>
-			<CompactBar />
+			<CompactBar onOpenChat={() => setChatOpen(true)} />
 			{/* Only staff get the company switcher; non-staff have no company row at all. */}
 			{isStaff ? (
 				<View style={styles.compactCompany}>
@@ -182,11 +186,14 @@ function Shell() {
 			<View style={styles.content}>
 				<Slot />
 			</View>
-			{/* Render the chat button before the tab bar so the "More" sheet and its
-			    backdrop layer above — and dim — the chat button while the sheet is open.
-			    The button is lifted by the measured bar height so the two never overlap
-			    when the sheet is closed. */}
-			<RivusChat key={chatKey} bottomOffset={tabBarHeight} />
+			{/* On mobile the chat opens full screen from the top bar's chat icon rather
+			    than from a floating launcher, so there's nothing to clear the tab bar. */}
+			<RivusChat
+				key={chatKey}
+				variant="fullscreen"
+				open={chatOpen}
+				onClose={() => setChatOpen(false)}
+			/>
 			<BottomTabBar height={tabBarHeight} onHeight={setTabBarHeight} />
 		</View>
 	);
@@ -297,7 +304,7 @@ function TopBar() {
 
 /* ------------------------------ Narrow layout ----------------------------- */
 
-function CompactBar() {
+function CompactBar({ onOpenChat }: { onOpenChat: () => void }) {
 	const insets = useSafeAreaInsets();
 	return (
 		<View style={[styles.compactBar, { paddingTop: insets.top + 12 }]}>
@@ -307,7 +314,21 @@ function CompactBar() {
 					<Dot color={colors.green} size={7} />
 					<Txt style={styles.compactStatusTxt}>Online</Txt>
 				</View>
-				<Pressable style={styles.compactBell}>
+				{/* Chat with Rivus — sits right before the bell and opens the agent chat
+				    full screen (the mobile layout has no floating chat launcher). */}
+				<Pressable
+					style={styles.compactIconBtn}
+					onPress={onOpenChat}
+					accessibilityRole="button"
+					accessibilityLabel="Open Rivus chat"
+				>
+					<Feather name="message-circle" size={18} color="#cfd0dc" />
+				</Pressable>
+				<Pressable
+					style={styles.compactIconBtn}
+					accessibilityRole="button"
+					accessibilityLabel="Notifications"
+				>
 					<Feather name="bell" size={18} color="#cfd0dc" />
 					<View style={styles.bellDot} />
 				</Pressable>
@@ -688,7 +709,7 @@ const styles = StyleSheet.create({
 		fontSize: 12,
 		color: '#cfd0dc',
 	},
-	compactBell: {
+	compactIconBtn: {
 		width: 34,
 		height: 34,
 		alignItems: 'center',

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -321,6 +321,7 @@ function CompactBar({ onOpenChat }: { onOpenChat: () => void }) {
 					onPress={onOpenChat}
 					accessibilityRole="button"
 					accessibilityLabel="Open Rivus chat"
+					hitSlop={{ top: 5, bottom: 5, left: 5, right: 5 }}
 				>
 					<Feather name="message-circle" size={18} color="#cfd0dc" />
 				</Pressable>
@@ -328,6 +329,7 @@ function CompactBar({ onOpenChat }: { onOpenChat: () => void }) {
 					style={styles.compactIconBtn}
 					accessibilityRole="button"
 					accessibilityLabel="Notifications"
+					hitSlop={{ top: 5, bottom: 5, left: 5, right: 5 }}
 				>
 					<Feather name="bell" size={18} color="#cfd0dc" />
 					<View style={styles.bellDot} />

--- a/packages/app/src/components/RivusChat.tsx
+++ b/packages/app/src/components/RivusChat.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
 	ActivityIndicator,
 	KeyboardAvoidingView,
+	Modal,
 	Platform,
 	Pressable,
 	ScrollView,
@@ -31,17 +32,37 @@ interface DisplayMessage extends ChatMessage {
 }
 
 /**
- * A floating "chat with Rivus" launcher pinned to the bottom-right of every
- * signed-in screen. Tapping it opens a small chat panel that talks to the Rivus
- * agent service (`@rivus/agent`). On first open it greets you — the end-to-end
- * proof that the app can reach the agent and get a reply back.
+ * The Rivus agent chat. It talks to the Rivus agent service (`@rivus/agent`);
+ * on first open it greets you — the end-to-end proof that the app can reach the
+ * agent and get a reply back.
+ *
+ * Two presentations share the same conversation logic:
+ *
+ * - `floating` (the wide layout): a launcher pinned to the bottom-right of every
+ *   signed-in screen that opens a small panel above itself. It owns its own open
+ *   state.
+ * - `fullscreen` (the narrow/mobile layout): no launcher of its own — the chat
+ *   icon lives in the top bar, and tapping it opens the conversation full screen.
+ *   The host owns the open state and passes it in via `open` / `onClose`.
+ *
+ * @param bottomOffset Height of bottom chrome the floating launcher must clear
+ * (e.g. the mobile tab bar). It already includes the safe-area inset, so we
+ * reserve the larger of it and the raw inset rather than summing the two.
+ * @param variant Which presentation to render (defaults to `floating`).
+ * @param open Controlled open state — only used (and required) for `fullscreen`.
+ * @param onClose Called when the `fullscreen` chat asks to close.
  */
-/**
- * @param bottomOffset Height of bottom chrome the launcher must clear (e.g. the
- * mobile tab bar). It already includes the safe-area inset, so we reserve the
- * larger of it and the raw inset rather than summing the two.
- */
-export function RivusChat({ bottomOffset = 0 }: { bottomOffset?: number }) {
+export function RivusChat({
+	bottomOffset = 0,
+	variant = 'floating',
+	open: openProp,
+	onClose,
+}: {
+	bottomOffset?: number;
+	variant?: 'floating' | 'fullscreen';
+	open?: boolean;
+	onClose?: () => void;
+}) {
 	const insets = useSafeAreaInsets();
 	const { width, height } = useWindowDimensions();
 	const bottomReserve = Math.max(insets.bottom, bottomOffset);
@@ -52,7 +73,18 @@ export function RivusChat({ bottomOffset = 0 }: { bottomOffset?: number }) {
 	// user and can answer from their company + knowledge base.
 	const token = session?.token ?? '';
 
-	const [open, setOpen] = useState(false);
+	// `floating` owns its open state; `fullscreen` is controlled by the host.
+	const isFullscreen = variant === 'fullscreen';
+	const [internalOpen, setInternalOpen] = useState(false);
+	const open = isFullscreen ? openProp === true : internalOpen;
+	const close = useCallback(() => {
+		if (isFullscreen) {
+			onClose?.();
+		} else {
+			setInternalOpen(false);
+		}
+	}, [isFullscreen, onClose]);
+
 	const [greeted, setGreeted] = useState(false);
 	const [messages, setMessages] = useState<DisplayMessage[]>([]);
 	const [draft, setDraft] = useState('');
@@ -105,6 +137,39 @@ export function RivusChat({ bottomOffset = 0 }: { bottomOffset?: number }) {
 		void send(next);
 	}
 
+	const conversation = (
+		<ChatConversation
+			messages={messages}
+			status={status}
+			draft={draft}
+			onDraft={setDraft}
+			onSubmit={submit}
+			onClose={close}
+			scrollRef={scrollRef}
+		/>
+	);
+
+	// Mobile: open over the whole screen with a clear close affordance in the
+	// header. The chat icon that opens it lives in the top bar (see CompactBar).
+	if (isFullscreen) {
+		return (
+			<Modal
+				visible={open}
+				animationType="slide"
+				onRequestClose={close}
+				presentationStyle="overFullScreen"
+				transparent={false}
+			>
+				<KeyboardAvoidingView
+					behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+					style={[styles.fullscreen, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
+				>
+					{conversation}
+				</KeyboardAvoidingView>
+			</Modal>
+		);
+	}
+
 	const panelWidth = Math.min(360, width - 24);
 	const panelHeight = Math.min(460, height - insets.top - bottomReserve - 96);
 
@@ -119,75 +184,12 @@ export function RivusChat({ bottomOffset = 0 }: { bottomOffset?: number }) {
 		>
 			{open ? (
 				<View style={[styles.panel, { width: panelWidth, height: panelHeight }]}>
-					<View style={styles.header}>
-						<BrandGradient style={styles.headerMark}>
-							<RivusSymbol size={18} />
-						</BrandGradient>
-						<View style={styles.headerText}>
-							<Txt style={styles.headerTitle}>Rivus</Txt>
-							<View style={styles.headerStatus}>
-								<Dot color={colors.green} size={6} />
-								<Txt style={styles.headerStatusTxt}>AI assistant</Txt>
-							</View>
-						</View>
-						<Pressable
-							onPress={() => setOpen(false)}
-							accessibilityRole="button"
-							accessibilityLabel="Close Rivus chat"
-							style={styles.headerClose}
-						>
-							<Feather name="x" size={18} color={colors.textMuted} />
-						</Pressable>
-					</View>
-
-					<ScrollView
-						ref={scrollRef}
-						style={styles.thread}
-						contentContainerStyle={styles.threadContent}
-						onContentSizeChange={() => scrollRef.current?.scrollToEnd({ animated: true })}
-					>
-						{messages.map((message) => (
-							<MessageBubble key={message.id} message={message} />
-						))}
-						{status === 'sending' ? (
-							<View style={[styles.bubble, styles.assistantBubble]}>
-								<ActivityIndicator color={colors.brandPurple} size="small" />
-							</View>
-						) : null}
-						{status === 'error' ? (
-							<Txt style={styles.errorTxt}>
-								Couldn't reach Rivus. Check that the agent is running, then try again.
-							</Txt>
-						) : null}
-					</ScrollView>
-
-					<View style={styles.composer}>
-						<TextInput
-							value={draft}
-							onChangeText={setDraft}
-							onSubmitEditing={submit}
-							placeholder="Message Rivus…"
-							placeholderTextColor={colors.textHint}
-							returnKeyType="send"
-							style={styles.input}
-						/>
-						<Pressable
-							onPress={submit}
-							accessibilityRole="button"
-							accessibilityLabel="Send message"
-							disabled={status === 'sending'}
-							style={({ pressed }) => [styles.sendBtnWrap, pressed && styles.pressed]}
-						>
-							<BrandGradient style={styles.sendBtn}>
-								<Feather name="arrow-up" size={18} color="#fff" />
-							</BrandGradient>
-						</Pressable>
-					</View>
+					{conversation}
 				</View>
 			) : null}
 
 			<Pressable
-				onPress={() => setOpen((value) => !value)}
+				onPress={() => setInternalOpen((value) => !value)}
 				accessibilityRole="button"
 				accessibilityLabel={open ? 'Close Rivus chat' : 'Open Rivus chat'}
 				style={({ pressed }) => [styles.fabWrap, pressed && styles.pressed]}
@@ -201,6 +203,99 @@ export function RivusChat({ bottomOffset = 0 }: { bottomOffset?: number }) {
 				</BrandGradient>
 			</Pressable>
 		</KeyboardAvoidingView>
+	);
+}
+
+/**
+ * The shared chat surface — header, message thread and composer — laid out to
+ * fill its parent. Both the floating panel and the fullscreen modal wrap this so
+ * the conversation looks and behaves identically in either presentation.
+ */
+function ChatConversation({
+	messages,
+	status,
+	draft,
+	onDraft,
+	onSubmit,
+	onClose,
+	scrollRef,
+}: {
+	messages: DisplayMessage[];
+	status: Status;
+	draft: string;
+	onDraft: (value: string) => void;
+	onSubmit: () => void;
+	onClose: () => void;
+	scrollRef: React.RefObject<ScrollView | null>;
+}) {
+	return (
+		<>
+			<View style={styles.header}>
+				<BrandGradient style={styles.headerMark}>
+					<RivusSymbol size={18} />
+				</BrandGradient>
+				<View style={styles.headerText}>
+					<Txt style={styles.headerTitle}>Rivus</Txt>
+					<View style={styles.headerStatus}>
+						<Dot color={colors.green} size={6} />
+						<Txt style={styles.headerStatusTxt}>AI assistant</Txt>
+					</View>
+				</View>
+				<Pressable
+					onPress={onClose}
+					accessibilityRole="button"
+					accessibilityLabel="Close Rivus chat"
+					hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+					style={styles.headerClose}
+				>
+					<Feather name="x" size={18} color={colors.textMuted} />
+				</Pressable>
+			</View>
+
+			<ScrollView
+				ref={scrollRef}
+				style={styles.thread}
+				contentContainerStyle={styles.threadContent}
+				onContentSizeChange={() => scrollRef.current?.scrollToEnd({ animated: true })}
+			>
+				{messages.map((message) => (
+					<MessageBubble key={message.id} message={message} />
+				))}
+				{status === 'sending' ? (
+					<View style={[styles.bubble, styles.assistantBubble]}>
+						<ActivityIndicator color={colors.brandPurple} size="small" />
+					</View>
+				) : null}
+				{status === 'error' ? (
+					<Txt style={styles.errorTxt}>
+						Couldn't reach Rivus. Check that the agent is running, then try again.
+					</Txt>
+				) : null}
+			</ScrollView>
+
+			<View style={styles.composer}>
+				<TextInput
+					value={draft}
+					onChangeText={onDraft}
+					onSubmitEditing={onSubmit}
+					placeholder="Message Rivus…"
+					placeholderTextColor={colors.textHint}
+					returnKeyType="send"
+					style={styles.input}
+				/>
+				<Pressable
+					onPress={onSubmit}
+					accessibilityRole="button"
+					accessibilityLabel="Send message"
+					disabled={status === 'sending'}
+					style={({ pressed }) => [styles.sendBtnWrap, pressed && styles.pressed]}
+				>
+					<BrandGradient style={styles.sendBtn}>
+						<Feather name="arrow-up" size={18} color="#fff" />
+					</BrandGradient>
+				</Pressable>
+			</View>
+		</>
 	);
 }
 
@@ -252,6 +347,12 @@ const styles = StyleSheet.create({
 		borderColor: colors.border,
 		overflow: 'hidden',
 		...shadowSoft,
+	},
+	// Fullscreen (mobile) container: fills the screen and pads the safe-area insets
+	// applied by the wrapping KeyboardAvoidingView.
+	fullscreen: {
+		flex: 1,
+		backgroundColor: colors.surface,
 	},
 	header: {
 		flexDirection: 'row',

--- a/packages/app/src/components/RivusChat.tsx
+++ b/packages/app/src/components/RivusChat.tsx
@@ -162,9 +162,20 @@ export function RivusChat({
 			>
 				<KeyboardAvoidingView
 					behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-					style={[styles.fullscreen, { paddingTop: insets.top, paddingBottom: insets.bottom }]}
+					style={styles.fullscreen}
 				>
-					{conversation}
+					{/* Hold the safe-area insets on an inner View: with behavior="padding"
+					    KeyboardAvoidingView overwrites its own paddingBottom with the
+					    keyboard height (0 when closed), which would otherwise wipe out the
+					    bottom inset and let the composer collide with the home indicator. */}
+					<View
+						style={[
+							styles.fullscreenInner,
+							{ paddingTop: insets.top, paddingBottom: insets.bottom },
+						]}
+					>
+						{conversation}
+					</View>
 				</KeyboardAvoidingView>
 			</Modal>
 		);
@@ -353,6 +364,9 @@ const styles = StyleSheet.create({
 	fullscreen: {
 		flex: 1,
 		backgroundColor: colors.surface,
+	},
+	fullscreenInner: {
+		flex: 1,
 	},
 	header: {
 		flexDirection: 'row',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — mobile navigation/UX change for the agent chat.

## What changed

On the narrow (mobile) layout, the floating bottom-right chat launcher is replaced by a **chat icon in the top bar**, placed **right before the bell icon**. Tapping it opens the Rivus agent conversation **full screen**, with a clear close (**X**) affordance in the header. The wide (desktop) layout is unchanged — it keeps the floating panel launcher.

### Details

- **`RivusChat`** now supports two presentations that share the same conversation logic (greeting, send, message thread, composer):
  - `floating` (default, wide layout): unchanged FAB launcher + small panel, owns its own open state.
  - `fullscreen` (mobile): no launcher of its own; rendered in a slide-up `Modal` that fills the screen and respects safe-area insets. Its open state is **controlled by the host** via `open` / `onClose`.
  - The shared header/thread/composer were extracted into a single `ChatConversation` component so both presentations look and behave identically.
- **`_layout.tsx` (`Shell`)** now owns the mobile chat-open state and:
  - passes `onOpenChat` to `CompactBar`, which renders the new `message-circle` icon button just before the bell (with an `Open Rivus chat` accessibility label).
  - renders `<RivusChat variant="fullscreen" open={chatOpen} onClose={…} />` instead of the bottom-anchored floating launcher.
  - the shared `compactBell` style was renamed to `compactIconBtn` since both top-bar icons now use it.

## How to verify

1. Run the app and narrow the window below the `880px` sidebar breakpoint (or use a mobile device/emulator).
2. Confirm the floating bottom-right chat button is gone and a chat icon appears in the top bar, immediately before the bell.
3. Tap it — the chat opens full screen and greets you. Tap the **X** in the header to exit.
4. Widen past `880px` and confirm the desktop floating chat launcher still works as before.

## Notes

- `pnpm lint`, `pnpm --filter @rivus/app type-check`, and `pnpm --filter @rivus/app test` all pass. UI follows the existing design-system tokens (no new literals introduced); the chat icon reuses the same Feather `message-circle` mark already used by the floating launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016wEcZtPwNrkrAGmUUx8rVf)_