### PR TITLE
fix(app): keep chat send button reachable on mobile web

### DIFF
--- a/packages/app/src/components/RivusChat.tsx
+++ b/packages/app/src/components/RivusChat.tsx
@@ -292,7 +292,10 @@ function ChatConversation({
 					placeholder="Message Rivus…"
 					placeholderTextColor={colors.textHint}
 					returnKeyType="send"
-					style={styles.input}
+					// Mobile Safari zooms the page when a focused input's font is under
+					// 16px, which shoves the send button off-screen. Hold the input at
+					// 16px on web to suppress that; native keeps the designed 14px.
+					style={[styles.input, IS_WEB && styles.inputWeb]}
 				/>
 				<Pressable
 					onPress={onSubmit}
@@ -470,6 +473,10 @@ const styles = StyleSheet.create({
 		borderRadius: radii.md,
 		paddingVertical: 10,
 		paddingHorizontal: 12,
+	},
+	// 16px is the threshold below which mobile Safari auto-zooms a focused input.
+	inputWeb: {
+		fontSize: 16,
 	},
 	sendBtnWrap: {
 		borderRadius: radii.md,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
  - This is a CSS/layout fix with no testable logic branch; the repo has no component-rendering test harness (existing app tests are logic-only). Verified manually against the reported mobile-web scenario.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

On mobile web (iOS Safari, `dev-app.rivus.ai`), opening the Rivus chat and tapping the message box left no way to send: the send button was pushed off the right edge of the screen.

**Root cause:** Mobile Safari auto-zooms the page whenever a focused `<input>` has a font size below 16px. The chat composer input was rendered at `fontSize: 14`, so focusing it zoomed the page in — shifting the composer right (sending the send button off-screen) and the header off the top, matching the reported screenshot.

**Fix:** Render the composer input at 16px on web to suppress the auto-zoom. Native keeps the designed 14px, where this behaviour doesn't occur. The change is scoped to the existing `IS_WEB` branch in `RivusChat.tsx`.

`pnpm lint`, `pnpm type-check`, and `pnpm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgVULGLHrwZuY6PLTje7uS)_