### PR TITLE
feat(app): greet dashboard user by their real name

### DIFF
--- a/packages/app/app/index.tsx
+++ b/packages/app/app/index.tsx
@@ -150,6 +150,8 @@ export default function HomeScreen() {
 	}, [jobs, members, customers]);
 
 	const todayLabel = useMemo(() => formatDayLabel(new Date()), []);
+	// Greet by first name, falling back to a plain greeting before the session loads.
+	const firstName = useMemo(() => session?.user.name?.trim().split(/\s+/)[0] ?? '', [session]);
 	const bookedCount = todayRows.length;
 	const pipeline = useMemo(
 		() =>
@@ -197,7 +199,7 @@ export default function HomeScreen() {
 				<View style={styles.head}>
 					<View>
 						<SectionLabel>{todayLabel}</SectionLabel>
-						<Txt style={styles.h1}>Good morning, Marcus</Txt>
+						<Txt style={styles.h1}>{firstName ? `Good morning, ${firstName}` : 'Good morning'}</Txt>
 					</View>
 					<GradientButton label="New job" icon="plus" onPress={() => router.push('/schedule')} />
 				</View>

--- a/packages/app/app/index.tsx
+++ b/packages/app/app/index.tsx
@@ -151,7 +151,10 @@ export default function HomeScreen() {
 
 	const todayLabel = useMemo(() => formatDayLabel(new Date()), []);
 	// Greet by first name, falling back to a plain greeting before the session loads.
-	const firstName = useMemo(() => session?.user.name?.trim().split(/\s+/)[0] ?? '', [session]);
+	const firstName = useMemo(
+		() => (session ? session.user.name.trim().split(/\s+/)[0] : ''),
+		[session],
+	);
 	const bookedCount = todayRows.length;
 	const pipeline = useMemo(
 		() =>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix / UI polish.

The dashboard home screen welcome message was hardcoded to the mockup placeholder `Good morning, Marcus`. It now greets the signed-in user by their actual first name, derived from `session.user.name`, and falls back to a plain `Good morning` before the session has loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKVKBJaw94sFuDE4SApyHB)_