### PR TITLE
feat: semantic FAQ-question routing + embedding retrieval for large knowledge bases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,13 @@ APP_URL=https://app.rivus.ai
 # XAI_MODEL=grok-4-fast
 # ANTHROPIC_API_KEY=sk-ant-...
 # ANTHROPIC_MODEL=claude-haiku-4-5
+# Embedding model for semantic FAQ retrieval. Once an account's knowledge base grows
+# past the answerer's candidate cap, the question and FAQs are embedded and the most
+# *relevant* FAQs (not just the newest) are sent to the model. Query and FAQs must use
+# the same model, so retrieval uses one provider: OpenAI when its key is set, else
+# Google. Without either key, the answerer keeps its newest-first behavior.
+# OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+# GOOGLE_EMBEDDING_MODEL=text-embedding-004
 
 # --- @rivus/website -----------------------------------------------------------
 # Base URL the marketing site uses to reach the API.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -104,18 +104,21 @@ secret exists), the **production** `deploy-api` job **fails fast** if either
 `PROD_MONGODB_URI` or `PROD_JWT_SECRET` is missing — the container always boots
 with `NODE_ENV=production` and would crash-loop without them.
 
-### Optional secrets (AI duplicate-FAQ detection)
+### Optional secrets (AI knowledge-base features)
 
 | Secret                 | Environment | Notes                                                     |
 | ---------------------- | ----------- | --------------------------------------------------------- |
-| `DEV_OPENAI_API_KEY`   | development | OpenAI key for the knowledge-base duplicate check. Pushed as the `OPENAI_API_KEY` Worker secret by `deploy-api`. |
+| `DEV_OPENAI_API_KEY`   | development | OpenAI key for the knowledge-base AI features (duplicate check, question answering, and embedding retrieval). Pushed as the `OPENAI_API_KEY` Worker secret by `deploy-api`. |
 | `PROD_OPENAI_API_KEY`  | production  | Same, for production. |
 
 These are **optional**: the `deploy-api` job pushes `OPENAI_API_KEY` only when the
