### PR TITLE
feat(app): replace Schedule "New job" button with compact + on title row

### DIFF
--- a/packages/app/app/schedule.tsx
+++ b/packages/app/app/schedule.tsx
@@ -470,6 +470,15 @@ export default function ScheduleScreen() {
 							</Pressable>
 						</View>
 					) : null}
+					<Pressable
+						style={styles.addBtn}
+						onPress={() => openCreate(localDateKey(view === 'list' ? today : anchor), 540)}
+						accessibilityRole="button"
+						accessibilityLabel="New job"
+						hitSlop={NAV_HIT_SLOP}
+					>
+						<GradientMark size={36} radius={radii.md} icon="plus" iconSize={20} />
+					</Pressable>
 					<Txt style={styles.rangeLabel}>{view === 'list' ? 'Next 30 days' : rangeLabel}</Txt>
 				</View>
 				<View style={styles.headerRight}>
@@ -490,11 +499,6 @@ export default function ScheduleScreen() {
 							);
 						})}
 					</View>
-					<GradientButton
-						label="New job"
-						icon="plus"
-						onPress={() => openCreate(localDateKey(view === 'list' ? today : anchor), 540)}
-					/>
 				</View>
 			</View>
 
@@ -968,6 +972,9 @@ const styles = StyleSheet.create({
 	headerNarrow: { flexDirection: 'column', alignItems: 'stretch', gap: 14 },
 	headerLeft: { flexDirection: 'row', alignItems: 'center', gap: 16, flexWrap: 'wrap' },
 	title: { fontFamily: font.semibold, fontSize: 20 },
+	// Push the create button to the far right of the title row; the range label
+	// then wraps onto its own line beneath it on the mobile layout.
+	addBtn: { marginLeft: 'auto', borderRadius: radii.md },
 	dateNav: { flexDirection: 'row', alignItems: 'center', gap: 6 },
 	navBtn: {
 		width: 32,

--- a/packages/app/app/schedule.tsx
+++ b/packages/app/app/schedule.tsx
@@ -444,41 +444,43 @@ export default function ScheduleScreen() {
 		<View style={styles.screen}>
 			<View style={[styles.header, narrow && styles.headerNarrow]}>
 				<View style={styles.headerLeft}>
-					<Txt style={styles.title}>Schedule</Txt>
-					{view !== 'list' ? (
-						<View style={styles.dateNav}>
-							<Pressable
-								style={styles.navBtn}
-								onPress={() => setAnchor((current) => addDays(current, -navStep))}
-								accessibilityRole="button"
-								accessibilityLabel="Previous"
-								hitSlop={NAV_HIT_SLOP}
-							>
-								<Icon name="chevron-left" size={16} color={colors.textSub} />
-							</Pressable>
-							<Pressable style={styles.todayBtn} onPress={() => setAnchor(today)}>
-								<Txt style={styles.todayBtnTxt}>Today</Txt>
-							</Pressable>
-							<Pressable
-								style={styles.navBtn}
-								onPress={() => setAnchor((current) => addDays(current, navStep))}
-								accessibilityRole="button"
-								accessibilityLabel="Next"
-								hitSlop={NAV_HIT_SLOP}
-							>
-								<Icon name="chevron-right" size={16} color={colors.textSub} />
-							</Pressable>
-						</View>
-					) : null}
-					<Pressable
-						style={styles.addBtn}
-						onPress={() => openCreate(localDateKey(view === 'list' ? today : anchor), 540)}
-						accessibilityRole="button"
-						accessibilityLabel="New job"
-						hitSlop={NAV_HIT_SLOP}
-					>
-						<GradientMark size={36} radius={radii.md} icon="plus" iconSize={20} />
-					</Pressable>
+					<View style={styles.titleRow}>
+						<Txt style={styles.title}>Schedule</Txt>
+						{view !== 'list' ? (
+							<View style={styles.dateNav}>
+								<Pressable
+									style={styles.navBtn}
+									onPress={() => setAnchor((current) => addDays(current, -navStep))}
+									accessibilityRole="button"
+									accessibilityLabel="Previous"
+									hitSlop={NAV_HIT_SLOP}
+								>
+									<Icon name="chevron-left" size={16} color={colors.textSub} />
+								</Pressable>
+								<Pressable style={styles.todayBtn} onPress={() => setAnchor(today)}>
+									<Txt style={styles.todayBtnTxt}>Today</Txt>
+								</Pressable>
+								<Pressable
+									style={styles.navBtn}
+									onPress={() => setAnchor((current) => addDays(current, navStep))}
+									accessibilityRole="button"
+									accessibilityLabel="Next"
+									hitSlop={NAV_HIT_SLOP}
+								>
+									<Icon name="chevron-right" size={16} color={colors.textSub} />
+								</Pressable>
+							</View>
+						) : null}
+						<Pressable
+							style={styles.addBtn}
+							onPress={() => openCreate(localDateKey(view === 'list' ? today : anchor), 540)}
+							accessibilityRole="button"
+							accessibilityLabel="New job"
+							hitSlop={NAV_HIT_SLOP}
+						>
+							<GradientMark size={36} radius={radii.md} icon="plus" iconSize={20} />
+						</Pressable>
+					</View>
 					<Txt style={styles.rangeLabel}>{view === 'list' ? 'Next 30 days' : rangeLabel}</Txt>
 				</View>
 				<View style={styles.headerRight}>
@@ -970,10 +972,13 @@ const styles = StyleSheet.create({
 	// Mobile: stack the title and controls; `stretch` gives each group a definite
 	// full width so `headerRight` wraps its children instead of overflowing.
 	headerNarrow: { flexDirection: 'column', alignItems: 'stretch', gap: 14 },
-	headerLeft: { flexDirection: 'row', alignItems: 'center', gap: 16, flexWrap: 'wrap' },
+	headerLeft: { gap: 8 },
+	// Title, date nav and the create button share one row; the range label sits on
+	// its own line beneath. On mobile the row stretches full width so the button
+	// lands at the far right of the title/nav row.
+	titleRow: { flexDirection: 'row', alignItems: 'center', gap: 16, flexWrap: 'wrap' },
 	title: { fontFamily: font.semibold, fontSize: 20 },
-	// Push the create button to the far right of the title row; the range label
-	// then wraps onto its own line beneath it on the mobile layout.
+	// Push the create button to the far right of the title row.
 	addBtn: { marginLeft: 'auto', borderRadius: radii.md },
 	dateNav: { flexDirection: 'row', alignItems: 'center', gap: 6 },
 	navBtn: {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

This is a presentational layout change to the Schedule header (no logic change), so no new tests were added. The existing app suite (134 tests) and `lint` / `type-check` all pass.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature / UI tweak.

Moves job creation out of the full-width **"New job"** button (previously below the view toggle) and onto the same row as the **Schedule** title and the date navigation, as a compact gradient **+** icon button aligned to the far right.

**Changes**
- Removed the `GradientButton` labelled "New job" from the header's right-hand control group.
- Added a right-aligned gradient `+` icon button (reusing `GradientMark` with `icon="plus"`) onto the title row, with `accessibilityLabel="New job"` and an expanded touch target (`hitSlop`).
- `marginLeft: 'auto'` pushes the button to the far right of the title row; the range label (e.g. "Jun 22 – 28") wraps onto its own line beneath it on the mobile layout.
- The button still opens the create-job form for the current view/anchor date, exactly as the old button did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfXMcYd9XzGR8nx4VMXW9m)_