### PR TITLE
feat(api): seed demo notifications

### DIFF
--- a/packages/api/src/seed-data.ts
+++ b/packages/api/src/seed-data.ts
@@ -4,9 +4,11 @@ import {
 	type CreateCustomerInput,
 	type CreateFaqInput,
 	type CreateJobInput,
+	type CreateNotificationInput,
 	createCustomerSchema,
 	createFaqSchema,
 	createJobSchema,
+	createNotificationSchema,
 	type JobStatus,
 } from '@rivus/core';
 
@@ -406,6 +408,105 @@ export function generateAppointments(options: GenerateAppointmentsOptions): Crea
 	);
 }
 
+// --- Notifications -----------------------------------------------------------
+
+// A demo account's bell should look lived-in: a handful of the per-user
+// notifications the app mints from real events (a job assigned, an invite
+// accepted, a role change), plus the occasional system message. These are
+// generic UI demo content — not business-specific — so they're always built
+// deterministically here rather than via the AI generator. `seed.ts` addresses
+// them to the account's members and marks a subset read.
+
+/** Default per-member notification count is a value in this (inclusive) range. */
+export const SEED_NOTIFICATION_MIN = 4;
+export const SEED_NOTIFICATION_MAX = 8;
+
+/** Short system/announcement messages, sampled for the `system` notifications. */
+const NOTIFICATION_SYSTEM_MESSAGES: ReadonlyArray<{ title: string; body: string }> = [
+	{ title: 'Welcome to Rivus', body: 'Your AI assistant is set up and ready to help.' },
+	{ title: 'Tip', body: 'Rivus can answer customer questions from your knowledge base.' },
+	{ title: 'Weekly summary ready', body: 'See how your team did this week on the dashboard.' },
+	{ title: 'New feature', body: 'You can now reschedule jobs directly from the calendar.' },
+] as const;
+
+/**
+ * The notification templates the demo seed draws from. Each fills in incidental
+ * detail with faker and validates through {@link createNotificationSchema} — the
+ * same schema the API applies — so a seeded row is indistinguishable from one
+ * the {@link NotificationService} mints. The `linkHref` matches the in-app route
+ * the live notification deep-links to.
+ */
+const NOTIFICATION_BUILDERS: ReadonlyArray<() => CreateNotificationInput> = [
+	() =>
+		createNotificationSchema.parse({
+			type: 'job_assigned',
+			title: 'New job assigned to you',
+			body: faker.helpers.arrayElement(APPOINTMENT_TITLES),
+			linkHref: '/schedule',
+		}),
+	() =>
+		createNotificationSchema.parse({
+			type: 'job_updated',
+			title: 'A job was rescheduled',
+			body: faker.helpers.arrayElement(APPOINTMENT_TITLES),
+			linkHref: '/schedule',
+		}),
+	() =>
+		createNotificationSchema.parse({
+			type: 'job_canceled',
+			title: 'A job was canceled',
+			body: faker.helpers.arrayElement(APPOINTMENT_TITLES),
+			linkHref: '/schedule',
+		}),
+	() =>
+		createNotificationSchema.parse({
+			type: 'invite_accepted',
+			title: 'Invitation accepted',
+			body: `${faker.person.firstName()} joined the team.`,
+			linkHref: '/team',
+		}),
+	() =>
+		createNotificationSchema.parse({
+			type: 'role_changed',
+			title: 'Your role changed',
+			body: `You're now ${faker.helpers.arrayElement(['an Owner', 'a Manager', 'a Member'])}.`,
+			linkHref: '/team',
+		}),
+	() => {
+		const message = faker.helpers.arrayElement(NOTIFICATION_SYSTEM_MESSAGES);
+		return createNotificationSchema.parse({
+			type: 'system',
+			title: message.title,
+			body: message.body,
+			linkHref: '',
+		});
+	},
+];
+
+/**
+ * Generate `count` validated notifications for one recipient. Templates are
+ * rotated (from a faker-chosen starting offset) so even a small batch shows a
+ * spread of types while staying reproducible under a fixed `faker.seed`. Seed
+ * faker beforehand for a deterministic batch.
+ */
+export function generateNotifications(count: number): CreateNotificationInput[] {
+	const total = Math.max(0, count);
+	if (total === 0) {
+		return [];
+	}
+	const offset = faker.number.int({ min: 0, max: NOTIFICATION_BUILDERS.length - 1 });
+	const notifications: CreateNotificationInput[] = [];
+	for (let index = 0; index < total; index += 1) {
+		// The modulo always lands in range; the guard only satisfies the
+		// noUncheckedIndexedAccess type (the undefined branch never runs).
+		const build = NOTIFICATION_BUILDERS[(offset + index) % NOTIFICATION_BUILDERS.length];
+		if (build) {
+			notifications.push(build());
+		}
+	}
+	return notifications;
+}
+
 // --- CLI ---------------------------------------------------------------------
 
 /** Validated options parsed from the seed command line. */
