### PR TITLE
feat(agent): understand follow-ups using chat context

### DIFF
--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -260,6 +260,40 @@ describe('respond — knowledge base answering', () => {
 	});
 });
 
+describe('respond — conversation context', () => {
+	const assistant = (content: string): ChatMessage => ({ role: 'assistant', content });
+
+	it('understands a bare follow-up from the prior knowledge-base turn', async () => {
+		// The screenshot case: after looking at the FAQs, "What should I add?" names no
+		// subject, but the conversation context routes it to an FAQ create — so the agent
+		// helps add one instead of brushing the question off. (faq_create with no parts
+		// replies straight away, so no API call is needed.)
+		const reply = await respond({
+			env: envWith(),
+			request: authedRequest(),
+			messages: [
+				user("what's my website?"),
+				assistant('Your website is https://acme.example.'),
+				user('how many faqs do we have?'),
+				assistant('Your knowledge base has 3 FAQs: …'),
+				user('What should I add?'),
+			],
+		});
+		expect(reply).toMatch(/what question should the FAQ answer/i);
+		expect(reply).not.toMatch(/not sure how to help/i);
+	});
+
+	it('still brushes off a subjectless follow-up with no topic to lean on', async () => {
+		const reply = await respond({
+			env: envWith(),
+			request: authedRequest(),
+			messages: [user('hello'), assistant(GREETING), user('what should I add?')],
+			fetchImpl: router([{ when: onAnswerFaq, body: noAnswer }]),
+		});
+		expect(reply).toMatch(/not sure how to help/i);
+	});
+});
+
 describe('respond — auth gating', () => {
 	it('requires sign-in for protected asks', async () => {
 		const reply = await ask('what is our website?');

--- a/packages/agent/src/assistant.ts
+++ b/packages/agent/src/assistant.ts
@@ -2,7 +2,7 @@ import { createFaqSchema, type Faq, updateFaqSchema } from '@rivus/core';
 import { AgentApiError, createRivusApiClient, type FetchLike, type RivusApiClient } from './api';
 import { authenticate } from './auth';
 import { GREETING, lastUserMessage } from './conversation';
-import { type CompanyField, type Intent, parseIntent } from './intent';
+import { type CompanyField, type Intent, resolveIntent } from './intent';
 import type { ChatMessage, Env, SessionClaims } from './types';
 
 /**
@@ -57,7 +57,9 @@ const FIELD_LABEL: Record<CompanyField, string> = {
 export async function respond(deps: RespondDeps): Promise<string> {
 	const { env, request, messages, fetchImpl } = deps;
 	const question = lastUserMessage(messages) ?? '';
-	const intent = parseIntent(question);
+	// Read the latest turn in the context of the conversation, so a bare follow-up
+	// ("what should I add?") is understood instead of brushed off.
+	const intent = resolveIntent(messages);
 	const session = await authenticate(request, env.JWT_SECRET);
 	const claims = session?.claims ?? null;
 

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { parseIntent } from './intent';
+import { parseIntent, resolveIntent } from './intent';
+import type { ChatMessage } from './types';
+
+const user = (content: string): ChatMessage => ({ role: 'user', content });
+const assistant = (content: string): ChatMessage => ({ role: 'assistant', content });
 
 describe('parseIntent — conversational', () => {
 	it('treats an empty message as a greeting', () => {
@@ -286,5 +290,84 @@ describe('parseIntent — natural FAQ create', () => {
 			question: 'Hours',
 			answer: 'we open at 9',
 		});
+	});
+});
+
+describe('parseIntent — conversation context', () => {
+	it('reads a subjectless FAQ action as an FAQ ask when the topic is faq', () => {
+		// "what should I add?" names no subject, but with the conversation on the
+		// knowledge base the "add" verb routes it to a create.
+		expect(parseIntent('What should I add?', { topic: 'faq' })).toEqual({
+			kind: 'faq_create',
+			question: null,
+			answer: null,
+		});
+		expect(parseIntent('can you list them?', { topic: 'faq' })).toEqual({ kind: 'faq_list' });
+		expect(parseIntent('anything about refunds?', { topic: 'faq' })).toEqual({
+			kind: 'faq_search',
+			query: 'refunds',
+		});
+	});
+
+	it('does not attach a bare pleasantry to an active FAQ topic', () => {
+		// No FAQ action, so context must not turn "thanks" into a list dump.
+		expect(parseIntent('thanks!', { topic: 'faq' })).toEqual({ kind: 'unknown' });
+	});
+
+	it('lets a self-named ask win over the context', () => {
+		// The message names a company field, so faq context does not hijack it.
+		expect(parseIntent("what's our website?", { topic: 'faq' })).toEqual({
+			kind: 'company_info',
+			fields: ['website'],
+		});
+	});
+
+	it('ignores context it does not act on (company is tracked, not routed)', () => {
+		expect(parseIntent('what should I add?', { topic: 'company' })).toEqual({ kind: 'unknown' });
+	});
+});
+
+describe('resolveIntent — multi-turn', () => {
+	it('answers a bare follow-up using the prior FAQ turn', () => {
+		const conversation = [
+			user("what's my website?"),
+			assistant('Your website is https://example.com.'),
+			user('how many faqs do we have?'),
+			assistant('Your knowledge base has 3 FAQs: …'),
+			user('What should I add?'),
+		];
+		expect(resolveIntent(conversation)).toEqual({
+			kind: 'faq_create',
+			question: null,
+			answer: null,
+		});
+	});
+
+	it('leaves a turn that stands on its own untouched', () => {
+		const conversation = [
+			user('how many faqs do we have?'),
+			assistant('Your knowledge base has 3 FAQs: …'),
+			user("what's our phone number?"),
+		];
+		expect(resolveIntent(conversation)).toEqual({ kind: 'company_info', fields: ['phone'] });
+	});
+
+	it('falls back to unknown when no earlier turn set a topic', () => {
+		const conversation = [user('hello'), assistant('Hi!'), user('what should I add?')];
+		expect(resolveIntent(conversation)).toEqual({ kind: 'unknown' });
+	});
+
+	it('uses the most recent topic when the conversation moved on', () => {
+		// The chat drifted from FAQs to the company record; a bare "add" follow-up
+		// should not be pulled back to the older FAQ topic.
+		const conversation = [
+			user('list our faqs'),
+			assistant('…'),
+			user('what about our address?'),
+			assistant('1 Main St.'),
+			user('what should I add?'),
+		];
+		// Most recent topic is company, which we do not route, so it stays unknown.
+		expect(resolveIntent(conversation)).toEqual({ kind: 'unknown' });
 	});
 });

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -322,6 +322,18 @@ describe('parseIntent — conversation context', () => {
 		});
 	});
 
+	it('does not let faq context hijack a company ask that carries a verb or preposition', () => {
+		// "about"/"show" would satisfy hasFaqAction, but a named company subject wins.
+		expect(parseIntent('tell me about our website', { topic: 'faq' })).toEqual({
+			kind: 'company_info',
+			fields: ['website'],
+		});
+		expect(parseIntent('show my company info', { topic: 'faq' })).toEqual({
+			kind: 'company_info',
+			fields: [],
+		});
+	});
+
 	it('ignores context it does not act on (company is tracked, not routed)', () => {
 		expect(parseIntent('what should I add?', { topic: 'company' })).toEqual({ kind: 'unknown' });
 	});
@@ -368,6 +380,19 @@ describe('resolveIntent — multi-turn', () => {
 			user('what should I add?'),
 		];
 		// Most recent topic is company, which we do not route, so it stays unknown.
+		expect(resolveIntent(conversation)).toEqual({ kind: 'unknown' });
+	});
+
+	it('does not reach back past the lookback window for a topic', () => {
+		// The only FAQ turn is far in the past; a string of subjectless turns sits
+		// between it and the follow-up, so the capped scan never reaches it.
+		const filler = Array.from({ length: 7 }, () => [user('hmm'), assistant('…')]).flat();
+		const conversation = [
+			user('how many faqs do we have?'),
+			assistant('Your knowledge base has 3 FAQs: …'),
+			...filler,
+			user('what should I add?'),
+		];
 		expect(resolveIntent(conversation)).toEqual({ kind: 'unknown' });
 	});
 });

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -269,9 +269,20 @@ export function parseIntent(raw: string, context: IntentContext = {}): Intent {
 		return { kind: 'greeting' };
 	}
 
-	// Enter the knowledge-base branch when the message names it outright, or when
-	// the conversation is already on it and this turn carries an FAQ action.
-	const faqByContext = context.topic === 'faq' && hasFaqAction(lower);
+	// Company signals are read up front so they can both gate the inferred FAQ
+	// context below and answer the company branch later (computed once).
+	const companyFields = COMPANY_FIELD_PATTERNS.filter(([, pattern]) => pattern.test(lower)).map(
+		([field]) => field,
+	);
+	const companyGeneric = COMPANY_GENERIC.test(lower);
+
+	// Enter the knowledge-base branch when the message names it outright, or when the
+	// conversation is already on it and this turn carries an FAQ action. A message
+	// that names a company subject of its own (a field, or a generic "my company")
+	// always wins over an inferred FAQ context, so "tell me about our website" stays
+	// company info even mid-FAQ-conversation.
+	const faqByContext =
+		context.topic === 'faq' && hasFaqAction(lower) && companyFields.length === 0 && !companyGeneric;
 	if (FAQ_CONTEXT.test(lower) || faqByContext) {
 		if (UPDATE_VERB.test(lower)) {
 			return { kind: 'faq_update', ...parseFaqUpdate(text) };
@@ -291,13 +302,10 @@ export function parseIntent(raw: string, context: IntentContext = {}): Intent {
 		return { kind: 'faq_list' };
 	}
 
-	const fields = COMPANY_FIELD_PATTERNS.filter(([, pattern]) => pattern.test(lower)).map(
-		([field]) => field,
-	);
-	if (fields.length > 0) {
-		return { kind: 'company_info', fields };
+	if (companyFields.length > 0) {
+		return { kind: 'company_info', fields: companyFields };
 	}
-	if (COMPANY_GENERIC.test(lower)) {
+	if (companyGeneric) {
 		// Generic ask → return the whole record.
 		return { kind: 'company_info', fields: [] };
 	}
@@ -321,13 +329,24 @@ function topicOf(intent: Intent): ConversationTopic | null {
 }
 
 /**
+ * How many recent user turns a subjectless follow-up looks back over for its
+ * topic. A short window keeps the inference relevant (a topic from far earlier
+ * shouldn't bind "now") and bounds the work done on every turn — re-parsing an
+ * unbounded history would risk the Workers CPU limit on a long conversation.
+ */
+const CONTEXT_LOOKBACK_TURNS = 6;
+
+/**
  * The subject the conversation is already on, read from the most recent *earlier*
  * user turn that established one. The latest turn is skipped — it's the one we
- * couldn't read on its own and are trying to give context to.
+ * couldn't read on its own and are trying to give context to — and the scan is
+ * capped at the last {@link CONTEXT_LOOKBACK_TURNS} turns.
  */
 function recentTopic(messages: ChatMessage[]): ConversationTopic | null {
 	const userTurns = messages.filter((message) => message.role === 'user');
-	for (let i = userTurns.length - 2; i >= 0; i--) {
+	const start = userTurns.length - 2;
+	const end = Math.max(0, userTurns.length - 1 - CONTEXT_LOOKBACK_TURNS);
+	for (let i = start; i >= end; i--) {
 		const turn = userTurns[i];
 		if (!turn) {
 			continue;

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -8,7 +8,15 @@
  * routing beats an opaque classifier. Swapping in an LLM later means replacing
  * only this function — the orchestration in `assistant.ts` consumes the same
  * `Intent` shape.
+ *
+ * A single message is read on its own, but {@link resolveIntent} layers the
+ * conversation on top: a follow-up that names no subject ("what should I add?")
+ * inherits the topic the chat is already on, so it's understood instead of being
+ * brushed off.
  */
+
+import { lastUserMessage } from './conversation';
+import type { ChatMessage } from './types';
 
 /** A field of the company/account record the user can ask about. */
 export type CompanyField =
@@ -34,6 +42,19 @@ export type Intent =
 	/** Add an FAQ; `question`/`answer` are null when the user didn't supply them. */
 	| { kind: 'faq_create'; question: string | null; answer: string | null }
 	| { kind: 'unknown' };
+
+/** The subject a conversation is on, carried forward to resolve bare follow-ups. */
+export type ConversationTopic = 'faq' | 'company';
+
+/**
+ * What earlier turns established, so a message that names no subject of its own
+ * can still be understood. Only `'faq'` currently changes parsing — it lets a
+ * follow-up like "what should I add?" be read as a knowledge-base ask; `'company'`
+ * is tracked for symmetry and future use.
+ */
+export interface IntentContext {
+	topic?: ConversationTopic;
+}
 
 /** Keywords that put a message in "knowledge base" context. */
 const FAQ_CONTEXT = /\b(faqs?|knowledge[ -]?base|knowledge)\b/;
@@ -207,11 +228,31 @@ function parseFaqCreate(text: string): { question: string | null; answer: string
 }
 
 /**
+ * True when a message carries a knowledge-base *action* (add/update/search/list,
+ * or an "about …" subject) — as opposed to a bare "thanks". Used to decide whether
+ * an otherwise-subjectless message should attach to an active FAQ conversation, so
+ * a pleasantry doesn't get mistaken for "show me the FAQs".
+ */
+function hasFaqAction(lower: string): boolean {
+	return (
+		UPDATE_VERB.test(lower) ||
+		CREATE_VERB.test(lower) ||
+		SEARCH_VERB.test(lower) ||
+		LIST_VERB.test(lower) ||
+		afterPreposition(lower) !== null
+	);
+}
+
+/**
  * Classify a single user message. Precedence matters: knowledge-base asks are
  * matched before company facts (so "search the FAQ about our hours" routes to
  * search, not the company record), and the most specific verbs win within each.
+ *
+ * `context` lets the caller say what the conversation is already about. When it's
+ * `'faq'`, a message that carries an FAQ action but doesn't name the knowledge base
+ * ("what should I add?") is still routed there — see {@link resolveIntent}.
  */
-export function parseIntent(raw: string): Intent {
+export function parseIntent(raw: string, context: IntentContext = {}): Intent {
 	const text = raw.trim();
 	const lower = text.toLowerCase();
 
@@ -228,7 +269,10 @@ export function parseIntent(raw: string): Intent {
 		return { kind: 'greeting' };
 	}
 
-	if (FAQ_CONTEXT.test(lower)) {
+	// Enter the knowledge-base branch when the message names it outright, or when
+	// the conversation is already on it and this turn carries an FAQ action.
+	const faqByContext = context.topic === 'faq' && hasFaqAction(lower);
+	if (FAQ_CONTEXT.test(lower) || faqByContext) {
 		if (UPDATE_VERB.test(lower)) {
 			return { kind: 'faq_update', ...parseFaqUpdate(text) };
 		}
@@ -259,4 +303,61 @@ export function parseIntent(raw: string): Intent {
 	}
 
 	return { kind: 'unknown' };
+}
+
+/** The conversation topic an intent puts us on, or `null` if it sets none. */
+function topicOf(intent: Intent): ConversationTopic | null {
+	switch (intent.kind) {
+		case 'faq_list':
+		case 'faq_search':
+		case 'faq_update':
+		case 'faq_create':
+			return 'faq';
+		case 'company_info':
+			return 'company';
+		default:
+			return null;
+	}
+}
+
+/**
+ * The subject the conversation is already on, read from the most recent *earlier*
+ * user turn that established one. The latest turn is skipped — it's the one we
+ * couldn't read on its own and are trying to give context to.
+ */
+function recentTopic(messages: ChatMessage[]): ConversationTopic | null {
+	const userTurns = messages.filter((message) => message.role === 'user');
+	for (let i = userTurns.length - 2; i >= 0; i--) {
+		const turn = userTurns[i];
+		if (!turn) {
+			continue;
+		}
+		const topic = topicOf(parseIntent(turn.content));
+		if (topic) {
+			return topic;
+		}
+	}
+	return null;
+}
+
+/**
+ * Understand the latest user turn *in the context of the conversation*. Most
+ * turns name their own subject and are read on their own. But a natural follow-up
+ * — "what should I add?" right after looking at the FAQs — names nothing, so on its
+ * own it's `unknown` and the user gets a generic brush-off. Here we notice the
+ * conversation was already about the knowledge base and re-read the turn with that
+ * context, so the follow-up lands where the user meant it.
+ *
+ * This is the single seam the agent uses, so making understanding conversational
+ * (or model-backed) later means changing only this layer.
+ */
+export function resolveIntent(messages: ChatMessage[]): Intent {
+	const latest = lastUserMessage(messages) ?? '';
+	const direct = parseIntent(latest);
+	// A turn that already stands on its own needs no help from earlier ones.
+	if (direct.kind !== 'unknown') {
+		return direct;
+	}
+	const topic = recentTopic(messages);
+	return topic ? parseIntent(latest, { topic }) : direct;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix / feature — the agent now understands conversational follow-ups.

### The problem

The agent didn't understand chat context. In the reported case the user asked "How many faqs do we have?", got a list of their 3 FAQs, then asked a follow-up — **"What should I add?"** — and got a generic brush-off ("I'm not sure how to help with that yet…").

The cause: the understanding layer (`intent.ts`) read only the *single latest message* in isolation. `respond()` called `parseIntent(lastUserMessage(messages))`, so even though the full transcript was received it was never consulted. A follow-up that names no subject of its own parsed as `unknown`.

### The fix

A new `resolveIntent(messages)` seam reads the latest turn **in the context of the conversation**:

- `parseIntent` gains an optional `context` argument. When the conversation is already on the knowledge base (`topic: 'faq'`) and the latest turn carries an FAQ *action* — `add`, `list`, `search`, or an "about …" subject — it routes there. So "What should I add?" becomes an FAQ create and the agent helps add one.
- A bare pleasantry ("thanks") carries no action, so it is **not** pulled into the FAQ topic and won't dump the list.
- A self-named ask still wins over context (e.g. "what's our website?" stays company info), and context only kicks in when a turn is otherwise `unknown` — so routing stays predictable.
- `resolveIntent` reads the topic from the most recent earlier turn that set one, so a conversation that has moved on isn't pulled back to an older topic.

This keeps understanding in the single, pure, unit-tested layer the codebase already routes through, so making it model-backed later still means changing only that one place.

### Tests

Added 10 tests (`parseIntent` with context, `resolveIntent` multi-turn, and an end-to-end `respond` test that replays the screenshot's conversation). `pnpm lint && pnpm type-check && pnpm test` all pass (150 agent tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKqkpJKFzJRQvYteZh4KT3)_