-secret is set, and when no key is present the "is this a duplicate?" check simply
-no-ops (FAQs are still created normally). The model defaults to `gpt-5.4-mini`; since
-the model id isn't sensitive, override it — if needed — by adding `OPENAI_MODEL` to
-the relevant environment's `vars` in `packages/api/wrangler.jsonc` rather than as a secret.
+secret is set. With no key, the "is this a duplicate?" check no-ops (FAQs are still
+created normally) and question-answering degrades to a deterministic keyword match.
+The chat model defaults to `gpt-5.4-mini` and the embedding model (used to rank FAQs
+by relevance once a knowledge base outgrows the answerer's candidate cap) to
+`text-embedding-3-small`; since model ids aren't sensitive, override them — if needed —
+by adding `OPENAI_MODEL` / `OPENAI_EMBEDDING_MODEL` to the relevant environment's
+`vars` in `packages/api/wrangler.jsonc` rather than as secrets.
 
 The production API also restricts CORS to Rivus origins: `CORS_ORIGIN` is set to
 `https://rivus.ai,*.rivus.ai`, which the API parses into the exact apex origin

--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -458,7 +458,31 @@ describe('respond — knowledge base reads', () => {
 		expect(reply).toMatch(/knowledge base is empty/i);
 	});
 
-	it('searches and ranks by relevance', async () => {
+	it('answers a knowledge-base question semantically and cites the FAQ', async () => {
+		// "what does the knowledge base say about our best price?" mentions the KB, so it
+		// parses as faq_search — but it's a question, so the agent tries the grounded AI
+		// answer first (which connects "best price" to a differently-worded cost FAQ)
+		// rather than the keyword list.
+		const reply = await ask('what does the knowledge base say about our best price?', {
+			token: TOKEN,
+			fetchImpl: router([
+				{
+					when: onAnswerFaq,
+					body: {
+						answered: true,
+						answer: 'Our standard rate is $125 an hour, and $85 on weekends.',
+						sources: [{ id: 'faq_1', question: 'How much does your service cost?' }],
+					},
+				},
+			]),
+		});
+		expect(reply).toContain('$125 an hour');
+		expect(reply).toContain('How much does your service cost?');
+		// It's the grounded answer, not the keyword "here's what I found" list.
+		expect(reply).not.toMatch(/here’s what i found/i);
+	});
+
+	it('falls back to the keyword list when the question has no grounded answer', async () => {
 		const faqs = [
 			makeFaq({
 				id: 'faq_1',
@@ -469,14 +493,53 @@ describe('respond — knowledge base reads', () => {
 		];
 		const reply = await ask('search the FAQ for refund', {
 			token: TOKEN,
-			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+			fetchImpl: router([
+				{ when: onAnswerFaq, body: noAnswer },
+				{ when: onListFaqs, body: page(faqs) },
+			]),
 		});
 		expect(reply).toMatch(/found about “refund”/i);
 		expect(reply).toContain('What is your refund policy?');
 		expect(reply).not.toContain('Where are you located?');
 	});
 
+	it('keeps an existence check on the list instead of a synthesized answer', async () => {
+		// "do we have an FAQ about X?" asks *whether* one exists; the matching list is the
+		// better reply, so the agent must NOT route it through the AI answer endpoint.
+		const faqs = [
+			makeFaq({ question: 'What is your refund policy?', answer: 'Refunds in 30 days.' }),
+		];
+		const reply = await ask('do we have an FAQ about refunds?', {
+			token: TOKEN,
+			fetchImpl: router([
+				// If the existence check wrongly hit the answer endpoint, this would surface.
+				{ when: onAnswerFaq, body: { answered: true, answer: 'SHOULD NOT APPEAR', sources: [] } },
+				{ when: onListFaqs, body: page(faqs) },
+			]),
+		});
+		expect(reply).toMatch(/found about “refunds”/i);
+		expect(reply).toContain('What is your refund policy?');
+		expect(reply).not.toContain('SHOULD NOT APPEAR');
+	});
+
+	it('degrades to the keyword list when the answer call fails', async () => {
+		// A flaky answer endpoint must never break search — it falls back to the keyword
+		// scan, which still surfaces the matching FAQ.
+		const faqs = [
+			makeFaq({ question: 'What is your refund policy?', answer: 'Refunds in 30 days.' }),
+		];
+		const reply = await ask('search the FAQ for refund', {
+			token: TOKEN,
+			fetchImpl: router([
+				{ when: onAnswerFaq, body: { message: 'boom' }, status: 500 },
+				{ when: onListFaqs, body: page(faqs) },
+			]),
+		});
+		expect(reply).toContain('What is your refund policy?');
+	});
+
 	it('falls back to a substring match for a short query', async () => {
+		// "do we have …" is an existence check, so this goes straight to the keyword list.
 		const faqs = [makeFaq({ question: 'What are your HR policies?', answer: 'See the handbook.' })];
 		const reply = await ask('do we have an faq about hr', {
 			token: TOKEN,
@@ -489,7 +552,10 @@ describe('respond — knowledge base reads', () => {
 		const faqs = [makeFaq({ question: 'Café opening hours?', answer: 'We open at 8am.' })];
 		const reply = await ask('search faqs for café', {
 			token: TOKEN,
-			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+			fetchImpl: router([
+				{ when: onAnswerFaq, body: noAnswer },
+				{ when: onListFaqs, body: page(faqs) },
+			]),
 		});
 		expect(reply).toContain('Café opening hours?');
 	});
@@ -497,7 +563,10 @@ describe('respond — knowledge base reads', () => {
 	it('says when a search finds nothing', async () => {
 		const reply = await ask('search faqs for skydiving', {
 			token: TOKEN,
-			fetchImpl: router([{ when: onListFaqs, body: page([makeFaq()]) }]),
+			fetchImpl: router([
+				{ when: onAnswerFaq, body: noAnswer },
+				{ when: onListFaqs, body: page([makeFaq()]) },
+			]),
 		});
 		expect(reply).toMatch(/couldn’t find anything/i);
 	});
@@ -507,7 +576,10 @@ describe('respond — knowledge base reads', () => {
 		const faqs = [makeFaq({ question: 'Refund policy?', answer: longAnswer })];
 		const reply = await ask('search faqs for refund', {
 			token: TOKEN,
-			fetchImpl: router([{ when: onListFaqs, body: page(faqs) }]),
+			fetchImpl: router([
+				{ when: onAnswerFaq, body: noAnswer },
+				{ when: onListFaqs, body: page(faqs) },
+			]),
 		});
 		expect(reply).toContain('…');
 		expect(reply).not.toContain('END');
@@ -669,6 +741,7 @@ describe('respond — knowledge base writes', () => {
 		const target = makeFaq({ id: 'target', question: 'What is your refund policy?', answer: 'X.' });
 		const firstPage = page(filler);
 		const fetchImpl = router([
+			{ when: onAnswerFaq, body: noAnswer },
 			{
 				when: (url, method) => method === 'GET' && url.includes('page=1'),
 				body: { data: filler, meta: { ...firstPage.meta, hasNextPage: true } },
@@ -716,9 +789,14 @@ describe('respond — API error handling', () => {
 	});
 
 	it('handles an unexpected API failure (500)', async () => {
+		// The grounded answer comes back empty, so the search falls to the keyword scan —
+		// whose list call fails, surfacing the generic data-unreachable message.
 		const reply = await ask('search faqs for refund', {
 			token: TOKEN,
-			fetchImpl: router([{ when: onListFaqs, body: { message: 'boom' }, status: 500 }]),
+			fetchImpl: router([
+				{ when: onAnswerFaq, body: noAnswer },
+				{ when: onListFaqs, body: { message: 'boom' }, status: 500 },
+			]),
 		});
 		expect(reply).toMatch(/couldn’t reach your Rivus data/i);
 	});

--- a/packages/agent/src/assistant.ts
+++ b/packages/agent/src/assistant.ts
@@ -112,7 +112,7 @@ export async function respond(deps: RespondDeps): Promise<string> {
 			case 'faq_list':
 				return await faqListReply(api);
 			case 'faq_search':
-				return await faqSearchReply(api, intent.query);
+				return await faqSearchReply(api, intent, question);
 			case 'faq_update':
 				return await faqUpdateReply(api, intent);
 			case 'faq_create':
@@ -176,11 +176,16 @@ async function knowledgeAnswerReply(
 	if (!answered || text === '') {
 		return unknownReply(claims);
 	}
+	return formatGroundedAnswer(text, sources);
+}
+
+/** Present a grounded answer, citing the source FAQ so the user sees where it came from. */
+function formatGroundedAnswer(
+	answer: string,
+	sources: ReadonlyArray<{ question: string }>,
+): string {
 	const [source] = sources;
-	if (source) {
-		return `${text}\n\n(From your FAQ “${source.question}”.)`;
-	}
-	return text;
+	return source ? `${answer}\n\n(From your FAQ “${source.question}”.)` : answer;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -302,18 +307,53 @@ async function faqListReply(api: RivusApiClient): Promise<string> {
 	return lines.join('\n');
 }
 
-async function faqSearchReply(api: RivusApiClient, query: string): Promise<string> {
+/**
+ * Reply to a knowledge-base search. A *question* about the knowledge base ("what
+ * does the FAQ say about our best price?") is best served by a grounded AI answer —
+ * keyword search alone can't connect "best price" to a differently-worded "cost"
+ * FAQ. So unless the ask is an existence check, we try the AI answer first and fall
+ * back to the keyword list when the knowledge base has no grounded answer (or the
+ * answer call fails). Existence checks ("do we have an FAQ about X?") skip straight
+ * to the list, where the matching FAQ titles are the better reply.
+ */
+async function faqSearchReply(
+	api: RivusApiClient,
+	intent: Extract<Intent, { kind: 'faq_search' }>,
+	rawQuestion: string,
+): Promise<string> {
+	if (!intent.existence) {
+		const grounded = await groundedSearchAnswer(api, rawQuestion);
+		if (grounded) {
+			return grounded;
+		}
+	}
 	const { faqs, complete } = await scanFaqs(api);
 	if (faqs.length === 0) {
 		return EMPTY_KB;
 	}
-	const ranked = rankFaqs(faqs, query);
+	const ranked = rankFaqs(faqs, intent.query);
 	if (ranked.length === 0) {
 		const scope = complete ? 'your knowledge base' : `the ${faqs.length} most recent FAQs`;
-		return `I couldn’t find anything in ${scope} about “${query}”. Try different wording, or ask me to list all your FAQs.`;
+		return `I couldn’t find anything in ${scope} about “${intent.query}”. Try different wording, or ask me to list all your FAQs.`;
 	}
 	const lines = ranked.slice(0, 3).map((faq) => `• ${faq.question}\n  ${snippet(faq.answer)}`);
-	return [`Here’s what I found about “${query}”:`, ...lines].join('\n');
+	return [`Here’s what I found about “${intent.query}”:`, ...lines].join('\n');
+}
+
+/**
+ * Try to answer `question` from the knowledge base, returning the formatted, cited
+ * answer — or null when the knowledge base doesn't cover it, the answer is blank, or
+ * the answer call fails. A failure returns null (not an error) so the caller falls
+ * back to the keyword list rather than breaking the search.
+ */
+async function groundedSearchAnswer(api: RivusApiClient, question: string): Promise<string | null> {
+	try {
+		const { answered, answer, sources } = await api.answerFromKnowledge({ question });
+		const text = answer.trim();
+		return answered && text !== '' ? formatGroundedAnswer(text, sources) : null;
+	} catch {
+		return null;
+	}
 }
 
 async function faqUpdateReply(

--- a/packages/agent/src/decide.test.ts
+++ b/packages/agent/src/decide.test.ts
@@ -50,6 +50,7 @@ describe('decisionToIntent', () => {
 		expect(decisionToIntent(decision({ action: 'faq_search', query: 'refunds' }), '')).toEqual({
 			kind: 'faq_search',
 			query: 'refunds',
+			existence: false,
 		});
 		expect(
 			decisionToIntent(decision({ action: 'faq_update', topic: 'returns', answer: '30 days' }), ''),
@@ -67,6 +68,17 @@ describe('decisionToIntent', () => {
 		expect(decisionToIntent(decision({ action: 'faq_search', query: '   ' }), '')).toEqual({
 			kind: 'faq_list',
 		});
+	});
+
+	it('flags an existence-check faq_search from the raw user turn', () => {
+		// The model routes "do we have an FAQ about X?" to faq_search; reading the raw turn
+		// marks it as an existence check so the assistant keeps it on the list path.
+		expect(
+			decisionToIntent(
+				decision({ action: 'faq_search', query: 'parking' }),
+				'do we have an FAQ about parking?',
+			),
+		).toEqual({ kind: 'faq_search', query: 'parking', existence: true });
 	});
 
 	it('drops an answer with no question so a create never breaks schema validation', () => {

--- a/packages/agent/src/decide.ts
+++ b/packages/agent/src/decide.ts
@@ -2,7 +2,7 @@ import { createAnthropic } from '@ai-sdk/anthropic';
 import { generateObject, type LanguageModel } from 'ai';
 import { z } from 'zod';
 import { lastUserMessage } from './conversation';
-import { type CompanyField, type Intent, resolveIntent } from './intent';
+import { type CompanyField, type Intent, isExistenceCheck, resolveIntent } from './intent';
 import type { ChatMessage, Env } from './types';
 
 /**
@@ -163,9 +163,15 @@ export function decisionToIntent(decision: AgentDecision, latestUserText: string
 		case 'faq_list':
 			return { kind: 'faq_list' };
 		case 'faq_search':
-			// A search with no subject is really just "show me the FAQs".
+			// A search with no subject is really just "show me the FAQs". Existence-check
+			// phrasing ("do we have an FAQ about X?") is read from the raw turn so it stays
+			// on the list path even when the model routes it here.
 			return decision.query.trim().length > 0
-				? { kind: 'faq_search', query: decision.query.trim() }
+				? {
+						kind: 'faq_search',
+						query: decision.query.trim(),
+						existence: isExistenceCheck(latestUserText),
+					}
 				: { kind: 'faq_list' };
 		case 'faq_answer': {
 			// Fall back to the raw user text when the model didn't restate the question.

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -78,14 +78,32 @@ describe('parseIntent — knowledge base', () => {
 		expect(parseIntent('search the FAQ for refunds')).toEqual({
 			kind: 'faq_search',
 			query: 'refunds',
-		});
-		expect(parseIntent('do we have an FAQ about parking?')).toEqual({
-			kind: 'faq_search',
-			query: 'parking',
+			existence: false,
 		});
 		expect(parseIntent('find FAQs about pricing')).toEqual({
 			kind: 'faq_search',
 			query: 'pricing',
+			existence: false,
+		});
+	});
+
+	it('flags existence-check phrasing so the assistant prefers a list', () => {
+		// "do we have …" / "is there …" / "are there …" ask *whether* an FAQ exists, so
+		// the matching list beats a synthesized answer. The flag carries that distinction.
+		expect(parseIntent('do we have an FAQ about parking?')).toEqual({
+			kind: 'faq_search',
+			query: 'parking',
+			existence: true,
+		});
+		expect(parseIntent('is there an FAQ about refunds?')).toEqual({
+			kind: 'faq_search',
+			query: 'refunds',
+			existence: true,
+		});
+		expect(parseIntent('are there any FAQs about parking?')).toEqual({
+			kind: 'faq_search',
+			query: 'parking',
+			existence: true,
 		});
 	});
 
@@ -165,6 +183,7 @@ describe('parseIntent — knowledge base', () => {
 		expect(parseIntent('knowledge base about onboarding')).toEqual({
 			kind: 'faq_search',
 			query: 'onboarding',
+			existence: false,
 		});
 	});
 });
@@ -301,6 +320,7 @@ describe('parseIntent — conversation context', () => {
 		expect(parseIntent('anything about refunds?', { topic: 'faq' })).toEqual({
 			kind: 'faq_search',
 			query: 'refunds',
+			existence: false,
 		});
 	});
 
@@ -365,7 +385,11 @@ describe('resolveIntent — multi-turn', () => {
 			assistant('Our basic plan is $9/mo.\n\n(From your FAQ “How much does it cost?”.)'),
 			user('anything about refunds?'),
 		];
-		expect(resolveIntent(conversation)).toEqual({ kind: 'faq_search', query: 'refunds' });
+		expect(resolveIntent(conversation)).toEqual({
+			kind: 'faq_search',
+			query: 'refunds',
+			existence: false,
+		});
 	});
 
 	it('leaves a turn that stands on its own untouched', () => {

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -35,8 +35,13 @@ export type Intent =
 	| { kind: 'company_info'; fields: CompanyField[] }
 	/** Browse the whole knowledge base. */
 	| { kind: 'faq_list' }
-	/** Search the knowledge base for `query`. */
-	| { kind: 'faq_search'; query: string }
+	/**
+	 * Search the knowledge base for `query`. `existence` is true for existence-check
+	 * phrasing ("do we have an FAQ about X?", "is there one on Y?"), where a list of
+	 * matching FAQs is the better response than a synthesized answer — the assistant
+	 * uses it to skip the semantic answer path and go straight to the keyword list.
+	 */
+	| { kind: 'faq_search'; query: string; existence: boolean }
 	/** Edit an FAQ identified by `topic`; `answer` is the new text, or null if unsaid. */
 	| { kind: 'faq_update'; topic: string; answer: string | null }
 	/** Add an FAQ; `question`/`answer` are null when the user didn't supply them. */
@@ -87,6 +92,21 @@ const UPDATE_VERB = /\b(update|change|edit|revise|modify|fix)\b/;
 const CREATE_VERB = /\b(add|create|new|make|insert)\b/;
 const LIST_VERB = /\b(list|show|view|see|browse|all (of )?(my|our|the)?)\b/;
 const SEARCH_VERB = /\b(search|find|look ?up|lookup|do we have|is there|tell me about)\b/;
+
+/**
+ * Existence-check / confirmation phrasing — "do we have an FAQ about X?", "is there
+ * one on Y?", "are there any covering Z?". The user wants to know *whether* an FAQ
+ * exists, so the matching list is a better answer than a synthesized one. Used to
+ * flag a {@link Intent} of kind `faq_search` so the assistant keeps these on the
+ * keyword list path instead of trying the AI answer first.
+ */
+const EXISTENCE_CHECK =
+	/\b(do (?:we|you|i) have|do we got|is there|are there|have (?:we|you) got)\b/;
+
+/** True when a message reads as an existence check rather than a question to answer. */
+export function isExistenceCheck(text: string): boolean {
+	return EXISTENCE_CHECK.test(text.toLowerCase());
+}
 
 /** Strip a leading article so an extracted topic reads cleanly. */
 function trimTopic(value: string): string {
@@ -301,7 +321,9 @@ export function parseIntent(raw: string, context: IntentContext = {}): Intent {
 		// Search wins over list when there's an actual subject to search for.
 		if (SEARCH_VERB.test(lower) || afterPreposition(lower)) {
 			const query = extractSearchQuery(text);
-			return query.length > 0 ? { kind: 'faq_search', query } : { kind: 'faq_list' };
+			return query.length > 0
+				? { kind: 'faq_search', query, existence: EXISTENCE_CHECK.test(lower) }
+				: { kind: 'faq_list' };
 		}
 		if (LIST_VERB.test(lower)) {
 			return { kind: 'faq_list' };

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -38,8 +38,15 @@ const envSchema = z
 		// duplicate), so none of these are required and none gate production boot.
 		OPENAI_API_KEY: z.string().min(1).optional(),
 		OPENAI_MODEL: z.string().min(1).default('gpt-5.4-mini'),
+		// Embedding model for semantic FAQ retrieval (used when a knowledge base grows
+		// past the prompt's candidate cap, so the most *relevant* FAQs — not just the
+		// newest — are sent to the model). The query and FAQs must be embedded by the
+		// same model, so retrieval uses a single provider: OpenAI when its key is set,
+		// otherwise Google. Both default to a small, inexpensive model.
+		OPENAI_EMBEDDING_MODEL: z.string().min(1).default('text-embedding-3-small'),
 		GOOGLE_GENERATIVE_AI_API_KEY: z.string().min(1).optional(),
 		GEMINI_MODEL: z.string().min(1).default('gemini-2.5-flash'),
+		GOOGLE_EMBEDDING_MODEL: z.string().min(1).default('text-embedding-004'),
 		XAI_API_KEY: z.string().min(1).optional(),
 		XAI_MODEL: z.string().min(1).default('grok-4-fast'),
 		ANTHROPIC_API_KEY: z.string().min(1).optional(),

--- a/packages/api/src/services/faq-answer.ts
+++ b/packages/api/src/services/faq-answer.ts
@@ -3,7 +3,13 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createXai } from '@ai-sdk/xai';
 import type { Faq, FaqId } from '@rivus/core';
-import { generateObject, type LanguageModel } from 'ai';
+import {
+	cosineSimilarity,
+	type EmbeddingModel,
+	embedMany,
+	generateObject,
+	type LanguageModel,
+} from 'ai';
 import { z } from 'zod';
 import type { Config } from '../config';
 
@@ -24,6 +30,17 @@ const MAX_OUTPUT_TOKENS = 700;
 const MAX_ANSWER_IN_PROMPT = 4000;
 /** Keep the composed answer chat-sized. */
 const MAX_ANSWER_LENGTH = 1200;
+
+// --- Embedding retrieval (for knowledge bases larger than MAX_CANDIDATES) ---
+// Cap the text embedded per FAQ. Embedding models accept far more, but a tight bound
+// keeps cost and latency predictable — an FAQ's question plus the start of its answer
+// carries the topic signal retrieval needs.
+const MAX_EMBED_CHARS = 2000;
+// How many FAQ vectors to keep in the in-process cache. Keyed by id + updatedAt, so an
+// edited FAQ re-embeds on next use and its stale vector ages out. Sized well above any
+// single request's candidate set so one large account can't evict its own vectors
+// mid-rank.
+const VECTOR_CACHE_CAPACITY = 5000;
 
 /** What the model returns when asked to answer from the knowledge base. */
 const answerSchema = z.object({
@@ -56,6 +73,21 @@ export interface FaqAnswerService {
 	 * a model outage degrades to a deterministic keyword match, not an error.
 	 */
 	answer(input: { question: string }, candidates: Faq[]): Promise<FaqAnswer>;
+}
+
+/**
+ * Narrows a candidate set down to the FAQs most relevant to a question before they're
+ * sent to the model. The answer service caps how many FAQs it can prompt with; for a
+ * small business that's the whole knowledge base, but once an account grows past the
+ * cap, picking the newest FAQs can miss the answer if it lives in an older one.
+ * A retriever ranks by *relevance* instead, so the right FAQs survive the cap.
+ */
+export interface FaqRetriever {
+	/**
+	 * Return up to `limit` of `candidates` most relevant to `query`, best first. Never
+	 * throws — an embedding outage degrades to the first `limit` (newest) candidates.
+	 */
+	retrieve(query: string, candidates: Faq[], limit: number): Promise<Faq[]>;
 }
 
 /**
@@ -106,26 +138,30 @@ export class AiFaqAnswerService implements FaqAnswerService {
 	private readonly models: LanguageModel[];
 	private readonly generate: GenerateObjectFn;
 	private readonly logger?: FaqAnswerLogger;
+	private readonly retriever?: FaqRetriever;
 
 	constructor(options: {
 		models: LanguageModel[];
 		generate?: GenerateObjectFn;
 		logger?: FaqAnswerLogger;
+		/**
+		 * Optional semantic retriever. When set and the candidate set is larger than the
+		 * prompt cap, the most *relevant* FAQs are sent to the model instead of the
+		 * newest. When absent, the newest are used (the small-business default).
+		 */
+		retriever?: FaqRetriever;
 	}) {
 		this.models = options.models;
 		this.generate = options.generate ?? defaultGenerateObject;
 		this.logger = options.logger;
+		this.retriever = options.retriever;
 	}
 
 	async answer(input: { question: string }, candidates: Faq[]): Promise<FaqAnswer> {
 		if (candidates.length === 0) {
 			return { answered: false, answer: '', sources: [] };
 		}
-		// Newest-first from the caller; send the most recent so the whole knowledge
-		// base of a small business is considered semantically (no keyword pre-filter,
-		// which would drop matches like "best price" → a "cost" FAQ before the model
-		// ever sees them).
-		const shortlist = candidates.slice(0, MAX_CANDIDATES);
+		const shortlist = await this.shortlist(input.question, candidates);
 		const ids = new Set<string>(shortlist.map((faq) => faq.id));
 		const knowledge = shortlist.map((faq) => ({
 			id: faq.id,
@@ -165,6 +201,20 @@ export class AiFaqAnswerService implements FaqAnswerService {
 		return { answered: true, answer, sources };
 	}
 
+	/**
+	 * Pick the FAQs to ground the answer in. For a small knowledge base (at or under
+	 * the prompt cap) that's all of them, newest-first — the existing behavior, with no
+	 * embedding cost. For a larger one, a configured retriever ranks by relevance so an
+	 * answer living in an older FAQ isn't dropped just for being old; without a
+	 * retriever we keep the newest, exactly as before.
+	 */
+	private async shortlist(question: string, candidates: Faq[]): Promise<Faq[]> {
+		if (!this.retriever || candidates.length <= MAX_CANDIDATES) {
+			return candidates.slice(0, MAX_CANDIDATES);
+		}
+		return this.retriever.retrieve(question, candidates, MAX_CANDIDATES);
+	}
+
 	/** Try each model in turn; return the first success, or null if all fail. */
 	private async generateWithFallback<T>(options: {
 		schema: z.ZodType<T>;
@@ -192,6 +242,149 @@ export class AiFaqAnswerService implements FaqAnswerService {
 			}
 		}
 		return null;
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/* Embedding-based retrieval                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The single embedding call this retriever makes, narrowed to what we use. Injectable
+ * so tests can drive ranking and the cache without a model or the network. Defaults to
+ * the AI SDK's {@link embedMany}.
+ */
+export type EmbedManyFn = (options: {
+	model: EmbeddingModel;
+	values: string[];
+}) => Promise<{ embeddings: number[][] }>;
+
+const defaultEmbedMany: EmbedManyFn = async (options) => {
+	const { embeddings } = await embedMany({ model: options.model, values: options.values });
+	return { embeddings };
+};
+
+/**
+ * A tiny bounded LRU cache for FAQ vectors. Keyed by `${id}:${updatedAt}` so a vector
+ * is reused across answers, but a fresh edit (new `updatedAt`) misses and re-embeds —
+ * the "refresh" half of storing vectors. Capacity-bounded so a long-lived process
+ * can't grow it without limit; the least-recently-used entry is evicted first.
+ */
+class VectorCache {
+	private readonly store = new Map<string, number[]>();
+
+	constructor(private readonly capacity: number) {}
+
+	get(key: string): number[] | undefined {
+		const value = this.store.get(key);
+		if (value !== undefined) {
+			// Re-insert so it counts as most-recently-used.
+			this.store.delete(key);
+			this.store.set(key, value);
+		}
+		return value;
+	}
+
+	set(key: string, value: number[]): void {
+		this.store.delete(key);
+		this.store.set(key, value);
+		if (this.store.size > this.capacity) {
+			const oldest = this.store.keys().next().value;
+			if (oldest !== undefined) {
+				this.store.delete(oldest);
+			}
+		}
+	}
+}
+
+/** The cache key for an FAQ: its id plus the timestamp that changes on every edit. */
+function vectorCacheKey(faq: Faq): string {
+	return `${faq.id}:${faq.updatedAt}`;
+}
+
+/** The text embedded for an FAQ — question, answer, and category carry the topic. */
+function faqEmbeddingText(faq: Faq): string {
+	return snippet(`${faq.question}\n${faq.answer}\n${faq.category}`, MAX_EMBED_CHARS);
+}
+
+/**
+ * Semantic retrieval over a candidate set using text embeddings. The question and each
+ * not-yet-cached FAQ are embedded in a single batch; FAQs are then ranked by cosine
+ * similarity to the question and the top `limit` returned. FAQ vectors are cached
+ * (keyed by id + `updatedAt`) so repeat questions don't re-embed and edits refresh on
+ * their own. Any failure degrades to the newest `limit` candidates — retrieval is an
+ * optimization, never a hard dependency of answering.
+ */
+export class EmbeddingFaqRetriever implements FaqRetriever {
+	private readonly model: EmbeddingModel;
+	private readonly embed: EmbedManyFn;
+	private readonly logger?: FaqAnswerLogger;
+	private readonly cache: VectorCache;
+
+	constructor(options: {
+		model: EmbeddingModel;
+		embed?: EmbedManyFn;
+		logger?: FaqAnswerLogger;
+		cacheCapacity?: number;
+	}) {
+		this.model = options.model;
+		this.embed = options.embed ?? defaultEmbedMany;
+		this.logger = options.logger;
+		this.cache = new VectorCache(options.cacheCapacity ?? VECTOR_CACHE_CAPACITY);
+	}
+
+	async retrieve(query: string, candidates: Faq[], limit: number): Promise<Faq[]> {
+		// Nothing to gain: the model would see them all anyway, so skip embedding.
+		if (candidates.length <= limit) {
+			return candidates.slice(0, limit);
+		}
+		try {
+			// Resolve a vector for every candidate, embedding only cache misses. The query
+			// rides in the same batch (always a miss — questions vary) at index 0.
+			const vectors = new Map<string, number[]>();
+			const misses: Faq[] = [];
+			for (const faq of candidates) {
+				const cached = this.cache.get(vectorCacheKey(faq));
+				if (cached) {
+					vectors.set(faq.id, cached);
+				} else {
+					misses.push(faq);
+				}
+			}
+			const { embeddings } = await this.embed({
+				model: this.model,
+				values: [query, ...misses.map(faqEmbeddingText)],
+			});
+			const queryVector = embeddings[0];
+			if (!queryVector) {
+				return candidates.slice(0, limit);
+			}
+			misses.forEach((faq, index) => {
+				const vector = embeddings[index + 1];
+				if (vector) {
+					this.cache.set(vectorCacheKey(faq), vector);
+					vectors.set(faq.id, vector);
+				}
+			});
+			return candidates
+				.map((faq) => {
+					const vector = vectors.get(faq.id);
+					// A candidate left without a vector (a short embedding batch) sinks below
+					// any scored one, but stays eligible if the limit isn't otherwise filled.
+					const score = vector ? cosineSimilarity(queryVector, vector) : Number.NEGATIVE_INFINITY;
+					return { faq, score };
+				})
+				.sort((a, b) => b.score - a.score)
+				.slice(0, limit)
+				.map((entry) => entry.faq);
+		} catch (error) {
+			// Retrieval is best-effort: log and fall back to the newest candidates so a
+			// flaky embeddings provider degrades to recency rather than failing the answer.
+			this.logger?.warn(
+				`Knowledge-base answer: embedding retrieval failed, using newest FAQs — ${String(error)}`,
+			);
+			return candidates.slice(0, limit);
+		}
 	}
 }
 
@@ -281,19 +474,54 @@ function snippet(text: string, max: number): string {
 }
 
 /**
+ * Build the embedding retriever from config, or undefined when no embeddings provider
+ * is configured (the answer service then keeps its newest-first behavior). The query
+ * and FAQs must be embedded by the same model, so retrieval uses a single provider:
+ * OpenAI when its key is set, otherwise Google. xAI and Anthropic have no first-party
+ * text-embedding model in the AI SDK, so they don't serve retrieval.
+ */
+export function createFaqRetriever(
+	config: Pick<
+		Config,
+		| 'OPENAI_API_KEY'
+		| 'OPENAI_EMBEDDING_MODEL'
+		| 'GOOGLE_GENERATIVE_AI_API_KEY'
+		| 'GOOGLE_EMBEDDING_MODEL'
+	>,
+): FaqRetriever | undefined {
+	if (config.OPENAI_API_KEY) {
+		const model = createOpenAI({ apiKey: config.OPENAI_API_KEY }).textEmbeddingModel(
+			config.OPENAI_EMBEDDING_MODEL,
+		);
+		return new EmbeddingFaqRetriever({ model, logger: console });
+	}
+	if (config.GOOGLE_GENERATIVE_AI_API_KEY) {
+		const model = createGoogleGenerativeAI({
+			apiKey: config.GOOGLE_GENERATIVE_AI_API_KEY,
+		}).textEmbeddingModel(config.GOOGLE_EMBEDDING_MODEL);
+		return new EmbeddingFaqRetriever({ model, logger: console });
+	}
+	return undefined;
+}
+
+/**
  * Build the knowledge-base answering service from config. Reuses the same ordered
  * provider list as the duplicate-FAQ check — OpenAI primary, then Google, xAI, and
- * Anthropic as backups. When no key is set at all, returns a
- * {@link NoopFaqAnswerService} so the feature degrades to deterministic keyword
- * matching and the API still boots.
+ * Anthropic as backups. For accounts whose knowledge base outgrows the prompt cap, an
+ * embedding retriever (when a provider supports embeddings) ranks FAQs by relevance so
+ * the answer isn't missed just because it lives in an older FAQ. When no key is set at
+ * all, returns a {@link NoopFaqAnswerService} so the feature degrades to deterministic
+ * keyword matching and the API still boots.
  */
 export function createFaqAnswerService(
 	config: Pick<
 		Config,
 		| 'OPENAI_API_KEY'
 		| 'OPENAI_MODEL'
+		| 'OPENAI_EMBEDDING_MODEL'
 		| 'GOOGLE_GENERATIVE_AI_API_KEY'
 		| 'GEMINI_MODEL'
+		| 'GOOGLE_EMBEDDING_MODEL'
 		| 'XAI_API_KEY'
 		| 'XAI_MODEL'
 		| 'ANTHROPIC_API_KEY'
@@ -320,5 +548,5 @@ export function createFaqAnswerService(
 	if (models.length === 0) {
 		return new NoopFaqAnswerService();
 	}
-	return new AiFaqAnswerService({ models, logger: console });
+	return new AiFaqAnswerService({ models, logger: console, retriever: createFaqRetriever(config) });
 }

--- a/packages/api/test/faq-answer.test.ts
+++ b/packages/api/test/faq-answer.test.ts
@@ -1,11 +1,15 @@
 import type { AccountId, Faq, FaqId } from '@rivus/core';
-import type { LanguageModel } from 'ai';
+import type { EmbeddingModel, LanguageModel } from 'ai';
 import { describe, expect, it, vi } from 'vitest';
 import {
 	AiFaqAnswerService,
 	createFaqAnswerService,
+	createFaqRetriever,
 	deterministicFaqAnswer,
+	EmbeddingFaqRetriever,
+	type EmbedManyFn,
 	type FaqAnswerService,
+	type FaqRetriever,
 	type GenerateObjectFn,
 	NoopFaqAnswerService,
 } from '../src/services/faq-answer';
@@ -230,7 +234,9 @@ describe('AiFaqAnswerService.answer', () => {
 describe('createFaqAnswerService', () => {
 	const baseConfig = {
 		OPENAI_MODEL: 'gpt-5.4-mini',
+		OPENAI_EMBEDDING_MODEL: 'text-embedding-3-small',
 		GEMINI_MODEL: 'gemini-2.5-flash',
+		GOOGLE_EMBEDDING_MODEL: 'text-embedding-004',
 		XAI_MODEL: 'grok-4-fast',
 		ANTHROPIC_MODEL: 'claude-haiku-4-5',
 	};
@@ -280,5 +286,231 @@ describe('deterministicFaqAnswer / NoopFaqAnswerService', () => {
 			answer: '',
 			sources: [],
 		});
+	});
+});
+
+// EmbeddingModel is a union that includes `string`, so a label stands in for a model;
+// the injected `embed` never resolves it.
+const EMBED_MODEL: EmbeddingModel = 'test-embedding-model';
+
+/** A deterministic stand-in for an embedding model: orthogonal vectors per topic. */
+function vectorFor(text: string): number[] {
+	const t = text.toLowerCase();
+	if (t.includes('pric') || t.includes('cost') || t.includes('rate')) return [1, 0, 0, 0];
+	if (t.includes('hour') || t.includes('open')) return [0, 1, 0, 0];
+	if (t.includes('refund') || t.includes('return')) return [0, 0, 1, 0];
+	return [0, 0, 0, 1];
+}
+
+/** A fake {@link EmbedManyFn} that records each batch's values and embeds them by topic. */
+function fakeEmbed(): { embed: EmbedManyFn; calls: string[][] } {
+	const calls: string[][] = [];
+	const embed: EmbedManyFn = async ({ values }) => {
+		calls.push(values);
+		return { embeddings: values.map(vectorFor) };
+	};
+	return { embed, calls };
+}
+
+describe('AiFaqAnswerService.answer — with a retriever', () => {
+	it('lets the retriever pick which FAQs reach the model for a large knowledge base', async () => {
+		// 30 newest-but-irrelevant FAQs plus the one that actually answers, oldest (last).
+		// Newest-first slicing would drop it past the cap; the retriever keeps it.
+		const filler = Array.from({ length: 30 }, (_, i) =>
+			makeFaq({ id: `faq-${i}` as FaqId, question: `Filler ${i}`, answer: 'n/a' }),
+		);
+		const target = makeFaq({
+			id: 'faq-target' as FaqId,
+			question: 'How much does your service cost?',
+			answer: 'Our rate is $125 an hour.',
+		});
+		const retrieve = vi.fn(async () => [target]);
+		const { generate, mock } = fakeGenerate(() => ({
+			object: { answered: true, answer: 'It is $125 an hour.', faqIds: ['faq-target'] },
+		}));
+		const service = new AiFaqAnswerService({
+			models: [PRIMARY],
+			generate,
+			retriever: { retrieve },
+		});
+
+		const result = await service.answer({ question: "what's our best price?" }, [
+			...filler,
+			target,
+		]);
+
+		// The retriever was asked for the cap's worth of the full candidate set…
+		expect(retrieve).toHaveBeenCalledWith("what's our best price?", expect.any(Array), 24);
+		// …and only its picks were sent to the model (a non-retrieved FAQ never appears).
+		const options = mock.mock.calls[0]?.[0] as { prompt: string };
+		expect(options.prompt).toContain('faq-target');
+		expect(options.prompt).not.toContain('Filler 0');
+		expect(result.sources).toEqual(['faq-target']);
+	});
+
+	it('skips the retriever when the knowledge base fits the prompt cap', async () => {
+		const retrieve = vi.fn(async () => [] as Faq[]);
+		const { generate } = fakeGenerate(() => ({
+			object: { answered: false, answer: '', faqIds: [] },
+		}));
+		const service = new AiFaqAnswerService({
+			models: [PRIMARY],
+			generate,
+			retriever: { retrieve },
+		});
+
+		await service.answer({ question: 'cost?' }, [makeFaq(), makeFaq({ id: 'faq-2' as FaqId })]);
+
+		// Two FAQs are under the cap, so there's nothing to rank — the retriever is untouched.
+		expect(retrieve).not.toHaveBeenCalled();
+	});
+});
+
+describe('EmbeddingFaqRetriever.retrieve', () => {
+	// Distinct categories: makeFaq defaults category to 'Pricing', which would otherwise
+	// make every FAQ's embedding text read as a pricing topic to the fake embedder.
+	const hours = makeFaq({
+		id: 'a' as FaqId,
+		question: 'What are your hours?',
+		answer: 'Open 9-5.',
+		category: 'General',
+	});
+	const where = makeFaq({
+		id: 'b' as FaqId,
+		question: 'Where are you?',
+		answer: 'Seattle.',
+		category: 'General',
+	});
+	const cost = makeFaq({
+		id: 'c' as FaqId,
+		question: 'How much does it cost?',
+		answer: 'Our rate is $125.',
+		category: 'Pricing',
+	});
+
+	it('ranks by semantic similarity, surfacing a relevant older FAQ over newer ones', async () => {
+		const { embed } = fakeEmbed();
+		const retriever = new EmbeddingFaqRetriever({ model: EMBED_MODEL, embed });
+
+		// Newest-first: hours, where, then the (oldest) pricing FAQ that answers the ask.
+		const result = await retriever.retrieve("what's our best price?", [hours, where, cost], 2);
+
+		expect(result).toHaveLength(2);
+		expect(result[0]?.id).toBe('c');
+	});
+
+	it('passes the candidates through, unembedded, when they fit the limit', async () => {
+		const { embed, calls } = fakeEmbed();
+		const retriever = new EmbeddingFaqRetriever({ model: EMBED_MODEL, embed });
+
+		const result = await retriever.retrieve('best price', [hours, where], 2);
+
+		expect(result).toEqual([hours, where]);
+		expect(calls).toHaveLength(0);
+	});
+
+	it('caches FAQ vectors so a repeat search re-embeds only the query', async () => {
+		const { embed, calls } = fakeEmbed();
+		const retriever = new EmbeddingFaqRetriever({ model: EMBED_MODEL, embed });
+
+		await retriever.retrieve('best price', [hours, where, cost], 2);
+		const second = await retriever.retrieve('opening hours', [hours, where, cost], 2);
+
+		expect(calls[0]).toHaveLength(4); // query + three FAQs
+		expect(calls[1]).toHaveLength(1); // FAQs cached; only the new query is embedded
+		expect(second[0]?.id).toBe('a'); // and the cached vectors still rank correctly
+	});
+
+	it('re-embeds an FAQ after it is edited (its updatedAt changes)', async () => {
+		const { embed, calls } = fakeEmbed();
+		const retriever = new EmbeddingFaqRetriever({ model: EMBED_MODEL, embed });
+		const editedCost = makeFaq({
+			id: 'c' as FaqId,
+			question: 'How much does it cost?',
+			answer: 'Our rate is now $150.',
+			updatedAt: '2026-02-01T00:00:00.000Z',
+		});
+
+		await retriever.retrieve('best price', [hours, where, cost], 2);
+		await retriever.retrieve('best price', [hours, where, editedCost], 2);
+
+		expect(calls[0]).toHaveLength(4); // query + three FAQs
+		expect(calls[1]).toHaveLength(2); // hours/where cached; only the edited FAQ re-embeds
+	});
+
+	it('evicts the least-recently-used vector when the cache is full', async () => {
+		const { embed, calls } = fakeEmbed();
+		const retriever = new EmbeddingFaqRetriever({ model: EMBED_MODEL, embed, cacheCapacity: 1 });
+
+		await retriever.retrieve('best price', [hours, cost], 1);
+		await retriever.retrieve('best price', [hours, cost], 1);
+
+		expect(calls[0]).toHaveLength(3); // query + both FAQs
+		// Capacity 1 evicted `hours`, so the second search re-embeds it (plus the query).
+		expect(calls[1]).toHaveLength(2);
+	});
+
+	it('degrades to the newest candidates when embedding fails', async () => {
+		const warnings: string[] = [];
+		const embed: EmbedManyFn = async () => {
+			throw new Error('embed down');
+		};
+		const retriever = new EmbeddingFaqRetriever({
+			model: EMBED_MODEL,
+			embed,
+			logger: { warn: (message) => warnings.push(message) },
+		});
+
+		const result = await retriever.retrieve('best price', [hours, where, cost], 2);
+
+		expect(result.map((faq) => faq.id)).toEqual(['a', 'b']);
+		expect(warnings[0]).toMatch(/embedding retrieval/i);
+	});
+
+	it('degrades to the newest candidates when the batch returns no query vector', async () => {
+		const embed: EmbedManyFn = async () => ({ embeddings: [] });
+		const retriever = new EmbeddingFaqRetriever({ model: EMBED_MODEL, embed });
+
+		const result = await retriever.retrieve('best price', [hours, where, cost], 2);
+
+		expect(result.map((faq) => faq.id)).toEqual(['a', 'b']);
+	});
+
+	it('keeps unscored candidates eligible when the batch is short a vector', async () => {
+		// Only the query comes back embedded; the FAQ vectors are missing, so none can be
+		// scored — retrieval still returns a full `limit` worth, in candidate order.
+		const embed: EmbedManyFn = async ({ values }) => ({ embeddings: [vectorFor(values[0] ?? '')] });
+		const retriever = new EmbeddingFaqRetriever({ model: EMBED_MODEL, embed });
+
+		const result = await retriever.retrieve('best price', [hours, where, cost], 2);
+
+		expect(result.map((faq) => faq.id)).toEqual(['a', 'b']);
+	});
+});
+
+describe('createFaqRetriever', () => {
+	const embedConfig = {
+		OPENAI_EMBEDDING_MODEL: 'text-embedding-3-small',
+		GOOGLE_EMBEDDING_MODEL: 'text-embedding-004',
+	};
+
+	it('returns undefined when no embeddings provider key is set', () => {
+		expect(createFaqRetriever({ ...embedConfig })).toBeUndefined();
+	});
+
+	it('builds a retriever from OpenAI when its key is set', () => {
+		const retriever: FaqRetriever | undefined = createFaqRetriever({
+			...embedConfig,
+			OPENAI_API_KEY: 'sk-test',
+		});
+		expect(retriever).toBeInstanceOf(EmbeddingFaqRetriever);
+	});
+
+	it('falls back to Google embeddings when only its key is set', () => {
+		const retriever = createFaqRetriever({
+			...embedConfig,
+			GOOGLE_GENERATIVE_AI_API_KEY: 'g-test',
+		});
+		expect(retriever).toBeInstanceOf(EmbeddingFaqRetriever);
 	});
 });


### PR DESCRIPTION
Closes #56 — the two enhancements deliberately scoped out of #54.

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — two follow-ups to #54's AI-backed knowledge-base answering.

---

## 1. Route explicit "FAQ"/"knowledge base" questions through the semantic path (`@rivus/agent`)

A read-only question that *mentions* the knowledge base — e.g. *"what does the knowledge base say about our best price?"* — was classified as `faq_search` and answered by keyword search, so it could miss a differently-worded "cost"/"rate" FAQ (the exact case the semantic answer path handles).

- **`intent.ts`** — `faq_search` now carries an `existence` flag, set by a new `isExistenceCheck` helper (`do we have…`, `is there…`, `are there…`). Existence checks want a *list*, not a synthesized answer.
- **`decide.ts`** — model-routed `faq_search` derives `existence` from the raw turn, so existence checks stay on the list path even when the model picks the action.
- **`assistant.ts`** — `faqSearchReply` is now **semantic-first**: it tries `/v1/faqs/answer` (citing the source FAQ) and falls back to the existing keyword list when there's no grounded answer *or the answer call fails*. Existence checks skip straight to the list. `faq_list` (browse) and the create/update intents keep their current paths.

## 2. Embedding retrieval for large knowledge bases (>24 FAQs) (`@rivus/api`)

`AiFaqAnswerService` sent the newest up to `MAX_CANDIDATES` (24) FAQs to the model — the whole KB for a small business, but a recency-bounded subset once an account grows past 24, so an answer in an older FAQ could be missed.

- **`services/faq-answer.ts`** — new `EmbeddingFaqRetriever` (behind a small `FaqRetriever` interface). When the candidate set exceeds the cap, it embeds the question + candidates, ranks by cosine similarity, and sends the **top-K most relevant** FAQs to the model instead of the newest.
- **Vector store/refresh** — a bounded LRU `VectorCache` keyed by `id + updatedAt`: repeat questions don't re-embed, and an edited FAQ refreshes on its own (new `updatedAt` → cache miss). This is the in-process "store/refresh vectors" layer; the retriever is an injectable interface, so a persisted/vector-DB backend can be swapped in later without touching the answer service.
- **Provider** — query and FAQs must share an embedding model, so retrieval uses a single provider: OpenAI (`text-embedding-3-small`) when its key is set, otherwise Google (`text-embedding-004`). `config.ts` adds `OPENAI_EMBEDDING_MODEL` / `GOOGLE_EMBEDDING_MODEL`.
- **Graceful degradation** — any embedding failure (or no embeddings key) falls back to newest-first; small knowledge bases (≤ the cap) keep their exact prior behavior with **zero** embedding cost. Never throws into the request path.

### Scope note

Retrieval ranks over the candidate page the route already fetches (newest 100 published). That covers the issue's >24 target with wide headroom; a knowledge base beyond ~100 published FAQs would need persisted vectors, which the `FaqRetriever` seam leaves open as a follow-up.

## Tests

- `packages/agent/src/{intent,decide,assistant}.test.ts` — existence-check classification; semantic-first search that cites a source; fallback to the keyword list when unanswered; existence checks kept on the list (not synthesized); degrade-to-keyword when the answer call fails; updated existing `faq_search` assertions.
- `packages/api/test/faq-answer.test.ts` — retriever picks which FAQs reach the model for a large KB and is skipped under the cap; cosine ranking surfaces a relevant *older* FAQ; cache hit/refresh-on-edit/LRU eviction; graceful fallback on embed failure, empty batch, and short batch; `createFaqRetriever` provider selection.

`pnpm lint && pnpm type-check && pnpm test` all pass (827 tests); API and agent coverage thresholds hold.

Neither change affects the small-business demo flow shipped in #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvb6cvh8U1hCRDcZ5oho6W

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dvb6cvh8U1hCRDcZ5oho6W)_