### PR TITLE
feat(agent): let a model route the agent across all its tools

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -12,9 +12,20 @@ Any other question is treated as a general ask and answered from the knowledge
 base: the agent forwards it to the API's AI-backed `/v1/faqs/answer` endpoint,
 which finds the relevant FAQs and composes a grounded reply (so "what's our best
 price?" is answered by a differently-worded "cost" FAQ), and cites the source FAQ.
-The reply logic is still a set of small, pure, unit-tested functions, so turning
-the deterministic understanding layer (`intent.ts`) into a real model-backed
-assistant later means changing only that one place.
+
+### Deciding what to do (`decide.ts`)
+
+Every turn, the agent first decides **which of those tools the message calls for**,
+reading the whole conversation. When an `ANTHROPIC_API_KEY` is configured a model
+makes that decision, so it follows context across turns (a bare "what should I
+add?" after looking at the FAQs is understood) and tells a *question* from a
+*command* ("how do I create an invoice?" is answered from the knowledge base, not
+turned into a new FAQ). The model only **routes** — it picks a structured action;
+the user-facing reply is still composed by the same small, pure, unit-tested
+functions. When no key is set — or a model call fails — routing degrades to the
+deterministic, rule-based parser (`intent.ts`), so the agent works (and its tests
+run) with no model and no network round-trip. `decide.ts` is the single seam: it's
+the one place that turns a conversation into an action.
 
 ## Authentication
 
@@ -44,9 +55,13 @@ source of truth. Any `401`/`403` from the API is turned into a clear sentence.
 | `JWT_SECRET`     | secret | (match the API)        | Verifies session tokens. `wrangler secret put JWT_SECRET`. |
 | `RIVUS_API_URL`  | var    | `https://api.rivus.ai` | The REST API the agent calls on the user's behalf.  |
 | `ALLOWED_ORIGINS`| var    | `https://app.rivus.ai` | Credentialed-CORS allowlist (`*` = any, dev only).  |
+| `ANTHROPIC_API_KEY` | secret | (a provider key)    | Turns on model routing. Unset → deterministic routing. `wrangler secret put ANTHROPIC_API_KEY`. |
+| `ANTHROPIC_MODEL`| var    | `claude-haiku-4-5`     | The routing model (small/fast — it only picks an action). |
 
-`RIVUS_API_URL` and `ALLOWED_ORIGINS` are set per environment in `wrangler.jsonc`;
-`JWT_SECRET` is a deploy-time secret and must equal the API's.
+`RIVUS_API_URL`, `ALLOWED_ORIGINS` and `ANTHROPIC_MODEL` are set per environment in
+`wrangler.jsonc`; `JWT_SECRET` and `ANTHROPIC_API_KEY` are deploy-time secrets
+(`JWT_SECRET` must equal the API's). The agent routes deterministically when
+`ANTHROPIC_API_KEY` is unset, so it boots and works without a model.
 
 ## How it fits together
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -16,8 +16,10 @@
 		"clean": "rm -rf dist coverage .wrangler"
 	},
 	"dependencies": {
+		"@ai-sdk/anthropic": "^3.0.85",
 		"@rivus/core": "workspace:*",
 		"agents": "^0.16.1",
+		"ai": "^6.0.208",
 		"zod": "catalog:"
 	},
 	"devDependencies": {

--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -260,37 +260,92 @@ describe('respond — knowledge base answering', () => {
 	});
 });
 
-describe('respond — conversation context', () => {
+describe('respond — conversation context (rule-based router)', () => {
 	const assistant = (content: string): ChatMessage => ({ role: 'assistant', content });
 
-	it('understands a bare follow-up from the prior knowledge-base turn', async () => {
-		// The screenshot case: after looking at the FAQs, "What should I add?" names no
-		// subject, but the conversation context routes it to an FAQ create — so the agent
-		// helps add one instead of brushing the question off. (faq_create with no parts
-		// replies straight away, so no API call is needed.)
+	it('resolves a bare browse follow-up from the prior knowledge-base turn', async () => {
+		// After looking at the FAQs, "show me them" names no subject; context routes it
+		// to the list, so the agent shows the knowledge base rather than brushing it off.
 		const reply = await respond({
 			env: envWith(),
 			request: authedRequest(),
 			messages: [
-				user("what's my website?"),
-				assistant('Your website is https://acme.example.'),
+				user('how many faqs do we have?'),
+				assistant('Your knowledge base has 3 FAQs: …'),
+				user('show me them'),
+			],
+			fetchImpl: router([{ when: onListFaqs, body: page([makeFaq()]) }]),
+		});
+		expect(reply).toMatch(/knowledge base has/i);
+	});
+
+	it('defers a bare "what should I add?" to the knowledge-answer path, not a create', async () => {
+		// Creating an FAQ isn't inferred from context, so this flows to the AI answer
+		// path and degrades to the friendly nudge when the KB has nothing — it does not
+		// jump straight into "add an FAQ".
+		const reply = await respond({
+			env: envWith(),
+			request: authedRequest(),
+			messages: [
 				user('how many faqs do we have?'),
 				assistant('Your knowledge base has 3 FAQs: …'),
 				user('What should I add?'),
 			],
-		});
-		expect(reply).toMatch(/what question should the FAQ answer/i);
-		expect(reply).not.toMatch(/not sure how to help/i);
-	});
-
-	it('still brushes off a subjectless follow-up with no topic to lean on', async () => {
-		const reply = await respond({
-			env: envWith(),
-			request: authedRequest(),
-			messages: [user('hello'), assistant(GREETING), user('what should I add?')],
 			fetchImpl: router([{ when: onAnswerFaq, body: noAnswer }]),
 		});
 		expect(reply).toMatch(/not sure how to help/i);
+		expect(reply).not.toMatch(/what question should the FAQ answer/i);
+	});
+});
+
+describe('respond — model-routed decisions', () => {
+	it('adds an FAQ when the model decides the user wants to create one', async () => {
+		// The model router resolves a bare "what should I add?" to a create; the agent
+		// then helps add one. (faq_create with no parts replies straight away.)
+		const reply = await respond({
+			env: envWith(),
+			request: authedRequest(),
+			messages: [user('What should I add?')],
+			decide: async () => ({ kind: 'faq_create', question: null, answer: null }),
+		});
+		expect(reply).toMatch(/what question should the FAQ answer/i);
+	});
+
+	it('answers from the knowledge base when the model reads a create-word as a question', async () => {
+		// "How do I create an invoice?" contains "create" but is a question; the model
+		// routes it to faq_answer, so it's answered from the FAQs, not turned into one.
+		const faqs = [
+			makeFaq({ question: 'Creating invoices', answer: 'Open Billing → New invoice.' }),
+		];
+		const reply = await respond({
+			env: envWith(),
+			request: authedRequest(),
+			messages: [user('How do I create an invoice?')],
+			decide: async () => ({ kind: 'faq_answer', question: 'How do I create an invoice?' }),
+			fetchImpl: router([
+				{
+					when: onAnswerFaq,
+					body: {
+						answered: true,
+						answer: 'Open Billing, then New invoice.',
+						sources: [{ id: faqs[0]?.id, question: faqs[0]?.question }],
+					},
+				},
+			]),
+		});
+		expect(reply).toMatch(/open billing/i);
+		expect(reply).toMatch(/from your faq/i);
+	});
+
+	it('falls back to the rule-based router when no model and no decide override', async () => {
+		// Default deps, no ANTHROPIC_API_KEY: a clear ask still routes deterministically.
+		const reply = await respond({
+			env: envWith(),
+			request: authedRequest(),
+			messages: [user('what is our website?')],
+			fetchImpl: router([{ when: onGetMe, body: sessionBody() }]),
+		});
+		expect(reply).toMatch(/your website is/i);
 	});
 });
 

--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -347,6 +347,33 @@ describe('respond — model-routed decisions', () => {
 		});
 		expect(reply).toMatch(/your website is/i);
 	});
+
+	it('never routes an unauthenticated caller through the model', async () => {
+		// An anonymous request must not send its transcript to a paid third-party model:
+		// it's routed deterministically and nudged to sign in, the router untouched.
+		const decide = vi.fn(async () => ({ kind: 'faq_list' as const }));
+		const reply = await respond({
+			env: envWith(),
+			request: anonRequest(),
+			messages: [user('what is our website?')],
+			decide,
+		});
+		expect(decide).not.toHaveBeenCalled();
+		expect(reply).toMatch(/signed in/i);
+	});
+
+	it('does not route an empty open through the model (just greets)', async () => {
+		// The app posts an empty transcript on open to fetch the greeting — no model call.
+		const decide = vi.fn(async () => ({ kind: 'faq_list' as const }));
+		const reply = await respond({
+			env: envWith(),
+			request: authedRequest(),
+			messages: [],
+			decide,
+		});
+		expect(decide).not.toHaveBeenCalled();
+		expect(reply).toContain(GREETING);
+	});
 });
 
 describe('respond — auth gating', () => {

--- a/packages/agent/src/assistant.ts
+++ b/packages/agent/src/assistant.ts
@@ -3,7 +3,7 @@ import { AgentApiError, createRivusApiClient, type FetchLike, type RivusApiClien
 import { authenticate } from './auth';
 import { GREETING, lastUserMessage } from './conversation';
 import { createDeciderFromEnv, type Decide } from './decide';
-import type { CompanyField, Intent } from './intent';
+import { type CompanyField, type Intent, resolveIntent } from './intent';
 import type { ChatMessage, Env, SessionClaims } from './types';
 
 /**
@@ -63,13 +63,25 @@ const FIELD_LABEL: Record<CompanyField, string> = {
 export async function respond(deps: RespondDeps): Promise<string> {
 	const { env, request, messages, fetchImpl } = deps;
 	const question = lastUserMessage(messages) ?? '';
-	// Let the agent decide which tool the latest turn calls for, reading the whole
-	// conversation. With a model configured the model chooses; otherwise this is the
-	// deterministic rule-based router. Either way we get an `Intent` to execute.
-	const decide = deps.decide ?? createDeciderFromEnv(env);
-	const intent = await decide(messages);
 	const session = await authenticate(request, env.JWT_SECRET);
 	const claims = session?.claims ?? null;
+
+	// Decide which tool the latest turn calls for — authenticating first, and spending
+	// a model call only when it can matter. An empty open (the app posts an empty
+	// transcript just to get the greeting) is the greeting, full stop. An
+	// unauthenticated caller can only be greeted, helped, or nudged to sign in, so it's
+	// routed deterministically — its transcript is never sent to a third-party model,
+	// nor does it incur model cost. Signed-in turns route via the model when one is
+	// configured; otherwise the same deterministic router.
+	let intent: Intent;
+	if (question.trim() === '') {
+		intent = { kind: 'greeting' };
+	} else if (session) {
+		const decide: Decide = deps.decide ?? createDeciderFromEnv(env);
+		intent = await decide(messages);
+	} else {
+		intent = resolveIntent(messages);
+	}
 
 	// Conversational intents need no data and work signed in or out.
 	if (intent.kind === 'greeting') {

--- a/packages/agent/src/assistant.ts
+++ b/packages/agent/src/assistant.ts
@@ -2,7 +2,8 @@ import { createFaqSchema, type Faq, updateFaqSchema } from '@rivus/core';
 import { AgentApiError, createRivusApiClient, type FetchLike, type RivusApiClient } from './api';
 import { authenticate } from './auth';
 import { GREETING, lastUserMessage } from './conversation';
-import { type CompanyField, type Intent, resolveIntent } from './intent';
+import { createDeciderFromEnv, type Decide } from './decide';
+import type { CompanyField, Intent } from './intent';
 import type { ChatMessage, Env, SessionClaims } from './types';
 
 /**
@@ -31,6 +32,11 @@ export interface RespondDeps {
 	messages: ChatMessage[];
 	/** Injected for tests; defaults to the global `fetch` in the Worker. */
 	fetchImpl?: FetchLike;
+	/**
+	 * Decides the agent's action from the conversation. Injected for tests; defaults
+	 * to a model-backed router (or the rule-based parser when no model is configured).
+	 */
+	decide?: Decide;
 }
 
 const SIGN_IN_REQUIRED =
@@ -57,9 +63,11 @@ const FIELD_LABEL: Record<CompanyField, string> = {
 export async function respond(deps: RespondDeps): Promise<string> {
 	const { env, request, messages, fetchImpl } = deps;
 	const question = lastUserMessage(messages) ?? '';
-	// Read the latest turn in the context of the conversation, so a bare follow-up
-	// ("what should I add?") is understood instead of brushed off.
-	const intent = resolveIntent(messages);
+	// Let the agent decide which tool the latest turn calls for, reading the whole
+	// conversation. With a model configured the model chooses; otherwise this is the
+	// deterministic rule-based router. Either way we get an `Intent` to execute.
+	const decide = deps.decide ?? createDeciderFromEnv(env);
+	const intent = await decide(messages);
 	const session = await authenticate(request, env.JWT_SECRET);
 	const claims = session?.claims ?? null;
 
@@ -72,14 +80,16 @@ export async function respond(deps: RespondDeps): Promise<string> {
 	}
 
 	// Everything below needs a session and a configured API. A general question
-	// (`unknown`) is the catch-all: rather than brushing it off, we try to answer it
-	// from the knowledge base with AI. It still degrades to a friendly nudge — not
-	// the sign-in / not-configured errors — when we can't reach the data.
+	// (`unknown`, or a model-chosen `faq_answer`) is the catch-all: rather than
+	// brushing it off, we try to answer it from the knowledge base with AI. It still
+	// degrades to a friendly nudge — not the sign-in / not-configured errors — when
+	// we can't reach the data.
+	const isQuestion = intent.kind === 'unknown' || intent.kind === 'faq_answer';
 	if (!session) {
-		return intent.kind === 'unknown' ? unknownReply(null) : SIGN_IN_REQUIRED;
+		return isQuestion ? unknownReply(null) : SIGN_IN_REQUIRED;
 	}
 	if (!env.RIVUS_API_URL) {
-		return intent.kind === 'unknown' ? unknownReply(claims) : NOT_CONFIGURED;
+		return isQuestion ? unknownReply(claims) : NOT_CONFIGURED;
 	}
 	const api = createRivusApiClient(env.RIVUS_API_URL, session.token, fetchImpl);
 
@@ -95,6 +105,8 @@ export async function respond(deps: RespondDeps): Promise<string> {
 				return await faqUpdateReply(api, intent);
 			case 'faq_create':
 				return await faqCreateReply(api, intent);
+			case 'faq_answer':
+				return await knowledgeAnswerReply(api, intent.question, claims);
 			case 'unknown':
 				return await knowledgeAnswerReply(api, question, claims);
 		}

--- a/packages/agent/src/decide.test.ts
+++ b/packages/agent/src/decide.test.ts
@@ -69,6 +69,18 @@ describe('decisionToIntent', () => {
 		});
 	});
 
+	it('drops an answer with no question so a create never breaks schema validation', () => {
+		// The model may emit an answer without a question; that violates the parser's
+		// invariant, so we reset to "nothing yet" and the assistant asks for the whole FAQ.
+		expect(
+			decisionToIntent(decision({ action: 'faq_create', answer: 'Yes, within 30 days' }), ''),
+		).toEqual({ kind: 'faq_create', question: null, answer: null });
+		// A blank/whitespace question is treated the same as none.
+		expect(
+			decisionToIntent(decision({ action: 'faq_create', question: '   ', answer: 'Yes' }), ''),
+		).toEqual({ kind: 'faq_create', question: null, answer: null });
+	});
+
 	it('falls back to the raw user text when faq_answer omits the question', () => {
 		expect(decisionToIntent(decision({ action: 'faq_answer' }), 'how do I cancel?')).toEqual({
 			kind: 'faq_answer',
@@ -105,6 +117,22 @@ describe('createDecider — with a model', () => {
 		expect(calls[0]).toContain('User: how many faqs do we have?');
 		expect(calls[0]).toContain('Assistant: Your knowledge base has 3 FAQs: …');
 		expect(calls[0]).toContain('User: What should I add?');
+	});
+
+	it('bounds the transcript: recent turns only, each clipped', async () => {
+		const { generate, calls } = fakeGenerate(decision({ action: 'faq_list' }));
+		const decide = createDecider({ model: MODEL, generate });
+		const many = Array.from({ length: 20 }, (_, i) => user(`message ${i}`));
+		many.push(user(`${'x'.repeat(2000)} END`));
+		await decide(many);
+		const prompt = calls[0] ?? '';
+		// Only the most recent turns are sent — the oldest are dropped…
+		expect(prompt).not.toContain('message 0');
+		expect(prompt).toContain('message 19');
+		expect(prompt.split('\n').length).toBeLessThanOrEqual(12);
+		// …and an over-long message is clipped (its tail never reaches the model).
+		expect(prompt).not.toContain('END');
+		expect(prompt).toContain('…');
 	});
 
 	it('falls back to deterministic routing when the model call fails', async () => {

--- a/packages/agent/src/decide.test.ts
+++ b/packages/agent/src/decide.test.ts
@@ -1,0 +1,140 @@
+import type { LanguageModel } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	type AgentDecision,
+	createDecider,
+	createDeciderFromEnv,
+	decisionToIntent,
+	type GenerateDecisionFn,
+} from './decide';
+import type { ChatMessage, Env } from './types';
+
+const user = (content: string): ChatMessage => ({ role: 'user', content });
+const assistant = (content: string): ChatMessage => ({ role: 'assistant', content });
+
+/** A complete decision with defaults; override the fields a case cares about. */
+function decision(over: Partial<AgentDecision>): AgentDecision {
+	return {
+		action: 'unknown',
+		fields: [],
+		query: '',
+		answerQuestion: '',
+		question: null,
+		answer: null,
+		topic: '',
+		...over,
+	};
+}
+
+/** A fake model: returns the scripted decision and records what it was asked. */
+function fakeGenerate(result: AgentDecision): { generate: GenerateDecisionFn; calls: string[] } {
+	const calls: string[] = [];
+	const generate: GenerateDecisionFn = async (options) => {
+		calls.push(options.prompt);
+		return { object: result };
+	};
+	return { generate, calls };
+}
+
+// A stand-in model handle — never used by the fake generate, just satisfies the type.
+const MODEL = {} as unknown as LanguageModel;
+
+describe('decisionToIntent', () => {
+	it('maps each action onto the matching intent', () => {
+		expect(decisionToIntent(decision({ action: 'greeting' }), '')).toEqual({ kind: 'greeting' });
+		expect(decisionToIntent(decision({ action: 'help' }), '')).toEqual({ kind: 'help' });
+		expect(decisionToIntent(decision({ action: 'company_info', fields: ['website'] }), '')).toEqual(
+			{ kind: 'company_info', fields: ['website'] },
+		);
+		expect(decisionToIntent(decision({ action: 'faq_list' }), '')).toEqual({ kind: 'faq_list' });
+		expect(decisionToIntent(decision({ action: 'faq_search', query: 'refunds' }), '')).toEqual({
+			kind: 'faq_search',
+			query: 'refunds',
+		});
+		expect(
+			decisionToIntent(decision({ action: 'faq_update', topic: 'returns', answer: '30 days' }), ''),
+		).toEqual({ kind: 'faq_update', topic: 'returns', answer: '30 days' });
+		expect(
+			decisionToIntent(
+				decision({ action: 'faq_create', question: 'Do you ship?', answer: 'Yes' }),
+				'',
+			),
+		).toEqual({ kind: 'faq_create', question: 'Do you ship?', answer: 'Yes' });
+		expect(decisionToIntent(decision({ action: 'unknown' }), '')).toEqual({ kind: 'unknown' });
+	});
+
+	it('treats an empty search as a list', () => {
+		expect(decisionToIntent(decision({ action: 'faq_search', query: '   ' }), '')).toEqual({
+			kind: 'faq_list',
+		});
+	});
+
+	it('falls back to the raw user text when faq_answer omits the question', () => {
+		expect(decisionToIntent(decision({ action: 'faq_answer' }), 'how do I cancel?')).toEqual({
+			kind: 'faq_answer',
+			question: 'how do I cancel?',
+		});
+		// …but prefers the model's restated question when present.
+		expect(
+			decisionToIntent(decision({ action: 'faq_answer', answerQuestion: 'cancellation' }), 'raw'),
+		).toEqual({ kind: 'faq_answer', question: 'cancellation' });
+	});
+});
+
+describe('createDecider — without a model', () => {
+	it('routes deterministically via resolveIntent', async () => {
+		const decide = createDecider();
+		expect(await decide([user('what is our website?')])).toEqual({
+			kind: 'company_info',
+			fields: ['website'],
+		});
+	});
+});
+
+describe('createDecider — with a model', () => {
+	it('routes using the model and sends the whole transcript', async () => {
+		const { generate, calls } = fakeGenerate(decision({ action: 'faq_create' }));
+		const decide = createDecider({ model: MODEL, generate });
+		const intent = await decide([
+			user('how many faqs do we have?'),
+			assistant('Your knowledge base has 3 FAQs: …'),
+			user('What should I add?'),
+		]);
+		expect(intent).toEqual({ kind: 'faq_create', question: null, answer: null });
+		// The transcript (both sides) is handed to the model, not just the last turn.
+		expect(calls[0]).toContain('User: how many faqs do we have?');
+		expect(calls[0]).toContain('Assistant: Your knowledge base has 3 FAQs: …');
+		expect(calls[0]).toContain('User: What should I add?');
+	});
+
+	it('falls back to deterministic routing when the model call fails', async () => {
+		const generate: GenerateDecisionFn = async () => {
+			throw new Error('model down');
+		};
+		const warn = vi.fn();
+		const decide = createDecider({ model: MODEL, generate, logger: { warn } });
+		// "what is our website?" still routes, via the rule-based fallback.
+		expect(await decide([user('what is our website?')])).toEqual({
+			kind: 'company_info',
+			fields: ['website'],
+		});
+		expect(warn).toHaveBeenCalledOnce();
+	});
+});
+
+describe('createDeciderFromEnv', () => {
+	it('routes deterministically when no ANTHROPIC_API_KEY is set', async () => {
+		const decide = createDeciderFromEnv({} as Env);
+		expect(await decide([user('faqs')])).toEqual({ kind: 'faq_list' });
+	});
+
+	it('builds a model-backed decider when a key is configured', () => {
+		// Construction only — we don't invoke it (that would hit the network). Proving the
+		// keyed branch wires a model provider without throwing is enough here.
+		const decide = createDeciderFromEnv({
+			ANTHROPIC_API_KEY: 'sk-test',
+			ANTHROPIC_MODEL: 'claude-haiku-4-5',
+		} as Env);
+		expect(typeof decide).toBe('function');
+	});
+});

--- a/packages/agent/src/decide.ts
+++ b/packages/agent/src/decide.ts
@@ -126,14 +126,29 @@ const SYSTEM = [
 	'Prefer faq_answer over faq_create whenever the user is asking rather than commanding.',
 ].join('\n');
 
-/** Render the transcript for the prompt, tagging each turn with its role. */
+// Bound what we send the router so a long or pasted conversation can't blow the
+// context window or run up latency/cost — routing only needs recent context, and
+// the rule-based fallback was capped too. Keep the most recent turns, each clipped.
+const MAX_TRANSCRIPT_MESSAGES = 12;
+const MAX_MESSAGE_CHARS = 1000;
+
+/** Render a bounded, role-tagged transcript for the prompt (most recent turns only). */
 function transcript(messages: ChatMessage[]): string {
 	const ROLE_LABEL: Record<ChatMessage['role'], string> = {
 		user: 'User',
 		assistant: 'Assistant',
 		system: 'System',
 	};
-	return messages.map((message) => `${ROLE_LABEL[message.role]}: ${message.content}`).join('\n');
+	return messages
+		.slice(-MAX_TRANSCRIPT_MESSAGES)
+		.map((message) => {
+			const content =
+				message.content.length > MAX_MESSAGE_CHARS
+					? `${message.content.slice(0, MAX_MESSAGE_CHARS - 1)}…`
+					: message.content;
+			return `${ROLE_LABEL[message.role]}: ${content}`;
+		})
+		.join('\n');
 }
 
 /** Map a validated model decision onto the `Intent` the assistant executes. */
@@ -157,8 +172,14 @@ export function decisionToIntent(decision: AgentDecision, latestUserText: string
 			const question = decision.answerQuestion.trim() || latestUserText;
 			return { kind: 'faq_answer', question };
 		}
-		case 'faq_create':
-			return { kind: 'faq_create', question: decision.question, answer: decision.answer };
+		case 'faq_create': {
+			// Preserve the parser's invariant that an answer only travels with a question.
+			// A model create that gives an answer but no question is treated as "nothing
+			// yet", so the assistant asks for the whole FAQ in one message rather than
+			// failing schema validation on a null question.
+			const question = decision.question?.trim() ? decision.question : null;
+			return { kind: 'faq_create', question, answer: question ? decision.answer : null };
+		}
 		case 'faq_update':
 			return { kind: 'faq_update', topic: decision.topic, answer: decision.answer };
 		default:

--- a/packages/agent/src/decide.ts
+++ b/packages/agent/src/decide.ts
@@ -1,0 +1,225 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateObject, type LanguageModel } from 'ai';
+import { z } from 'zod';
+import { lastUserMessage } from './conversation';
+import { type CompanyField, type Intent, resolveIntent } from './intent';
+import type { ChatMessage, Env } from './types';
+
+/**
+ * The agent's "understanding" layer. Given the whole conversation, it decides
+ * *which of the agent's tools to use* — read company facts, browse or search the
+ * knowledge base, answer a question from it, or add/update an FAQ — and with what
+ * arguments. The chosen action is then carried out by `assistant.ts` against the
+ * Rivus API.
+ *
+ * When a model is configured the model makes that decision, so it reasons over the
+ * full chat (a bare "what should I add?" after looking at the FAQs is understood),
+ * and tells a *question* apart from a *command* ("how do I create an invoice?" is
+ * answered from the knowledge base, not turned into a new FAQ). When no model is
+ * configured — or a model call fails — it degrades to the deterministic, rule-based
+ * `resolveIntent`, so the agent always understands *something* without a network
+ * round-trip. This is the single seam the README points at: the agent's routing
+ * lives here and nowhere else.
+ */
+
+/** The company fields the model may ask for, kept in sync with {@link CompanyField}. */
+const COMPANY_FIELDS = [
+	'name',
+	'website',
+	'phone',
+	'address',
+	'timezone',
+	'slug',
+	'status',
+] as const satisfies readonly CompanyField[];
+
+/**
+ * The structured decision the model returns: one action (the tool to use) plus the
+ * arguments it needs. Every argument is optional with a safe default so a terse
+ * model response still validates; {@link decisionToIntent} turns it into the
+ * `Intent` the assistant already knows how to execute.
+ */
+const decisionSchema = z.object({
+	action: z.enum([
+		'greeting',
+		'help',
+		'company_info',
+		'faq_list',
+		'faq_search',
+		'faq_answer',
+		'faq_create',
+		'faq_update',
+		'unknown',
+	]),
+	/** For `company_info`: which fields to report (empty = the whole record). */
+	fields: z.array(z.enum(COMPANY_FIELDS)).default([]),
+	/** For `faq_search`: what to search the knowledge base for. */
+	query: z.string().default(''),
+	/** For `faq_answer`: the question to answer from the knowledge base. */
+	answerQuestion: z.string().default(''),
+	/** For `faq_create`/`faq_update`: the FAQ's question/topic and answer text. */
+	question: z.string().nullable().default(null),
+	answer: z.string().nullable().default(null),
+	topic: z.string().default(''),
+});
+
+export type AgentDecision = z.infer<typeof decisionSchema>;
+
+/** Decides the agent's action for a conversation. */
+export type Decide = (messages: ChatMessage[]) => Promise<Intent>;
+
+/**
+ * The single AI call this layer makes, narrowed to what we use. Injectable so tests
+ * drive the routing without a model or the network — the same seam `@rivus/api`'s
+ * FAQ answerer uses. Defaults to the AI SDK's {@link generateObject}.
+ */
+export type GenerateDecisionFn = (options: {
+	model: LanguageModel;
+	schema: typeof decisionSchema;
+	system: string;
+	prompt: string;
+	maxOutputTokens?: number;
+}) => Promise<{ object: AgentDecision }>;
+
+const defaultGenerateDecision: GenerateDecisionFn = async (options) => {
+	const { object } = await generateObject({
+		model: options.model,
+		schema: options.schema,
+		schemaName: 'agent_decision',
+		system: options.system,
+		prompt: options.prompt,
+		maxOutputTokens: options.maxOutputTokens,
+	});
+	return { object };
+};
+
+/** Keep the routing call small and fast — it only picks an action, never composes prose. */
+const MAX_OUTPUT_TOKENS = 300;
+
+const SYSTEM = [
+	'You are the router for Rivus, an assistant for a small business. Decide the single',
+	'best action to take for the latest user message, using the whole conversation for',
+	'context. Reply with the structured decision only — you never write the user-facing',
+	'text yourself.',
+	'',
+	'Actions:',
+	'- greeting: the user is just saying hello.',
+	'- help: the user asks what you can do.',
+	'- company_info: the user wants company/account facts (name, website, phone, address,',
+	'  timezone, slug, status). Put the specific fields in `fields`, or leave it empty for',
+	'  the whole record.',
+	'- faq_list: the user wants to browse/see their knowledge base (their FAQs).',
+	'- faq_search: the user wants to find FAQs on a topic. Put the topic in `query`.',
+	'- faq_answer: the user asks a QUESTION they want answered from the knowledge base.',
+	'  This is the default for any genuine question, even one containing words like',
+	'  "create"/"add"/"make" (e.g. "how do I create an invoice?" is a question, not a',
+	'  request to add an FAQ). Put the question in `answerQuestion`.',
+	'- faq_create: the user explicitly asks to ADD a new FAQ. Only choose this when they',
+	'  clearly want to create one. Put the FAQ wording in `question` and `answer` (use null',
+	'  for whichever they did not give).',
+	'- faq_update: the user explicitly asks to CHANGE an existing FAQ. Put the FAQ topic in',
+	'  `topic` and the new text in `answer` (null if not given).',
+	'- unknown: none of the above and not a knowledge-base question.',
+	'',
+	'Resolve follow-ups from context: after looking at the FAQs, "what should I add?" means',
+	'faq_create with no question/answer yet; "anything about refunds?" means faq_search.',
+	'Prefer faq_answer over faq_create whenever the user is asking rather than commanding.',
+].join('\n');
+
+/** Render the transcript for the prompt, tagging each turn with its role. */
+function transcript(messages: ChatMessage[]): string {
+	const ROLE_LABEL: Record<ChatMessage['role'], string> = {
+		user: 'User',
+		assistant: 'Assistant',
+		system: 'System',
+	};
+	return messages.map((message) => `${ROLE_LABEL[message.role]}: ${message.content}`).join('\n');
+}
+
+/** Map a validated model decision onto the `Intent` the assistant executes. */
+export function decisionToIntent(decision: AgentDecision, latestUserText: string): Intent {
+	switch (decision.action) {
+		case 'greeting':
+			return { kind: 'greeting' };
+		case 'help':
+			return { kind: 'help' };
+		case 'company_info':
+			return { kind: 'company_info', fields: decision.fields };
+		case 'faq_list':
+			return { kind: 'faq_list' };
+		case 'faq_search':
+			// A search with no subject is really just "show me the FAQs".
+			return decision.query.trim().length > 0
+				? { kind: 'faq_search', query: decision.query.trim() }
+				: { kind: 'faq_list' };
+		case 'faq_answer': {
+			// Fall back to the raw user text when the model didn't restate the question.
+			const question = decision.answerQuestion.trim() || latestUserText;
+			return { kind: 'faq_answer', question };
+		}
+		case 'faq_create':
+			return { kind: 'faq_create', question: decision.question, answer: decision.answer };
+		case 'faq_update':
+			return { kind: 'faq_update', topic: decision.topic, answer: decision.answer };
+		default:
+			return { kind: 'unknown' };
+	}
+}
+
+export interface DecideDeps {
+	/** The model to route with; when absent, routing is purely deterministic. */
+	model?: LanguageModel;
+	/** Injected for tests; defaults to the AI SDK's structured generation. */
+	generate?: GenerateDecisionFn;
+	/** Surfaced so a failed model call is visible in production logs. */
+	logger?: { warn(message: string): void };
+}
+
+/**
+ * Build the agent's decider. With a model it asks the model to choose the action,
+ * falling back to {@link resolveIntent} if the call fails; with no model it *is*
+ * {@link resolveIntent}. Either way it returns an `Intent` the assistant executes,
+ * so the rest of the agent is unchanged whether or not a model is configured.
+ */
+export function createDecider(deps: DecideDeps = {}): Decide {
+	const { model, generate = defaultGenerateDecision, logger } = deps;
+	return async (messages) => {
+		if (!model) {
+			return resolveIntent(messages);
+		}
+		const latestUserText = lastUserMessage(messages) ?? '';
+		try {
+			const { object } = await generate({
+				model,
+				schema: decisionSchema,
+				system: SYSTEM,
+				prompt: transcript(messages),
+				maxOutputTokens: MAX_OUTPUT_TOKENS,
+			});
+			return decisionToIntent(object, latestUserText);
+		} catch (error) {
+			// A model outage must never break the chat: log it and fall back to the
+			// deterministic understanding, exactly as the API's answerer degrades.
+			logger?.warn(`Agent routing failed, falling back to rule-based intent — ${String(error)}`);
+			return resolveIntent(messages);
+		}
+	};
+}
+
+/** Default routing model, overridable per environment via `ANTHROPIC_MODEL`. */
+const DEFAULT_MODEL = 'claude-haiku-4-5';
+
+/**
+ * Wire a decider from the Worker environment. When `ANTHROPIC_API_KEY` is set the
+ * agent routes with the model; otherwise it routes deterministically. Mirrors the
+ * API's provider wiring (and its graceful no-key degradation).
+ */
+export function createDeciderFromEnv(env: Env): Decide {
+	if (!env.ANTHROPIC_API_KEY) {
+		return createDecider();
+	}
+	const model = createAnthropic({ apiKey: env.ANTHROPIC_API_KEY })(
+		env.ANTHROPIC_MODEL ?? DEFAULT_MODEL,
+	);
+	return createDecider({ model, logger: console });
+}

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -294,18 +294,23 @@ describe('parseIntent — natural FAQ create', () => {
 });
 
 describe('parseIntent — conversation context', () => {
-	it('reads a subjectless FAQ action as an FAQ ask when the topic is faq', () => {
-		// "what should I add?" names no subject, but with the conversation on the
-		// knowledge base the "add" verb routes it to a create.
-		expect(parseIntent('What should I add?', { topic: 'faq' })).toEqual({
-			kind: 'faq_create',
-			question: null,
-			answer: null,
-		});
+	it('reads a subjectless browse/search as an FAQ ask when the topic is faq', () => {
+		// A bare "list them" / "anything about refunds?" names no subject, but with the
+		// conversation on the knowledge base these resolve against it.
 		expect(parseIntent('can you list them?', { topic: 'faq' })).toEqual({ kind: 'faq_list' });
 		expect(parseIntent('anything about refunds?', { topic: 'faq' })).toEqual({
 			kind: 'faq_search',
 			query: 'refunds',
+		});
+	});
+
+	it('does not infer FAQ creation from context (a create verb is usually a question)', () => {
+		// "what should I add?" / "how do I create an invoice?" merely contain a create
+		// verb; the rule-based router does NOT turn that into faq_create from context —
+		// it leaves them for the knowledge-answer path. Creating needs explicit phrasing.
+		expect(parseIntent('What should I add?', { topic: 'faq' })).toEqual({ kind: 'unknown' });
+		expect(parseIntent('how do I create an invoice?', { topic: 'faq' })).toEqual({
+			kind: 'unknown',
 		});
 	});
 
@@ -340,19 +345,27 @@ describe('parseIntent — conversation context', () => {
 });
 
 describe('resolveIntent — multi-turn', () => {
-	it('answers a bare follow-up using the prior FAQ turn', () => {
+	it('resolves a bare browse follow-up using the prior FAQ turn', () => {
 		const conversation = [
 			user("what's my website?"),
 			assistant('Your website is https://example.com.'),
 			user('how many faqs do we have?'),
 			assistant('Your knowledge base has 3 FAQs: …'),
-			user('What should I add?'),
+			user('show me them'),
 		];
-		expect(resolveIntent(conversation)).toEqual({
-			kind: 'faq_create',
-			question: null,
-			answer: null,
-		});
+		expect(resolveIntent(conversation)).toEqual({ kind: 'faq_list' });
+	});
+
+	it('inherits FAQ context from an assistant knowledge answer, not just user turns', () => {
+		// The user's prior turn ("what's our best price?") parses as unknown; the proof
+		// the chat is on the knowledge base is the assistant's cited answer. A bare
+		// search follow-up should still resolve against the FAQs.
+		const conversation = [
+			user("what's our best price?"),
+			assistant('Our basic plan is $9/mo.\n\n(From your FAQ “How much does it cost?”.)'),
+			user('anything about refunds?'),
+		];
+		expect(resolveIntent(conversation)).toEqual({ kind: 'faq_search', query: 'refunds' });
 	});
 
 	it('leaves a turn that stands on its own untouched', () => {

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -41,6 +41,13 @@ export type Intent =
 	| { kind: 'faq_update'; topic: string; answer: string | null }
 	/** Add an FAQ; `question`/`answer` are null when the user didn't supply them. */
 	| { kind: 'faq_create'; question: string | null; answer: string | null }
+	/**
+	 * Answer a free-text question from the knowledge base (AI-assisted, via the API).
+	 * The rule-based parser never produces this — it routes general questions through
+	 * `unknown` — but a model router can pick it explicitly. The assistant handles
+	 * both the same way.
+	 */
+	| { kind: 'faq_answer'; question: string }
 	| { kind: 'unknown' };
 
 /** The subject a conversation is on, carried forward to resolve bare follow-ups. */
@@ -228,15 +235,16 @@ function parseFaqCreate(text: string): { question: string | null; answer: string
 }
 
 /**
- * True when a message carries a knowledge-base *action* (add/update/search/list,
- * or an "about …" subject) — as opposed to a bare "thanks". Used to decide whether
- * an otherwise-subjectless message should attach to an active FAQ conversation, so
- * a pleasantry doesn't get mistaken for "show me the FAQs".
+ * True when a message carries a knowledge-base *action* that's safe to infer from
+ * an active FAQ conversation — browsing, searching, updating, or an "about …"
+ * subject — as opposed to a bare "thanks". Deliberately excludes *creation*: a turn
+ * that merely contains "add"/"create"/"make" is far more often a question to answer
+ * ("how do I create an invoice?") than a request to add an FAQ, so creating one
+ * requires explicit FAQ phrasing rather than being inferred from context.
  */
 function hasFaqAction(lower: string): boolean {
 	return (
 		UPDATE_VERB.test(lower) ||
-		CREATE_VERB.test(lower) ||
 		SEARCH_VERB.test(lower) ||
 		LIST_VERB.test(lower) ||
 		afterPreposition(lower) !== null
@@ -320,6 +328,7 @@ function topicOf(intent: Intent): ConversationTopic | null {
 		case 'faq_search':
 		case 'faq_update':
 		case 'faq_create':
+		case 'faq_answer':
 			return 'faq';
 		case 'company_info':
 			return 'company';
@@ -329,8 +338,24 @@ function topicOf(intent: Intent): ConversationTopic | null {
 }
 
 /**
- * How many recent user turns a subjectless follow-up looks back over for its
- * topic. A short window keeps the inference relevant (a topic from far earlier
+ * Markers in the agent's *own* FAQ replies — a list, a search result, a knowledge
+ * answer's citation, or a create/update confirmation. A prior user turn answered
+ * from the knowledge base parses as `unknown` (it was a general question), so the
+ * proof the conversation is on the FAQs lives in the assistant's reply, not the
+ * user's ask. These phrases appear only in the agent's knowledge-base replies, not
+ * its greeting or help text, so they don't misfire on boilerplate.
+ */
+const ASSISTANT_FAQ_REPLY =
+	/your knowledge base (?:has|is empty)|from your faq|here’s what i found about|couldn’t find anything|added a new faq|i updated|currently says/i;
+
+/** The topic an assistant turn establishes, read from the agent's FAQ-reply markers. */
+function assistantTopic(content: string): ConversationTopic | null {
+	return ASSISTANT_FAQ_REPLY.test(content) ? 'faq' : null;
+}
+
+/**
+ * How many recent turns (either side) a subjectless follow-up looks back over for
+ * its topic. A short window keeps the inference relevant (a topic from far earlier
  * shouldn't bind "now") and bounds the work done on every turn — re-parsing an
  * unbounded history would risk the Workers CPU limit on a long conversation.
  */
@@ -338,20 +363,31 @@ const CONTEXT_LOOKBACK_TURNS = 6;
 
 /**
  * The subject the conversation is already on, read from the most recent *earlier*
- * user turn that established one. The latest turn is skipped — it's the one we
- * couldn't read on its own and are trying to give context to — and the scan is
- * capped at the last {@link CONTEXT_LOOKBACK_TURNS} turns.
+ * turn that established one. We look at both sides: a user turn via its parsed
+ * intent, and an assistant turn via the agent's FAQ-reply markers — so context the
+ * user set ("how many faqs?") *and* context only the assistant's answer proves
+ * (a knowledge answer to "what's our best price?") both count. The latest turn is
+ * skipped — it's the one we couldn't read on its own — and the scan is capped at
+ * the last {@link CONTEXT_LOOKBACK_TURNS} turns to keep it relevant and bounded.
  */
 function recentTopic(messages: ChatMessage[]): ConversationTopic | null {
-	const userTurns = messages.filter((message) => message.role === 'user');
-	const start = userTurns.length - 2;
-	const end = Math.max(0, userTurns.length - 1 - CONTEXT_LOOKBACK_TURNS);
-	for (let i = start; i >= end; i--) {
-		const turn = userTurns[i];
-		if (!turn) {
+	// Drop the latest user turn: it's what we're resolving, not context for itself.
+	let lastUserIndex = -1;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		if (messages[i]?.role === 'user') {
+			lastUserIndex = i;
+			break;
+		}
+	}
+	let scanned = 0;
+	for (let i = lastUserIndex - 1; i >= 0 && scanned < CONTEXT_LOOKBACK_TURNS; i--) {
+		const turn = messages[i];
+		if (!turn || turn.role === 'system') {
 			continue;
 		}
-		const topic = topicOf(parseIntent(turn.content));
+		const topic =
+			turn.role === 'assistant' ? assistantTopic(turn.content) : topicOf(parseIntent(turn.content));
+		scanned += 1;
 		if (topic) {
 			return topic;
 		}

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -32,6 +32,20 @@ export interface Env {
 	 * in wrangler.jsonc; unset locally (treated as development).
 	 */
 	NODE_ENV?: string;
+	/**
+	 * Anthropic API key used to route the agent — i.e. to let the model decide which
+	 * of the agent's tools (company facts, knowledge-base search/answer/edits) the
+	 * latest message calls for. A deploy-time secret (`wrangler secret put
+	 * ANTHROPIC_API_KEY`), never a plaintext var. When unset, routing degrades to the
+	 * deterministic rule-based parser, so the agent still works without a model.
+	 */
+	ANTHROPIC_API_KEY?: string;
+	/**
+	 * The model used for routing, e.g. `claude-haiku-4-5` (small and fast — it only
+	 * picks an action, it doesn't write the reply). Set per environment in
+	 * wrangler.jsonc; defaults to a fast model when unset.
+	 */
+	ANTHROPIC_MODEL?: string;
 }
 
 /**

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
 				'src/api.ts',
 				'src/intent.ts',
 				'src/assistant.ts',
+				'src/decide.ts',
 			],
 			exclude: ['src/**/*.test.ts'],
 			thresholds: {

--- a/packages/agent/wrangler.jsonc
+++ b/packages/agent/wrangler.jsonc
@@ -12,8 +12,12 @@
 	// Plain (non-secret) vars for local `wrangler dev`. `RIVUS_API_URL` is the Rivus
 	// REST API the agent calls on a signed-in user's behalf; `ALLOWED_ORIGINS` is the
 	// credentialed-CORS allowlist (`*` reflects any origin — local dev only).
-	// The shared `JWT_SECRET` (used to verify session tokens; must match the API's)
-	// is a *secret*, not a var: set it with `wrangler secret put JWT_SECRET`.
+	// Secrets are *not* vars: set them with `wrangler secret put <NAME>`.
+	//   - `JWT_SECRET` verifies session tokens; must match the API's.
+	//   - `ANTHROPIC_API_KEY` lets the model route the agent (decide which tool a
+	//     message calls for). Unset locally, so dev routes deterministically; set it
+	//     per environment to turn on model routing. `ANTHROPIC_MODEL` (a var below)
+	//     picks the routing model.
 	"vars": {
 		"RIVUS_API_URL": "http://localhost:4000",
 		"ALLOWED_ORIGINS": "*"
@@ -38,7 +42,8 @@
 			"vars": {
 				"NODE_ENV": "production",
 				"RIVUS_API_URL": "https://dev-api.rivus.ai",
-				"ALLOWED_ORIGINS": "https://dev-app.rivus.ai"
+				"ALLOWED_ORIGINS": "https://dev-app.rivus.ai",
+				"ANTHROPIC_MODEL": "claude-haiku-4-5"
 			},
 			"durable_objects": {
 				"bindings": [{ "name": "RivusAgent", "class_name": "RivusAgent" }]
@@ -50,7 +55,8 @@
 			"vars": {
 				"NODE_ENV": "production",
 				"RIVUS_API_URL": "https://api.rivus.ai",
-				"ALLOWED_ORIGINS": "https://app.rivus.ai"
+				"ALLOWED_ORIGINS": "https://app.rivus.ai",
+				"ANTHROPIC_MODEL": "claude-haiku-4-5"
 			},
 			"durable_objects": {
 				"bindings": [{ "name": "RivusAgent", "class_name": "RivusAgent" }]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,12 +53,18 @@ importers:
 
   packages/agent:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.85
+        version: 3.0.85(zod@4.4.3)
       '@rivus/core':
         specifier: workspace:*
         version: link:../core
       agents:
         specifier: ^0.16.1
         version: 0.16.2(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@cloudflare/workers-types@4.20260616.1)(ai@6.0.208(zod@4.4.3))(react@19.2.7)(rolldown@1.1.1)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(zod@4.4.3)
+      ai:
+        specifier: ^6.0.208
+        version: 6.0.208(zod@4.4.3)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -358,20 +364,8 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
-  '@ai-sdk/anthropic@3.0.84':
-    resolution: {integrity: sha512-BIDaHmCHs6Sr5VUsEkTbbVlAN4GWjg97X9x/IfXyviLtzsXvffui9XIcZugkAi1Ri6FnvI5T5qDGh5YLnSuzRg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
   '@ai-sdk/anthropic@3.0.85':
     resolution: {integrity: sha512-fNeDB644l5wbRNQU0FnI+F7UTtOenMnPtACfMPUJaS2zJfuBlseEa1TMg+otHkETZgaJB+6Na51NQEv0+m7czw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/gateway@3.0.129':
-    resolution: {integrity: sha512-KEQpZGJuCksc4iFxYtVHeHHG7yH0izGFzJLmRZlriI0hFIzJF9bT2AzJoaTHUI6minlxtP0WKYh84dP18o/Cuw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -3569,12 +3563,6 @@ packages:
         optional: true
       vite:
         optional: true
-
-  ai@6.0.203:
-    resolution: {integrity: sha512-2Qi1ZPGF/FnlvnRqntVgRbUYGeA5ZKFYwTtgu8rcUzMmddArM/nLsvCW69Ip99B1cop6XHRHl+GCKk9t9B+GDA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
 
   ai@6.0.208:
     resolution: {integrity: sha512-STz+AaZqJ4ZjH7UkpXkbHx+bjgIDOsE8fIUoZjkZ2whoZcfVmG9K/TqEKouJZ03SuZuD7lagntlU3zBhAEkRpQ==}
@@ -7650,23 +7638,10 @@ snapshots:
 
   '@adobe/css-tools@4.5.0': {}
 
-  '@ai-sdk/anthropic@3.0.84(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
-      zod: 4.4.3
-
   '@ai-sdk/anthropic@3.0.85(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
-      zod: 4.4.3
-
-  '@ai-sdk/gateway@3.0.129(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
-      '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
   '@ai-sdk/gateway@3.0.133(zod@4.4.3)':
@@ -11127,14 +11102,6 @@ snapshots:
       - rolldown
       - supports-color
 
-  ai@6.0.203(zod@4.4.3):
-    dependencies:
-      '@ai-sdk/gateway': 3.0.129(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
-      zod: 4.4.3
-
   ai@6.0.208(zod@4.4.3):
     dependencies:
       '@ai-sdk/gateway': 3.0.133(zod@4.4.3)
@@ -11815,11 +11782,11 @@ snapshots:
 
   docula@2.0.0(@types/react@19.2.17)(zod@4.4.3):
     dependencies:
-      '@ai-sdk/anthropic': 3.0.84(zod@4.4.3)
+      '@ai-sdk/anthropic': 3.0.85(zod@4.4.3)
       '@ai-sdk/google': 3.0.82(zod@4.4.3)
       '@ai-sdk/openai': 3.0.71(zod@4.4.3)
       '@cacheable/net': 2.0.8
-      ai: 6.0.203(zod@4.4.3)
+      ai: 6.0.208(zod@4.4.3)
       colorette: 2.0.20
       ecto: 4.8.7(@types/react@19.2.17)
       hashery: 2.0.0
@@ -15899,7 +15866,7 @@ snapshots:
 
   writr@6.1.2(@types/react@19.2.17):
     dependencies:
-      ai: 6.0.203(zod@4.4.3)
+      ai: 6.0.208(zod@4.4.3)
       cacheable: 2.3.5
       hashery: 2.0.0
       hookified: 2.2.0


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — gives the agent its tools and lets a model decide which to use. Follow-up to #67, addressing two review findings from that PR.

### Background

#67 made the agent read follow-ups in context, but reviewers found the deterministic, verb-matching approach misrouted real questions:

1. In an FAQ conversation, **"How do I create an invoice?"** routed to the *add-an-FAQ* prompt because it contains "create", instead of being answered from the knowledge base.
2. FAQ context set only by an **assistant's** knowledge answer (e.g. answering "what's our best price?" by citing a FAQ) was ignored — `recentTopic` looked at user turns only.

When asked how to resolve it, the direction was: *let the agent have all the tools and make the right decision itself.*

### What this does

Adds **`decide.ts`** — a model-backed router. Every turn, given the whole conversation, the model picks **which of the agent's tools the message calls for** (company facts, knowledge-base browse / search / answer, FAQ add / update) and returns the same `Intent` the assistant already executes. Because the model reasons over the full transcript and distinguishes a *question* from a *command*, both review issues are fixed at the source:

- "How do I create an invoice?" → `faq_answer` (answered from the KB), not a create.
- Context from an assistant's cited answer is available to the model directly.

The model **only routes** — it returns a structured action; the user-facing reply is still composed by the existing small, pure functions. It's the single seam the README always pointed at for going model-backed.

### Safe by default

- Reuses `@rivus/api`'s injectable `generateObject` pattern, so routing is **unit-tested with a fake model and no network**.
- With **no `ANTHROPIC_API_KEY`** — or if a model call throws — routing degrades to the rule-based parser (`intent.ts`), so the agent boots and its tests run with no model.
- The rule-based fallback is **also hardened** for the same two review points: FAQ *creation* is no longer inferred from context (it requires explicit phrasing), and FAQ context is now read from the agent's own knowledge-base replies too.

### Config

New, both optional: `ANTHROPIC_API_KEY` (secret — turns on model routing) and `ANTHROPIC_MODEL` (var, default `claude-haiku-4-5` — small/fast, it only picks an action). Documented in the README and `wrangler.jsonc`.

### Verification

`pnpm lint && pnpm type-check && pnpm test` all pass (agent 165 tests, incl. a new `decide.test.ts`; api/app/website unchanged and green). `wrangler deploy --dry-run` bundles the Worker with the AI SDK (426 KiB gzipped). Coverage stays above the package's 90/80 thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKqkpJKFzJRQvYteZh4KT3)_