### PR TITLE
fix(app): stack schedule header on mobile so controls don't overflow

### DIFF
--- a/packages/app/app/schedule.tsx
+++ b/packages/app/app/schedule.tsx
@@ -119,6 +119,10 @@ export default function ScheduleScreen() {
 	const { session, client } = useAuth();
 	const { width } = useWindowDimensions();
 	const sidebar = width >= SIDEBAR_BREAKPOINT ? SIDEBAR_WIDTH : 0;
+	// On the mobile layout the header's controls can't fit beside the title on
+	// one row, so stack it into a column and let each group take the full width
+	// (and wrap its own children) instead of overflowing off the right edge.
+	const narrow = width < SIDEBAR_BREAKPOINT;
 
 	const [view, setView] = useState<ScheduleView>('week');
 	const [anchor, setAnchor] = useState<Date>(() => startOfDay(new Date()));
@@ -438,7 +442,7 @@ export default function ScheduleScreen() {
 
 	return (
 		<View style={styles.screen}>
-			<View style={styles.header}>
+			<View style={[styles.header, narrow && styles.headerNarrow]}>
 				<View style={styles.headerLeft}>
 					<Txt style={styles.title}>Schedule</Txt>
 					{view !== 'list' ? (
@@ -959,6 +963,9 @@ const styles = StyleSheet.create({
 		borderBottomColor: colors.border,
 		backgroundColor: colors.surface,
 	},
+	// Mobile: stack the title and controls; `stretch` gives each group a definite
+	// full width so `headerRight` wraps its children instead of overflowing.
+	headerNarrow: { flexDirection: 'column', alignItems: 'stretch', gap: 14 },
 	headerLeft: { flexDirection: 'row', alignItems: 'center', gap: 16, flexWrap: 'wrap' },
 	title: { fontFamily: font.semibold, fontSize: 20 },
 	dateNav: { flexDirection: 'row', alignItems: 'center', gap: 6 },


### PR DESCRIPTION
On the mobile Schedule view, the header row didn't fit correctly: the "New job" button was clipped off the right edge of the screen.

**Root cause**

The header laid out two groups — the title group (title + date nav) and the controls group (jobs-booked pill, Day/Week/List toggle, "New job" button) — as two wrapping flex items in a `space-between` row. On narrow screens the controls group wrapped onto its own line but had no definite width, so its children never wrapped internally. The group sized to its single-line max-content width and overflowed off the right edge, clipping the "New job" button.

(The week grid columns extending past the right edge are intentional — that grid is horizontally scrollable.)

**Fix**

Below the sidebar breakpoint (the existing mobile-layout boundary used elsewhere in this screen), stack the header into a column with `alignItems: 'stretch'`. Each group now gets a full-width line, so the controls wrap cleanly instead of being cut off. The wide (≥ 880px) layout is unchanged.

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — This is a presentation-only, width-responsive style change (RN layout), not covered by the package's hermetic Node unit tests. `pnpm lint`, `pnpm type-check`, and `@rivus/app` tests (134 passing) all pass.

**What kind of change does this PR introduce?**

Bug fix — responsive layout fix for the mobile Schedule header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0159kuxDTLeLCfXxDVyoxZFu)_