### PR TITLE
feat(app): show "New job" label on Schedule button in desktop view

### DIFF
--- a/packages/app/app/schedule.tsx
+++ b/packages/app/app/schedule.tsx
@@ -471,15 +471,26 @@ export default function ScheduleScreen() {
 								</Pressable>
 							</View>
 						) : null}
-						<Pressable
-							style={styles.addBtn}
-							onPress={() => openCreate(localDateKey(view === 'list' ? today : anchor), 540)}
-							accessibilityRole="button"
-							accessibilityLabel="New job"
-							hitSlop={NAV_HIT_SLOP}
-						>
-							<GradientMark size={36} radius={radii.md} icon="plus" iconSize={20} />
-						</Pressable>
+						{narrow ? (
+							// Mobile: the title row is tight, so use the compact icon-only button.
+							<Pressable
+								style={styles.addBtn}
+								onPress={() => openCreate(localDateKey(view === 'list' ? today : anchor), 540)}
+								accessibilityRole="button"
+								accessibilityLabel="New job"
+								hitSlop={NAV_HIT_SLOP}
+							>
+								<GradientMark size={36} radius={radii.md} icon="plus" iconSize={20} />
+							</Pressable>
+						) : (
+							// Desktop: there's room for the full labelled button.
+							<GradientButton
+								label="New job"
+								icon="plus"
+								onPress={() => openCreate(localDateKey(view === 'list' ? today : anchor), 540)}
+								style={styles.addBtn}
+							/>
+						)}
 					</View>
 					<Txt style={styles.rangeLabel}>{view === 'list' ? 'Next 30 days' : rangeLabel}</Txt>
 				</View>

--- a/packages/app/app/schedule.tsx
+++ b/packages/app/app/schedule.tsx
@@ -445,32 +445,36 @@ export default function ScheduleScreen() {
 			<View style={[styles.header, narrow && styles.headerNarrow]}>
 				<View style={styles.headerLeft}>
 					<View style={styles.titleRow}>
-						<Txt style={styles.title}>Schedule</Txt>
-						{view !== 'list' ? (
-							<View style={styles.dateNav}>
-								<Pressable
-									style={styles.navBtn}
-									onPress={() => setAnchor((current) => addDays(current, -navStep))}
-									accessibilityRole="button"
-									accessibilityLabel="Previous"
-									hitSlop={NAV_HIT_SLOP}
-								>
-									<Icon name="chevron-left" size={16} color={colors.textSub} />
-								</Pressable>
-								<Pressable style={styles.todayBtn} onPress={() => setAnchor(today)}>
-									<Txt style={styles.todayBtnTxt}>Today</Txt>
-								</Pressable>
-								<Pressable
-									style={styles.navBtn}
-									onPress={() => setAnchor((current) => addDays(current, navStep))}
-									accessibilityRole="button"
-									accessibilityLabel="Next"
-									hitSlop={NAV_HIT_SLOP}
-								>
-									<Icon name="chevron-right" size={16} color={colors.textSub} />
-								</Pressable>
-							</View>
-						) : null}
+						{/* Keep the title and date nav together so the action button to their
+						    right is never split off or pushed to its own line. */}
+						<View style={styles.titleGroup}>
+							<Txt style={styles.title}>Schedule</Txt>
+							{view !== 'list' ? (
+								<View style={styles.dateNav}>
+									<Pressable
+										style={styles.navBtn}
+										onPress={() => setAnchor((current) => addDays(current, -navStep))}
+										accessibilityRole="button"
+										accessibilityLabel="Previous"
+										hitSlop={NAV_HIT_SLOP}
+									>
+										<Icon name="chevron-left" size={16} color={colors.textSub} />
+									</Pressable>
+									<Pressable style={styles.todayBtn} onPress={() => setAnchor(today)}>
+										<Txt style={styles.todayBtnTxt}>Today</Txt>
+									</Pressable>
+									<Pressable
+										style={styles.navBtn}
+										onPress={() => setAnchor((current) => addDays(current, navStep))}
+										accessibilityRole="button"
+										accessibilityLabel="Next"
+										hitSlop={NAV_HIT_SLOP}
+									>
+										<Icon name="chevron-right" size={16} color={colors.textSub} />
+									</Pressable>
+								</View>
+							) : null}
+						</View>
 						{narrow ? (
 							// Mobile: the title row is tight, so use the compact icon-only button.
 							<Pressable
@@ -984,10 +988,19 @@ const styles = StyleSheet.create({
 	// full width so `headerRight` wraps its children instead of overflowing.
 	headerNarrow: { flexDirection: 'column', alignItems: 'stretch', gap: 14 },
 	headerLeft: { gap: 8 },
-	// Title, date nav and the create button share one row; the range label sits on
+	// The title group and the create button share one row; the range label sits on
 	// its own line beneath. On mobile the row stretches full width so the button
 	// lands at the far right of the title/nav row.
 	titleRow: { flexDirection: 'row', alignItems: 'center', gap: 16, flexWrap: 'wrap' },
+	// Title + date nav stay grouped; the group shrinks/wraps internally on tight
+	// widths so the action button keeps its place beside it instead of dropping.
+	titleGroup: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 16,
+		flexShrink: 1,
+		flexWrap: 'wrap',
+	},
 	title: { fontFamily: font.semibold, fontSize: 20 },
 	// Push the create button to the far right of the title row.
 	addBtn: { marginLeft: 'auto', borderRadius: radii.md },


### PR DESCRIPTION
The Schedule header's create-job button rendered as an icon-only gradient "+" mark on every viewport. On desktop there's room for the full labelled action, so it now renders the `GradientButton` ("+" with **New job** text) when the layout isn't narrow — matching the dashboard's primary action. The compact icon-only button is kept on mobile, where the title row is already tight (consistent with the existing `narrow` header handling).

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
  - This is a presentation-only, responsive rendering tweak that reuses the existing `GradientButton` component. The `@rivus/app` package currently has no component/render test harness (its tests cover logic, API, and date utilities), so no unit test was added. `pnpm lint`, `pnpm type-check`, and `pnpm test` all pass.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature / UI enhancement — adds the "New job" text label to the Schedule create-job button in desktop view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gqmKnCUk1BNYZDWfNijSX

---
_Generated by [Claude Code](https://claude.ai/code/session_012gqmKnCUk1BNYZDWfNijSX)_