@@ -418,6 +519,8 @@ export interface SeedOptions {
 	faqs?: number;
 	/** Number of appointments to create; `undefined` means "use the default range". */
 	appointments?: number;
+	/** Notifications to create per member; `undefined` means "use the default range". */
+	notifications?: number;
 	/** Whether to use AI generation (when a provider key is set). `--no-ai` clears it. */
 	ai: boolean;
 	/** Optional faker seed for a reproducible batch. */
@@ -453,6 +556,9 @@ Options:
   -p, --appointments <n>      How many appointments (scheduled jobs) to create.
                               Default: a random count in [${SEED_APPOINTMENT_MIN}, ${SEED_APPOINTMENT_MAX}].
                               Pass 0 to skip appointments.
+  -n, --notifications <n>     How many notifications to create per member.
+                              Default: a random count in [${SEED_NOTIFICATION_MIN}, ${SEED_NOTIFICATION_MAX}].
+                              Pass 0 to skip notifications.
       --no-ai                 Force built-in faker/curated generation even when a
                               provider key is set.
   -s, --seed <n>              Seed the random generator for a reproducible batch.
@@ -466,7 +572,7 @@ Environment:
 
 Examples:
   pnpm --filter @rivus/api seed --account acme-co
-  pnpm --filter @rivus/api seed -a acme-co -c 25 -f 12 -p 20
+  pnpm --filter @rivus/api seed -a acme-co -c 25 -f 12 -p 20 -n 6
   pnpm --filter @rivus/api seed -a acme-co --no-ai --seed 42
   pnpm --filter @rivus/api seed -a 665f1e... --customers 0   # FAQs + appointments only
 `;
@@ -494,6 +600,7 @@ export function parseSeedArgs(argv: string[]): SeedOptions {
 		customers?: string;
 		faqs?: string;
 		appointments?: string;
+		notifications?: string;
 		'no-ai'?: boolean;
 		seed?: string;
 		'dry-run'?: boolean;
@@ -508,6 +615,7 @@ export function parseSeedArgs(argv: string[]): SeedOptions {
 				customers: { type: 'string', short: 'c' },
 				faqs: { type: 'string', short: 'f' },
 				appointments: { type: 'string', short: 'p' },
+				notifications: { type: 'string', short: 'n' },
 				'no-ai': { type: 'boolean', default: false },
 				seed: { type: 'string', short: 's' },
 				'dry-run': { type: 'boolean', default: false },
@@ -522,6 +630,7 @@ export function parseSeedArgs(argv: string[]): SeedOptions {
 		customers: parseCountOption(values.customers, 'customers'),
 		faqs: parseCountOption(values.faqs, 'faqs'),
 		appointments: parseCountOption(values.appointments, 'appointments'),
+		notifications: parseCountOption(values.notifications, 'notifications'),
 		ai: !(values['no-ai'] ?? false),
 		seed: parseCountOption(values.seed, 'seed'),
 		dryRun: values['dry-run'] ?? false,

--- a/packages/api/src/seed.ts
+++ b/packages/api/src/seed.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import type { Account, AccountId } from '@rivus/core';
+import type { Account, AccountId, UserId } from '@rivus/core';
 import { loadConfig } from './config';
 import { connectMongoose, disconnectMongoose } from './db/mongoose';
 import {
@@ -8,12 +8,14 @@ import {
 	MongoFaqRepository,
 	MongoJobRepository,
 	MongoMembershipRepository,
+	MongoNotificationRepository,
 } from './repositories/mongo';
 import type {
 	AccountRepository,
 	CustomerRepository,
 	FaqRepository,
 	JobRepository,
+	NotificationRepository,
 } from './repositories/types';
 import {
 	type BusinessContext,
@@ -22,12 +24,15 @@ import {
 	type SeedGenerator,
 } from './seed-ai';
 import {
+	generateNotifications,
 	parseSeedArgs,
 	SEED_APPOINTMENT_MAX,
 	SEED_APPOINTMENT_MIN,
 	SEED_CUSTOMER_MAX,
 	SEED_CUSTOMER_MIN,
 	SEED_FAQ_DEFAULT,
+	SEED_NOTIFICATION_MAX,
+	SEED_NOTIFICATION_MIN,
 	SEED_USAGE,
 	SeedArgError,
 	type SeedOptions,
@@ -162,6 +167,46 @@ async function seedAppointments(
 	write(`Appointments: created ${inputs.length}${linkNote}.`);
 }
 
+/**
+ * Create `countPerMember` demo notifications for each of the account's members so
+ * their bell looks lived-in, then mark the older half read so the unread badge
+ * shows a realistic subset rather than every row glowing.
+ */
+async function seedNotifications(
+	notifications: NotificationRepository,
+	account: Account,
+	memberIds: string[],
+	countPerMember: number,
+): Promise<void> {
+	if (countPerMember === 0) {
+		write('Notifications: skipped (count 0).');
+		return;
+	}
+	if (memberIds.length === 0) {
+		write('Notifications: skipped (no members to notify).');
+		return;
+	}
+	let created = 0;
+	for (const memberId of memberIds) {
+		const ids = [];
+		for (const input of generateNotifications(countPerMember)) {
+			const notification = await notifications.create(account.id, memberId as UserId, input);
+			ids.push(notification.id);
+		}
+		// The list is newest-first, so marking the first (oldest) half read leaves the
+		// most recent notifications unread — the natural "haven't seen these yet" state.
+		const readCount = Math.floor(ids.length / 2);
+		for (let i = 0; i < readCount; i += 1) {
+			const id = ids[i];
+			if (id) {
+				await notifications.markRead(account.id, memberId as UserId, id);
+			}
+		}
+		created += ids.length;
+	}
+	write(`Notifications: created ${created} across ${memberIds.length} member(s).`);
+}
+
 async function run(options: SeedOptions): Promise<void> {
 	if (options.seed !== undefined) {
 		faker.seed(options.seed);
@@ -180,6 +225,9 @@ async function run(options: SeedOptions): Promise<void> {
 	const appointmentCount =
 		options.appointments ??
 		faker.number.int({ min: SEED_APPOINTMENT_MIN, max: SEED_APPOINTMENT_MAX });
+	const notificationCount =
+		options.notifications ??
+		faker.number.int({ min: SEED_NOTIFICATION_MIN, max: SEED_NOTIFICATION_MAX });
 
 	await connectMongoose(config.MONGODB_URI);
 	try {
@@ -213,6 +261,7 @@ async function run(options: SeedOptions): Promise<void> {
 			write(`Customers: would create ${customerCount}.`);
 			write(`FAQs: would create up to ${faqCount} (new questions only).`);
 			write(`Appointments: would create ${appointmentCount}.`);
+			write(`Notifications: would create ${notificationCount} per member.`);
 			write('Dry run complete — no AI calls, nothing written.');
 			return;
 		}
@@ -251,6 +300,12 @@ async function run(options: SeedOptions): Promise<void> {
 			appointmentCount,
 			customerIds,
 			memberIds,
+		);
+		await seedNotifications(
+			new MongoNotificationRepository(),
+			account,
+			memberIds,
+			notificationCount,
 		);
 
 		write('Seeding complete.');

--- a/packages/api/test/seed-data.test.ts
+++ b/packages/api/test/seed-data.test.ts
@@ -1,11 +1,17 @@
 import { faker } from '@faker-js/faker';
-import { createCustomerSchema, createFaqSchema, createJobSchema } from '@rivus/core';
+import {
+	createCustomerSchema,
+	createFaqSchema,
+	createJobSchema,
+	createNotificationSchema,
+} from '@rivus/core';
 import { describe, expect, it } from 'vitest';
 import {
 	buildAppointment,
 	FAQ_SEEDS,
 	generateAppointments,
 	generateCustomers,
+	generateNotifications,
 	normalizeFaqQuestion,
 	parseSeedArgs,
 	pickFaqSeeds,
@@ -13,6 +19,8 @@ import {
 	SEED_APPOINTMENT_MIN,
 	SEED_CUSTOMER_MAX,
 	SEED_CUSTOMER_MIN,
+	SEED_NOTIFICATION_MAX,
+	SEED_NOTIFICATION_MIN,
 	SeedArgError,
 	selectNewFaqs,
 } from '../src/seed-data';
@@ -28,6 +36,8 @@ describe('parseSeedArgs', () => {
 			'12',
 			'--appointments',
 			'20',
+			'--notifications',
+			'6',
 			'--seed',
 			'7',
 			'--dry-run',
@@ -37,6 +47,7 @@ describe('parseSeedArgs', () => {
 			customers: 25,
 			faqs: 12,
 			appointments: 20,
+			notifications: 6,
 			ai: true,
 			seed: 7,
 			dryRun: true,
@@ -45,11 +56,25 @@ describe('parseSeedArgs', () => {
 	});
 
 	it('supports short flags', () => {
-		const options = parseSeedArgs(['-a', 'acme-co', '-c', '30', '-f', '10', '-p', '15', '-s', '1']);
+		const options = parseSeedArgs([
+			'-a',
+			'acme-co',
+			'-c',
+			'30',
+			'-f',
+			'10',
+			'-p',
+			'15',
+			'-n',
+			'5',
+			'-s',
+			'1',
+		]);
 		expect(options.account).toBe('acme-co');
 		expect(options.customers).toBe(30);
 		expect(options.faqs).toBe(10);
 		expect(options.appointments).toBe(15);
+		expect(options.notifications).toBe(5);
 		expect(options.seed).toBe(1);
 	});
 
@@ -58,6 +83,7 @@ describe('parseSeedArgs', () => {
 		expect(options.customers).toBeUndefined();
 		expect(options.faqs).toBeUndefined();
 		expect(options.appointments).toBeUndefined();
+		expect(options.notifications).toBeUndefined();
 		expect(options.seed).toBeUndefined();
 		expect(options.ai).toBe(true);
 		expect(options.dryRun).toBe(false);
@@ -83,6 +109,7 @@ describe('parseSeedArgs', () => {
 		['non-integer', ['-a', 'x', '-c', '2.5']],
 		['not a number', ['-a', 'x', '-f', 'lots']],
 		['bad appointments', ['-a', 'x', '-p', '-3']],
+		['bad notifications', ['-a', 'x', '-n', '-2']],
 	])('throws SeedArgError on a %s count', (_label, argv) => {
 		expect(() => parseSeedArgs(argv)).toThrow(SeedArgError);
 	});
@@ -239,6 +266,58 @@ describe('generateAppointments', () => {
 	it('keeps the default range sane', () => {
 		expect(SEED_APPOINTMENT_MIN).toBeLessThanOrEqual(SEED_APPOINTMENT_MAX);
 		expect(SEED_APPOINTMENT_MIN).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe('generateNotifications', () => {
+	it('generates exactly the requested number of notifications', () => {
+		expect(generateNotifications(6)).toHaveLength(6);
+		expect(generateNotifications(0)).toHaveLength(0);
+		// A negative count is clamped to an empty batch rather than throwing.
+		expect(generateNotifications(-3)).toHaveLength(0);
+	});
+
+	it('produces notifications that satisfy the API create schema', () => {
+		faker.seed(7);
+		for (const notification of generateNotifications(40)) {
+			// Re-validating through the schema throws (failing the test) if a template
+			// ever drifts outside the bounds the API enforces.
+			expect(() => createNotificationSchema.parse(notification)).not.toThrow();
+			expect(notification.title.length).toBeGreaterThan(0);
+			expect(notification.title.length).toBeLessThanOrEqual(200);
+			expect(notification.body.length).toBeLessThanOrEqual(2000);
+			expect(notification.linkHref.length).toBeLessThanOrEqual(512);
+		}
+	});
+
+	it('spans every notification type across a full rotation', () => {
+		faker.seed(1);
+		// A batch at least as large as the template set hits every template, since the
+		// generator rotates through them from its starting offset.
+		const types = new Set(generateNotifications(24).map((notification) => notification.type));
+		expect(types).toEqual(
+			new Set([
+				'job_assigned',
+				'job_updated',
+				'job_canceled',
+				'invite_accepted',
+				'role_changed',
+				'system',
+			]),
+		);
+	});
+
+	it('is reproducible for a fixed faker seed', () => {
+		faker.seed(404);
+		const first = generateNotifications(8);
+		faker.seed(404);
+		const second = generateNotifications(8);
+		expect(first).toEqual(second);
+	});
+
+	it('keeps the default range sane', () => {
+		expect(SEED_NOTIFICATION_MIN).toBeLessThanOrEqual(SEED_NOTIFICATION_MAX);
+		expect(SEED_NOTIFICATION_MIN).toBeGreaterThanOrEqual(1);
 	});
 });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — extends the seed script to populate the notification bell, so a freshly seeded demo account looks lived-in instead of showing an empty bell.

---

## Summary

Follow-up to the notification feature (#75). Notifications are minted by domain events at runtime, so a brand-new seeded account has an empty bell. This adds demo notifications to the seeder, scoped per member (since notifications are per-user).

## `seed-data.ts` (pure builders, unit-tested)
- `generateNotifications(count)` — rotates through realistic per-type templates (`job_assigned`, `job_updated`, `job_canceled`, `invite_accepted`, `role_changed`, `system`), filling incidental detail with faker and validating each through `createNotificationSchema`, so a seeded row is indistinguishable from one the `NotificationService` mints. Rotation (from a faker-chosen offset) means even a small batch shows a spread of types, and it stays reproducible under a fixed `faker.seed`.
- `SEED_NOTIFICATION_MIN/MAX` default range and a new `-n, --notifications <n>` CLI flag (count is **per member**; `0` skips).

## `seed.ts` (Mongo wrapper)
- A `seedNotifications` step writes the generated notifications to each of the account's members via `MongoNotificationRepository`, then **marks the older half read** so the unread badge shows a realistic subset rather than every row glowing. Reported in the run summary and the `--dry-run` plan.

## Usage
```bash
pnpm --filter @rivus/api seed -a acme-co            # ~4–8 notifications per member
pnpm --filter @rivus/api seed -a acme-co -n 6       # exactly 6 per member
pnpm --filter @rivus/api seed -a acme-co -n 0       # skip notifications
```

## Testing
`pnpm lint && pnpm type-check && pnpm test` all pass (809 tests across packages; API 346). New tests cover the builder (count clamping, schema validity, every type across a rotation, reproducibility) and the `--notifications`/`-n` flag parsing. `seed-data.ts` stays at 100% statements/functions/lines; `seed.ts` is coverage-excluded like the other seed wrappers. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012RW2o2TB2VaU9H7M72JkiC)_