### PR TITLE
feat(search): wire up global search across customers and jobs

### DIFF
--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -3192,6 +3192,74 @@
           }
         }
       }
+    },
+    "/v1/search/": {
+      "get": {
+        "summary": "Search your account's customers and jobs",
+        "tags": [
+          "search"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            },
+            "in": "query",
+            "name": "q",
+            "required": true
+          },
+          {
+            "schema": {
+              "default": 8,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -22,6 +22,7 @@ import { itemRoutes } from './routes/items';
 import { jobRoutes } from './routes/jobs';
 import { memberRoutes } from './routes/members';
 import { notificationRoutes } from './routes/notifications';
+import { searchRoutes } from './routes/search';
 import type { AppDeps } from './types';
 
 function buildLogger(deps: AppDeps) {
@@ -184,6 +185,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	app.register(customerRoutes, { prefix: '/v1/customers' });
 	app.register(jobRoutes, { prefix: '/v1/jobs' });
 	app.register(notificationRoutes, { prefix: '/v1/notifications' });
+	app.register(searchRoutes, { prefix: '/v1/search' });
 
 	return app;
 }

--- a/packages/api/src/http-schemas.ts
+++ b/packages/api/src/http-schemas.ts
@@ -209,6 +209,19 @@ export const jobListResponseSchema = z
 	})
 	.meta({ id: 'JobList' });
 
+/**
+ * Result of the dashboard's global search: the account's customers and jobs whose
+ * text fields match the query, each list independently capped by the query's
+ * `limit`. Grouped by type so the client can render labelled sections; more types
+ * (messages, …) can be added here as they become searchable.
+ */
+export const searchResponseSchema = z
+	.object({
+		customers: z.array(customerResponseSchema),
+		jobs: z.array(jobResponseSchema),
+	})
+	.meta({ id: 'SearchResults' });
+
 export const notificationResponseSchema = z
 	.object({
 		id: z.string(),

--- a/packages/api/src/repositories/memory.ts
+++ b/packages/api/src/repositories/memory.ts
@@ -55,6 +55,8 @@ import type {
 	NewVerificationCode,
 	NotificationRepository,
 	OnboardingRepository,
+	SearchCustomersOptions,
+	SearchJobsOptions,
 	SignupInput,
 	SignupResult,
 	StoredUser,
@@ -632,6 +634,27 @@ export class InMemoryCustomerRepository implements CustomerRepository {
 		};
 	}
 
+	async search(options: SearchCustomersOptions): Promise<Customer[]> {
+		const needle = options.query.trim().toLowerCase();
+		if (needle === '') {
+			return [];
+		}
+		const limit = Math.max(1, Math.trunc(options.limit));
+		return (
+			[...this.data.customers.values()]
+				.filter((customer) => customer.accountId === options.accountId)
+				.filter((customer) =>
+					[customer.name, customer.email, customer.phone, customer.address, customer.notes].some(
+						(field) => field.toLowerCase().includes(needle),
+					),
+				)
+				// Newest-first, matching list() (Map preserves insertion order).
+				.reverse()
+				.slice(0, limit)
+				.map((customer) => structuredClone(customer))
+		);
+	}
+
 	async findById(accountId: AccountId, id: CustomerId): Promise<Customer | null> {
 		const customer = this.data.customers.get(id);
 		return customer && customer.accountId === accountId ? structuredClone(customer) : null;
@@ -712,6 +735,25 @@ export class InMemoryJobRepository implements JobRepository {
 			jobs: matched.slice(skip, skip + pageSize).map((job) => structuredClone(job)),
 			total: matched.length,
 		};
+	}
+
+	async search(options: SearchJobsOptions): Promise<Job[]> {
+		const needle = options.query.trim().toLowerCase();
+		if (needle === '') {
+			return [];
+		}
+		const limit = Math.max(1, Math.trunc(options.limit));
+		return (
+			[...this.data.jobs.values()]
+				.filter((job) => job.accountId === options.accountId)
+				.filter((job) =>
+					[job.title, job.address, job.notes].some((field) => field.toLowerCase().includes(needle)),
+				)
+				// Newest-first, matching the customer search (Map preserves insertion order).
+				.reverse()
+				.slice(0, limit)
+				.map((job) => structuredClone(job))
+		);
 	}
 
 	async findById(accountId: AccountId, id: JobId): Promise<Job | null> {

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -68,6 +68,8 @@ import type {
 	NewVerificationCode,
 	NotificationRepository,
 	OnboardingRepository,
+	SearchCustomersOptions,
+	SearchJobsOptions,
 	SignupInput,
 	SignupResult,
 	StoredUser,
@@ -76,6 +78,15 @@ import type {
 	UserRepository,
 	VerificationCodeRepository,
 } from './types';
+
+/**
+ * Escape regex metacharacters so a user's search term is matched literally — a
+ * query like "a.b" or "(206)" is treated as text, not as a pattern (which could
+ * also be crafted to be pathologically slow).
+ */
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 /** MongoServerError code 11000 = duplicate key (unique index violation). */
 function isDuplicateKeyError(
@@ -295,15 +306,15 @@ export class MongoAccountRepository implements AccountRepository {
 		const { pageSize } = normalizePagination(options.page, options.pageSize);
 		const skip = pageToSkip(options.page, options.pageSize);
 		const needle = options.search?.trim();
-		// Escape regex metacharacters so a search like "a.b" is matched literally, then
-		// match it case-insensitively against either the name or the slug. Only active
-		// accounts are listed — a canceled one can't be entered.
+		// Match the term case-insensitively against either the name or the slug (escaped
+		// so it's literal text). Only active accounts are listed — a canceled one can't
+		// be entered.
 		const filter = needle
 			? {
 					status: 'active' as const,
 					$or: [
-						{ name: new RegExp(needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') },
-						{ slug: new RegExp(needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') },
+						{ name: new RegExp(escapeRegex(needle), 'i') },
+						{ slug: new RegExp(escapeRegex(needle), 'i') },
 					],
 				}
 			: { status: 'active' as const };
@@ -752,6 +763,23 @@ export class MongoCustomerRepository implements CustomerRepository {
 		return { customers: docs.map(mapCustomer), total };
 	}
 
+	async search(options: SearchCustomersOptions): Promise<Customer[]> {
+		const term = options.query.trim();
+		if (term === '' || !Types.ObjectId.isValid(options.accountId)) {
+			return [];
+		}
+		const limit = Math.max(1, Math.trunc(options.limit));
+		const rx = new RegExp(escapeRegex(term), 'i');
+		const docs = await CustomerModel.find({
+			accountId: new Types.ObjectId(options.accountId),
+			$or: [{ name: rx }, { email: rx }, { phone: rx }, { address: rx }, { notes: rx }],
+		})
+			.sort({ createdAt: -1, _id: -1 })
+			.limit(limit)
+			.exec();
+		return docs.map(mapCustomer);
+	}
+
 	async findById(accountId: AccountId, id: CustomerId): Promise<Customer | null> {
 		if (!Types.ObjectId.isValid(id) || !Types.ObjectId.isValid(accountId)) {
 			return null;
@@ -890,6 +918,23 @@ export class MongoJobRepository implements JobRepository {
 			JobModel.countDocuments(filter).exec(),
 		]);
 		return { jobs: docs.map(mapJob), total };
+	}
+
+	async search(options: SearchJobsOptions): Promise<Job[]> {
+		const term = options.query.trim();
+		if (term === '' || !Types.ObjectId.isValid(options.accountId)) {
+			return [];
+		}
+		const limit = Math.max(1, Math.trunc(options.limit));
+		const rx = new RegExp(escapeRegex(term), 'i');
+		const docs = await JobModel.find({
+			accountId: new Types.ObjectId(options.accountId),
+			$or: [{ title: rx }, { address: rx }, { notes: rx }],
+		})
+			.sort({ createdAt: -1, _id: -1 })
+			.limit(limit)
+			.exec();
+		return docs.map(mapJob);
 	}
 
 	async findById(accountId: AccountId, id: JobId): Promise<Job | null> {

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -762,9 +762,19 @@ export class MongoCustomerRepository implements CustomerRepository {
 		}
 		const limit = Math.max(1, Math.trunc(options.limit));
 		const rx = new RegExp(escapeRegex(term), 'i');
+		// `area` is the legacy location field that `mapCustomer` still surfaces as
+		// `address` for customers created before the rename — match it too so those
+		// records are findable by the location the app shows for them.
 		const docs = await CustomerModel.find({
 			accountId: new Types.ObjectId(options.accountId),
-			$or: [{ name: rx }, { email: rx }, { phone: rx }, { address: rx }, { notes: rx }],
+			$or: [
+				{ name: rx },
+				{ email: rx },
+				{ phone: rx },
+				{ address: rx },
+				{ area: rx },
+				{ notes: rx },
+			],
 		})
 			.sort({ createdAt: -1, _id: -1 })
 			.limit(limit)

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -8,6 +8,7 @@ import {
 	type CreateNotificationInput,
 	type Customer,
 	type CustomerId,
+	escapeRegex,
 	type Faq,
 	type FaqId,
 	type Invite,
@@ -78,15 +79,6 @@ import type {
 	UserRepository,
 	VerificationCodeRepository,
 } from './types';
-
-/**
- * Escape regex metacharacters so a user's search term is matched literally — a
- * query like "a.b" or "(206)" is treated as text, not as a pattern (which could
- * also be crafted to be pathologically slow).
- */
-function escapeRegex(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 /** MongoServerError code 11000 = duplicate key (unique index violation). */
 function isDuplicateKeyError(

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -238,9 +238,24 @@ export interface ListCustomersOptions {
 	pageSize: number;
 }
 
+/**
+ * Options for {@link CustomerRepository.search}: a free-text term matched against
+ * one account's customers, capped at `limit` matches. Powers the global search
+ * box, so it returns a short, newest-first slice rather than a full page.
+ */
+export interface SearchCustomersOptions {
+	accountId: AccountId;
+	/** Case-insensitive term matched as a substring of name/email/phone/address/notes. */
+	query: string;
+	/** Maximum number of matches to return. */
+	limit: number;
+}
+
 export interface CustomerRepository {
 	create(accountId: AccountId, input: CreateCustomerInput): Promise<Customer>;
 	list(options: ListCustomersOptions): Promise<{ customers: Customer[]; total: number }>;
+	/** Up to `limit` customers matching a free-text term, newest-first (empty term → no matches). */
+	search(options: SearchCustomersOptions): Promise<Customer[]>;
 	findById(accountId: AccountId, id: CustomerId): Promise<Customer | null>;
 	update(
 		accountId: AccountId,
@@ -283,9 +298,24 @@ export interface FindOverlappingJobsOptions {
 	excludeJobId?: JobId;
 }
 
+/**
+ * Options for {@link JobRepository.search}: a free-text term matched against one
+ * account's jobs, capped at `limit` matches. The global-search counterpart to the
+ * customer search above.
+ */
+export interface SearchJobsOptions {
+	accountId: AccountId;
+	/** Case-insensitive term matched as a substring of title/address/notes. */
+	query: string;
+	/** Maximum number of matches to return. */
+	limit: number;
+}
+
 export interface JobRepository {
 	create(accountId: AccountId, input: CreateJobInput): Promise<Job>;
 	list(options: ListJobsOptions): Promise<{ jobs: Job[]; total: number }>;
+	/** Up to `limit` jobs matching a free-text term, newest-first (empty term → no matches). */
+	search(options: SearchJobsOptions): Promise<Job[]>;
 	findById(accountId: AccountId, id: JobId): Promise<Job | null>;
 	update(accountId: AccountId, id: JobId, input: UpdateJobInput): Promise<Job | null>;
 	delete(accountId: AccountId, id: JobId): Promise<boolean>;

--- a/packages/api/src/routes/search.ts
+++ b/packages/api/src/routes/search.ts
@@ -1,0 +1,44 @@
+import { type AccountId, searchQuerySchema } from '@rivus/core';
+import type { FastifyPluginAsync } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { errorResponseSchema, searchResponseSchema } from '../http-schemas';
+
+/**
+ * Global search behind the dashboard's top-bar search box. Fans the one term out
+ * to each searchable repository (customers, jobs) in parallel and returns the
+ * matches grouped by type. Account-scoped via the JWT, exactly like the resource
+ * routes — a member only ever searches their own account's records.
+ */
+export const searchRoutes: FastifyPluginAsync = async (fastify) => {
+	const app = fastify.withTypeProvider<ZodTypeProvider>();
+	const { customers, jobs } = app.deps;
+
+	// Every search requires a valid JWT.
+	app.addHook('onRequest', fastify.authenticate);
+
+	app.get(
+		'/',
+		{
+			schema: {
+				tags: ['search'],
+				summary: "Search your account's customers and jobs",
+				security: [{ bearerAuth: [] }],
+				querystring: searchQuerySchema,
+				response: {
+					200: searchResponseSchema,
+					400: errorResponseSchema,
+					401: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const accountId = request.user.accountId as AccountId;
+			const { q, limit } = request.query;
+			const [customerMatches, jobMatches] = await Promise.all([
+				customers.search({ accountId, query: q, limit }),
+				jobs.search({ accountId, query: q, limit }),
+			]);
+			return { customers: customerMatches, jobs: jobMatches };
+		},
+	);
+};

--- a/packages/api/test/notifications.test.ts
+++ b/packages/api/test/notifications.test.ts
@@ -594,6 +594,7 @@ describe('job delete race', () => {
 		const jobs: JobRepository = {
 			create: (accountId, input) => base.create(accountId, input),
 			list: (options) => base.list(options),
+			search: (options) => base.search(options),
 			findById: (accountId, id) => base.findById(accountId, id),
 			update: (accountId, id, input) => base.update(accountId, id, input),
 			delete: async () => false,

--- a/packages/api/test/search.test.ts
+++ b/packages/api/test/search.test.ts
@@ -91,13 +91,25 @@ describe('search', () => {
 		expect(names).toEqual(['a.b']);
 	});
 
-	it('caps each type at the requested limit', async () => {
+	it('caps both customers and jobs at the requested limit', async () => {
+		const startAt = '2026-07-01T17:00:00.000Z';
 		for (let i = 0; i < 5; i += 1) {
 			await createCustomer({ name: `Match ${i}` });
+			await createJob({ title: `Match job ${i}`, startAt });
 		}
 		const response = await search('q=Match&limit=2');
 		expect(response.statusCode).toBe(200);
 		expect(response.json().customers).toHaveLength(2);
+		expect(response.json().jobs).toHaveLength(2);
+	});
+
+	it('falls back to the schema default of 8 per type when no limit is given', async () => {
+		for (let i = 0; i < 9; i += 1) {
+			await createCustomer({ name: `Bulk ${i}` });
+		}
+		const response = await search('q=Bulk');
+		expect(response.statusCode).toBe(200);
+		expect(response.json().customers).toHaveLength(8);
 	});
 
 	it('rejects a limit outside 1–20 (400)', async () => {

--- a/packages/api/test/search.test.ts
+++ b/packages/api/test/search.test.ts
@@ -1,0 +1,123 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { authHeader, buildTestApp, signupOwner } from './helpers';
+
+describe('search', () => {
+	let app: FastifyInstance;
+	let token: string;
+
+	beforeEach(async () => {
+		app = await buildTestApp();
+		token = (await signupOwner(app)).token;
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	function createCustomer(payload: Record<string, unknown>) {
+		return app.inject({
+			method: 'POST',
+			url: '/v1/customers',
+			headers: authHeader(token),
+			payload,
+		});
+	}
+
+	function createJob(payload: Record<string, unknown>) {
+		return app.inject({
+			method: 'POST',
+			url: '/v1/jobs',
+			headers: authHeader(token),
+			payload,
+		});
+	}
+
+	function search(query: string, asToken = token) {
+		return app.inject({
+			method: 'GET',
+			url: `/v1/search?${query}`,
+			headers: authHeader(asToken),
+		});
+	}
+
+	it('requires authentication', async () => {
+		const response = await app.inject({ method: 'GET', url: '/v1/search?q=anything' });
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('rejects a missing or blank term (400)', async () => {
+		expect((await search('')).statusCode).toBe(400);
+		expect((await search('q=')).statusCode).toBe(400);
+		expect((await search('q=%20%20')).statusCode).toBe(400);
+	});
+
+	it('matches customers across name, email, phone, address and notes', async () => {
+		await createCustomer({ name: 'Grace Kim' });
+		await createCustomer({ name: 'Other', email: 'grace@example.com' });
+		await createCustomer({ name: 'Phoned', phone: '(206) 555-0199' });
+		await createCustomer({ name: 'Located', address: '12 Grace Avenue' });
+		await createCustomer({ name: 'Noted', notes: 'ask for grace' });
+		await createCustomer({ name: 'Unrelated' });
+
+		const response = await search('q=grace');
+		expect(response.statusCode).toBe(200);
+		const names = (response.json().customers as { name: string }[]).map((c) => c.name).sort();
+		expect(names).toEqual(['Grace Kim', 'Located', 'Noted', 'Other']);
+		expect(response.json().jobs).toEqual([]);
+	});
+
+	it('matches jobs across title, address and notes (and is case-insensitive)', async () => {
+		const startAt = '2026-07-01T17:00:00.000Z';
+		await createJob({ title: 'Water Heater Install', startAt });
+		await createJob({ title: 'Drain clear', startAt, address: '9 Heater Lane' });
+		await createJob({ title: 'Inspection', startAt, notes: 'bring the heater' });
+		await createJob({ title: 'Unrelated', startAt });
+
+		const response = await search('q=HEATER');
+		expect(response.statusCode).toBe(200);
+		const titles = (response.json().jobs as { title: string }[]).map((j) => j.title).sort();
+		expect(titles).toEqual(['Drain clear', 'Inspection', 'Water Heater Install']);
+		expect(response.json().customers).toEqual([]);
+	});
+
+	it('treats the term literally, not as a regex', async () => {
+		await createCustomer({ name: 'axb' });
+		await createCustomer({ name: 'a.b' });
+
+		const response = await search('q=a.b');
+		expect(response.statusCode).toBe(200);
+		const names = (response.json().customers as { name: string }[]).map((c) => c.name);
+		expect(names).toEqual(['a.b']);
+	});
+
+	it('caps each type at the requested limit', async () => {
+		for (let i = 0; i < 5; i += 1) {
+			await createCustomer({ name: `Match ${i}` });
+		}
+		const response = await search('q=Match&limit=2');
+		expect(response.statusCode).toBe(200);
+		expect(response.json().customers).toHaveLength(2);
+	});
+
+	it('rejects a limit outside 1–20 (400)', async () => {
+		expect((await search('q=x&limit=0')).statusCode).toBe(400);
+		expect((await search('q=x&limit=21')).statusCode).toBe(400);
+	});
+
+	it('returns empty groups when nothing matches', async () => {
+		await createCustomer({ name: 'Grace Kim' });
+		const response = await search('q=zzz-no-such-thing');
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ customers: [], jobs: [] });
+	});
+
+	it('does not leak another account’s records', async () => {
+		await createCustomer({ name: 'Private Grace' });
+
+		const otherToken = (await signupOwner(app)).token;
+		const response = await search('q=grace', otherToken);
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ customers: [], jobs: [] });
+	});
+});

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -24,9 +24,10 @@ import { AuthProvider, initialsOf, roleLabel, useAuth } from '@/src/auth/AuthCon
 import { AuthScreen } from '@/src/auth/AuthScreen';
 import { RivusWordmark } from '@/src/brand/RivusLogo';
 import { CompanySwitcher } from '@/src/components/CompanySwitcher';
+import { GlobalSearch } from '@/src/components/GlobalSearch';
 import { BrandGradient } from '@/src/components/Gradient';
 import { RivusChat } from '@/src/components/RivusChat';
-import { Avatar, Icon, Txt } from '@/src/components/ui';
+import { Avatar, Txt } from '@/src/components/ui';
 import { NotificationsBell } from '@/src/notifications/NotificationsBell';
 import { NotificationsProvider } from '@/src/notifications/NotificationsContext';
 import { installFocusRing } from '@/src/theme/focusRing';
@@ -287,14 +288,7 @@ function TopBar() {
 		<View style={styles.topbar}>
 			<CompanySwitcher />
 
-			<View style={styles.searchWrap}>
-				<View style={styles.search}>
-					<Icon name="search" size={16} color={colors.textFaint} />
-					<Txt style={styles.searchTxt} numberOfLines={1}>
-						Search customers, jobs, messages…
-					</Txt>
-				</View>
-			</View>
+			<GlobalSearch />
 
 			<View style={styles.topbarRight}>
 				<NotificationsBell variant="topbar" />
@@ -630,28 +624,6 @@ const styles = StyleSheet.create({
 		borderBottomWidth: 1,
 		borderBottomColor: colors.border,
 		backgroundColor: colors.surface,
-	},
-	searchWrap: {
-		flex: 1,
-		alignItems: 'center',
-	},
-	search: {
-		flexDirection: 'row',
-		alignItems: 'center',
-		gap: 9,
-		width: 420,
-		maxWidth: '100%',
-		backgroundColor: colors.field,
-		borderWidth: 1,
-		borderColor: colors.borderField,
-		borderRadius: radii.md,
-		paddingVertical: 8,
-		paddingHorizontal: 13,
-	},
-	searchTxt: {
-		flex: 1,
-		fontSize: 13,
-		color: colors.textFaint,
 	},
 	topbarRight: {
 		flexDirection: 'row',

--- a/packages/app/app/customers.tsx
+++ b/packages/app/app/customers.tsx
@@ -1,3 +1,4 @@
+import { useLocalSearchParams } from 'expo-router';
 import { type ComponentProps, useCallback, useEffect, useMemo, useState } from 'react';
 import {
 	ActivityIndicator,
@@ -143,6 +144,15 @@ export default function CustomersScreen() {
 			active = false;
 		};
 	}, [load]);
+
+	// Deep link from the global search: `?focus=<id>` selects (and, where the panel
+	// shows, opens) that customer once the list has loaded.
+	const { focus } = useLocalSearchParams<{ focus?: string }>();
+	useEffect(() => {
+		if (typeof focus === 'string' && focus) {
+			setSelectedId(focus);
+		}
+	}, [focus]);
 
 	function resetForm() {
 		setName('');

--- a/packages/app/app/schedule.tsx
+++ b/packages/app/app/schedule.tsx
@@ -1,4 +1,5 @@
 import type { JobStatus } from '@rivus/core';
+import { useLocalSearchParams } from 'expo-router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
 	ActivityIndicator,
@@ -262,6 +263,16 @@ export default function ScheduleScreen() {
 			active = false;
 		};
 	}, [load]);
+
+	// Deep link from the global search: `?focus=<YYYY-MM-DD>` jumps the calendar to
+	// that job's day in the day view, so the searched-for job is on screen.
+	const { focus } = useLocalSearchParams<{ focus?: string }>();
+	useEffect(() => {
+		if (typeof focus === 'string' && isValidDateKey(focus)) {
+			setAnchor(dateFromKeyAndMinutes(focus, 0));
+			setView('day');
+		}
+	}, [focus]);
 
 	// Live double-booking check while the form is open: re-run whenever the assignee
 	// or proposed slot changes, ignoring stale responses if they change again mid-flight.

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -1140,6 +1140,41 @@ describe('createApiClient', () => {
 		});
 	});
 
+	describe('search', () => {
+		it('sends the term with the default limit and parses grouped results', async () => {
+			const customers = [makeCustomer(), makeCustomer()];
+			const jobs = [makeJob()];
+			fetchMock.mockResolvedValueOnce(jsonResponse({ customers, jobs }));
+
+			const client = createApiClient(BASE, fetchMock);
+			const token = faker.string.alphanumeric(32);
+			const result = await client.search(token, { q: 'grace' });
+
+			expect(result.customers).toEqual(customers);
+			expect(result.jobs).toEqual(jobs);
+
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/search?q=grace&limit=8`);
+			expect(init.headers).toMatchObject({ Authorization: `Bearer ${token}` });
+		});
+
+		it('forwards a custom limit', async () => {
+			fetchMock.mockResolvedValueOnce(jsonResponse({ customers: [], jobs: [] }));
+
+			const client = createApiClient(BASE, fetchMock);
+			await client.search('token', { q: 'heater', limit: 3 });
+
+			const [url] = fetchMock.mock.calls[0] as [string];
+			expect(url).toBe(`${BASE}/v1/search?q=heater&limit=3`);
+		});
+
+		it('rejects a blank term before calling the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.search('token', { q: '   ' })).rejects.toBeInstanceOf(ValidationError);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('listCompanies', () => {
 		function companyPage(accounts: ReturnType<typeof makeAccount>[]) {
 			return {

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -35,6 +35,7 @@ import {
 	paginationQuerySchema,
 	type Role,
 	roleSchema,
+	searchQuerySchema,
 	signupSchema,
 	type UpdateAccountInput,
 	type UpdateCustomerInput,
@@ -346,6 +347,22 @@ export interface JobConflictQueryInput {
 /** Query for {@link RivusApiClient.listJobs}: pagination plus calendar filters. */
 export type JobListQueryInput = Partial<JobListQuery>;
 
+const searchResultsResponseSchema = z.object({
+	customers: z.array(customerResponseSchema),
+	jobs: z.array(jobResponseSchema),
+});
+
+export interface SearchResults {
+	customers: Customer[];
+	jobs: Job[];
+}
+
+/** Query for {@link RivusApiClient.search}: a term plus an optional per-type result cap. */
+export interface SearchQueryInput {
+	q: string;
+	limit?: number;
+}
+
 const notificationResponseSchema = z.object({
 	id: notificationId(),
 	accountId: accountId(),
@@ -494,6 +511,11 @@ export interface RivusApiClient {
 	 * overlapping jobs (empty when the slot is free).
 	 */
 	getJobConflicts(token: string, query: JobConflictQueryInput): Promise<{ conflicts: Job[] }>;
+	/**
+	 * Global search across the account's customers and jobs (the dashboard's
+	 * top-bar search box). Returns the matches grouped by type.
+	 */
+	search(token: string, query: SearchQueryInput): Promise<SearchResults>;
 	/** List your notifications, optionally narrowed to unread only. */
 	listNotifications(
 		token: string,
@@ -814,6 +836,15 @@ export function createApiClient(
 				params.set('excludeJobId', parsed.excludeJobId);
 			}
 			return request(`/v1/jobs/conflicts?${params.toString()}`, jobConflictsResponseSchema, {
+				method: 'GET',
+				headers: authHeaders(token),
+			});
+		},
+
+		async search(token: string, query: SearchQueryInput) {
+			const parsed = parseInput(searchQuerySchema, query);
+			const params = new URLSearchParams({ q: parsed.q, limit: String(parsed.limit) });
+			return request(`/v1/search?${params.toString()}`, searchResultsResponseSchema, {
 				method: 'GET',
 				headers: authHeaders(token),
 			});

--- a/packages/app/src/components/GlobalSearch.tsx
+++ b/packages/app/src/components/GlobalSearch.tsx
@@ -42,6 +42,10 @@ export function GlobalSearch() {
 	const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
 	// Monotonic request id so a slow earlier search can't overwrite a newer one.
 	const latestRequest = useRef(0);
+	// `autoFocus` on a TextInput inside a Modal can miss on native (focus is
+	// attempted mid-transition), so we also focus via this ref in the Modal's
+	// `onShow`. Keeping `autoFocus` covers web, where react-native-web honors it.
+	const inputRef = useRef<TextInput>(null);
 
 	const runSearch = useCallback(
 		async (term: string) => {
@@ -131,13 +135,20 @@ export function GlobalSearch() {
 				</Txt>
 			</Pressable>
 
-			<Modal visible={open} transparent animationType="fade" onRequestClose={close}>
+			<Modal
+				visible={open}
+				transparent
+				animationType="fade"
+				onRequestClose={close}
+				onShow={() => inputRef.current?.focus()}
+			>
 				<Pressable style={styles.backdrop} onPress={close}>
 					{/* Stop taps inside the panel from dismissing it. */}
 					<Pressable style={styles.panel} onPress={() => {}}>
 						<View style={styles.searchRow}>
 							<Feather name="search" size={15} color={colors.textFaint} />
 							<TextInput
+								ref={inputRef}
 								placeholder="Search customers and jobs…"
 								placeholderTextColor={colors.textHint}
 								value={query}
@@ -145,6 +156,9 @@ export function GlobalSearch() {
 								autoCorrect={false}
 								autoCapitalize="none"
 								autoFocus
+								// Match the API's `q` cap (searchQuerySchema) so an over-long query is
+								// prevented here rather than rejected with a 400.
+								maxLength={200}
 								style={styles.searchInput}
 							/>
 							{loading ? <ActivityIndicator size="small" color={colors.brandPurple} /> : null}

--- a/packages/app/src/components/GlobalSearch.tsx
+++ b/packages/app/src/components/GlobalSearch.tsx
@@ -1,0 +1,350 @@
+import { Feather } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+	ActivityIndicator,
+	Modal,
+	Pressable,
+	ScrollView,
+	StyleSheet,
+	TextInput,
+	View,
+} from 'react-native';
+import type { SearchResults } from '@/src/api/client';
+import { initialsOf, useAuth } from '@/src/auth/AuthContext';
+import { formatClock, formatDayLabel, localDateKey } from '@/src/schedule/datetime';
+import { colors, font, radii, shadowSoft } from '@/src/theme/tokens';
+import { Avatar, Icon, Txt } from './ui';
+
+/** Debounce window for the search, matching the company switcher / address fields. */
+const SEARCH_DEBOUNCE_MS = 250;
+/** How many matches of each type the dropdown asks for (the API caps this at 20). */
+const RESULT_LIMIT = 8;
+
+const EMPTY_RESULTS: SearchResults = { customers: [], jobs: [] };
+
+/**
+ * The dashboard's global search box. A field-styled trigger in the top bar opens
+ * a dropdown that searches the account's customers and jobs (via `GET /v1/search`,
+ * backed by MongoDB) as you type, debounced. Selecting a result deep-links to the
+ * relevant screen — a customer focuses their CRM record, a job opens the schedule
+ * on its day.
+ */
+export function GlobalSearch() {
+	const { session, client } = useAuth();
+	const router = useRouter();
+
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState('');
+	const [results, setResults] = useState<SearchResults>(EMPTY_RESULTS);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+	// Monotonic request id so a slow earlier search can't overwrite a newer one.
+	const latestRequest = useRef(0);
+
+	const runSearch = useCallback(
+		async (term: string) => {
+			const trimmed = term.trim();
+			const requestId = latestRequest.current + 1;
+			latestRequest.current = requestId;
+			// An empty term has no results — clear and skip the round-trip (the API
+			// would reject a blank `q` anyway).
+			if (!session || trimmed === '') {
+				setResults(EMPTY_RESULTS);
+				setLoading(false);
+				setError(null);
+				return;
+			}
+			setLoading(true);
+			setError(null);
+			try {
+				const data = await client.search(session.token, { q: trimmed, limit: RESULT_LIMIT });
+				if (requestId === latestRequest.current) {
+					setResults(data);
+				}
+			} catch {
+				if (requestId === latestRequest.current) {
+					setResults(EMPTY_RESULTS);
+					setError('Could not run that search. Please try again.');
+				}
+			} finally {
+				if (requestId === latestRequest.current) {
+					setLoading(false);
+				}
+			}
+		},
+		[client, session],
+	);
+
+	// Clear any pending debounce when the dropdown closes so a late keystroke can't
+	// fire a search against a closed sheet (the cleanup runs on the open→false
+	// transition).
+	useEffect(() => {
+		if (!open) {
+			return;
+		}
+		return () => {
+			if (debounce.current) {
+				clearTimeout(debounce.current);
+			}
+		};
+	}, [open]);
+
+	function handleQuery(next: string) {
+		setQuery(next);
+		if (debounce.current) {
+			clearTimeout(debounce.current);
+		}
+		debounce.current = setTimeout(() => void runSearch(next), SEARCH_DEBOUNCE_MS);
+	}
+
+	function close() {
+		// Bump the request id so any in-flight response is ignored on the way out.
+		latestRequest.current += 1;
+		setOpen(false);
+		setQuery('');
+		setResults(EMPTY_RESULTS);
+		setLoading(false);
+		setError(null);
+	}
+
+	function goTo(pathname: '/customers' | '/schedule', focus: string) {
+		close();
+		router.push({ pathname, params: { focus } });
+	}
+
+	const trimmed = query.trim();
+	const hasResults = results.customers.length > 0 || results.jobs.length > 0;
+
+	return (
+		<View style={styles.wrap}>
+			<Pressable
+				style={styles.trigger}
+				onPress={() => setOpen(true)}
+				accessibilityRole="button"
+				accessibilityLabel="Search customers and jobs"
+			>
+				<Icon name="search" size={16} color={colors.textFaint} />
+				<Txt style={styles.triggerTxt} numberOfLines={1}>
+					Search customers and jobs…
+				</Txt>
+			</Pressable>
+
+			<Modal visible={open} transparent animationType="fade" onRequestClose={close}>
+				<Pressable style={styles.backdrop} onPress={close}>
+					{/* Stop taps inside the panel from dismissing it. */}
+					<Pressable style={styles.panel} onPress={() => {}}>
+						<View style={styles.searchRow}>
+							<Feather name="search" size={15} color={colors.textFaint} />
+							<TextInput
+								placeholder="Search customers and jobs…"
+								placeholderTextColor={colors.textHint}
+								value={query}
+								onChangeText={handleQuery}
+								autoCorrect={false}
+								autoCapitalize="none"
+								autoFocus
+								style={styles.searchInput}
+							/>
+							{loading ? <ActivityIndicator size="small" color={colors.brandPurple} /> : null}
+						</View>
+
+						{error ? (
+							<View style={styles.state}>
+								<Txt style={styles.stateTxt}>{error}</Txt>
+							</View>
+						) : trimmed === '' ? (
+							<View style={styles.state}>
+								<Txt style={styles.stateTxt}>Search your customers and jobs by name or detail.</Txt>
+							</View>
+						) : !hasResults && !loading ? (
+							<View style={styles.state}>
+								<Txt style={styles.stateTxt}>No matches for “{trimmed}”.</Txt>
+							</View>
+						) : (
+							<ScrollView style={styles.list} keyboardShouldPersistTaps="handled">
+								{results.customers.length > 0 ? (
+									<View style={styles.section}>
+										<Txt style={styles.sectionLabel}>Customers</Txt>
+										{results.customers.map((customer) => {
+											const detail = customer.email || customer.phone || customer.address;
+											return (
+												<Pressable
+													key={customer.id}
+													style={styles.row}
+													onPress={() => goTo('/customers', customer.id)}
+													accessibilityRole="button"
+												>
+													<Avatar initials={initialsOf(customer.name)} size={32} />
+													<View style={styles.rowText}>
+														<Txt style={styles.rowTitle} numberOfLines={1}>
+															{customer.name}
+														</Txt>
+														{detail ? (
+															<Txt style={styles.rowSub} numberOfLines={1}>
+																{detail}
+															</Txt>
+														) : null}
+													</View>
+												</Pressable>
+											);
+										})}
+									</View>
+								) : null}
+
+								{results.jobs.length > 0 ? (
+									<View style={styles.section}>
+										<Txt style={styles.sectionLabel}>Jobs</Txt>
+										{results.jobs.map((job) => {
+											const start = new Date(job.startAt);
+											return (
+												<Pressable
+													key={job.id}
+													style={styles.row}
+													onPress={() => goTo('/schedule', localDateKey(start))}
+													accessibilityRole="button"
+												>
+													<View style={styles.jobIcon}>
+														<Icon name="calendar" size={16} color={colors.brandPurple} />
+													</View>
+													<View style={styles.rowText}>
+														<Txt style={styles.rowTitle} numberOfLines={1}>
+															{job.title}
+														</Txt>
+														<Txt style={styles.rowSub} numberOfLines={1}>
+															{formatDayLabel(start)} · {formatClock(job.startAt)}
+														</Txt>
+													</View>
+												</Pressable>
+											);
+										})}
+									</View>
+								) : null}
+							</ScrollView>
+						)}
+					</Pressable>
+				</Pressable>
+			</Modal>
+		</View>
+	);
+}
+
+const styles = StyleSheet.create({
+	wrap: {
+		flex: 1,
+		alignItems: 'center',
+	},
+	trigger: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 9,
+		width: 420,
+		maxWidth: '100%',
+		backgroundColor: colors.field,
+		borderWidth: 1,
+		borderColor: colors.borderField,
+		borderRadius: radii.md,
+		paddingVertical: 8,
+		paddingHorizontal: 13,
+	},
+	triggerTxt: {
+		flex: 1,
+		fontSize: 13,
+		color: colors.textFaint,
+	},
+	// Anchor the dropdown near the top center, approximating the trigger's place.
+	backdrop: {
+		flex: 1,
+		alignItems: 'center',
+		paddingTop: 58,
+	},
+	panel: {
+		width: 460,
+		maxWidth: '92%',
+		maxHeight: 460,
+		backgroundColor: colors.surface,
+		borderWidth: 1,
+		borderColor: colors.border,
+		borderRadius: radii.lg,
+		padding: 10,
+		gap: 8,
+		...shadowSoft,
+	},
+	searchRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 8,
+		backgroundColor: colors.field,
+		borderWidth: 1,
+		borderColor: colors.borderField,
+		borderRadius: radii.md,
+		paddingHorizontal: 11,
+	},
+	searchInput: {
+		flex: 1,
+		fontFamily: font.regular,
+		fontSize: 13.5,
+		color: colors.text,
+		paddingVertical: 9,
+	},
+	list: {
+		flexGrow: 0,
+	},
+	section: {
+		gap: 2,
+		marginBottom: 4,
+	},
+	sectionLabel: {
+		fontFamily: font.semibold,
+		fontSize: 11,
+		letterSpacing: 0.6,
+		textTransform: 'uppercase',
+		color: colors.textFaint,
+		paddingHorizontal: 8,
+		paddingTop: 6,
+		paddingBottom: 4,
+	},
+	row: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 11,
+		paddingVertical: 8,
+		paddingHorizontal: 8,
+		borderRadius: radii.md,
+	},
+	jobIcon: {
+		width: 32,
+		height: 32,
+		borderRadius: radii.sm,
+		backgroundColor: colors.purpleTint,
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	rowText: {
+		flex: 1,
+		minWidth: 0,
+	},
+	rowTitle: {
+		fontFamily: font.medium,
+		fontSize: 13.5,
+		color: colors.text,
+	},
+	rowSub: {
+		fontFamily: font.regular,
+		fontSize: 11.5,
+		color: colors.textMuted,
+		marginTop: 1,
+	},
+	state: {
+		paddingVertical: 22,
+		paddingHorizontal: 10,
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	stateTxt: {
+		fontSize: 12.5,
+		color: colors.textMuted,
+		textAlign: 'center',
+	},
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './pagination';
+export * from './regex';
 export * from './schemas';
 export * from './slug';
 export * from './staff';

--- a/packages/core/src/regex.test.ts
+++ b/packages/core/src/regex.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { escapeRegex } from './regex';
+
+describe('escapeRegex', () => {
+	it('escapes every regex metacharacter so the term matches only itself', () => {
+		// Built from a char array so the literal `${` never appears in source (which
+		// would trip Biome's template-string lint); the value is the metachar set.
+		const metachars = ['.', '*', '+', '?', '^', '$', '{', '}', '(', ')', '|', '[', ']', '\\'].join(
+			'',
+		);
+		const rx = new RegExp(escapeRegex(metachars));
+		expect(rx.test(metachars)).toBe(true);
+		expect(rx.test('anything else')).toBe(false);
+	});
+
+	it('treats a dotted term as literal text, not a wildcard', () => {
+		const rx = new RegExp(escapeRegex('a.b'), 'i');
+		expect(rx.test('a.b')).toBe(true);
+		expect(rx.test('axb')).toBe(false);
+	});
+
+	it('escapes phone-style and quantifier inputs', () => {
+		expect(new RegExp(escapeRegex('(206)')).test('(206)')).toBe(true);
+		// `a+` must match the literal "a+", not "one or more a".
+		const plus = new RegExp(escapeRegex('a+'));
+		expect(plus.test('a+')).toBe(true);
+		expect(plus.test('aaaa')).toBe(false);
+	});
+
+	it('leaves an ordinary term unchanged', () => {
+		expect(escapeRegex('grace')).toBe('grace');
+	});
+});

--- a/packages/core/src/regex.ts
+++ b/packages/core/src/regex.ts
@@ -1,0 +1,9 @@
+/**
+ * Escape regex metacharacters so a user-supplied string is matched literally — a
+ * term like `a.b` or `(206)` is treated as text, not as a pattern (which could
+ * also be crafted to run pathologically slowly). Shared by the Mongo repositories,
+ * which build case-insensitive search filters with `new RegExp(escapeRegex(term), 'i')`.
+ */
+export function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -323,6 +323,25 @@ export const updateCustomerSchema = z
 	});
 export type UpdateCustomerInput = z.infer<typeof updateCustomerSchema>;
 
+// --- Global search ------------------------------------------------------------
+
+/**
+ * Query for the dashboard's global search box (`GET /v1/search`): a required
+ * free-text term plus an optional per-type result cap. `q` is trimmed and bounded
+ * like every other text field; `limit` caps how many matches of *each* type
+ * (customers, jobs) come back so the results dropdown stays small and fast.
+ */
+export const searchQuerySchema = z.object({
+	q: requiredText('Search', 200),
+	limit: z.coerce
+		.number()
+		.int({ error: 'Limit must be a whole number.' })
+		.min(1, { error: 'Limit must be 1 or greater.' })
+		.max(20, { error: 'Limit must be 20 or fewer.' })
+		.default(8),
+});
+export type SearchQuery = z.infer<typeof searchQuerySchema>;
+
 /** Query string for list endpoints; coerces `?page=2&pageSize=50`. */
 export const paginationQuerySchema = z.object({
 	page: z.coerce.number().int().min(1, { error: 'Page must be 1 or greater.' }).default(1),


### PR DESCRIPTION
Makes the dashboard's top-bar search box functional end to end, backed by MongoDB through the API. Previously the box was a static label (`Search customers, jobs, messages…`); now it searches the account's customers and jobs as you type and deep-links to the matching record.

## Summary

**`@rivus/core`**
- Add `searchQuerySchema` — a required, bounded term (`q`) plus a per-type result cap (`limit`, 1–20, default 8).

**`@rivus/api`**
- Add `search()` to the `CustomerRepository` and `JobRepository` interfaces and to **both** implementations (`memory.ts`, `mongo.ts`).
- Add a new authenticated `GET /v1/search` route that fans the term out to both repositories in parallel and returns matches grouped by type (`{ customers, jobs }`).
- Mongo matching is **account-scoped**, case-insensitive, and **regex-escaped** (literal match, ReDoS-safe), capped at `limit`; customers match on name/email/phone/address/notes, jobs on title/address/notes. Factored the regex escaping into a shared `escapeRegex` helper (also de-duplicating the existing account-search usage).
- Regenerate `openapi.json`.

**`@rivus/app`**
- Add `client.search()` plus its response schema/types.
- Add a `GlobalSearch` dropdown component (debounced, request-race-guarded — modeled on `CompanySwitcher`) that replaces the static box in the top bar. Selecting a result deep-links via a `?focus=` param: a customer focuses its CRM record on the Customers screen; a job opens the Schedule on that job's day.

## Notes
- "Messages" from the old placeholder are out of scope — chat lives in the agent (a Cloudflare Durable Object / SQLite), not MongoDB — so the copy now reads "customers and jobs".
- The search box renders in the wide (sidebar) top bar, matching where the box already existed.

---

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — a new global search capability across the API and the app.

### Testing
- `pnpm lint`, `pnpm type-check`, and `pnpm test` all pass.
- New API tests (`test/search.test.ts`): auth required; blank-term and out-of-range `limit` rejected (400); multi-field, case-insensitive matching for customers and jobs; literal (not regex) matching; `limit` cap; and account isolation.
- New app client tests: term + default/custom `limit` forwarding and grouped-result parsing; blank term rejected before any network call.
- Coverage thresholds held for the touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014uqobKexFs3DgwHJUvSSYy

---
_Generated by [Claude Code](https://claude.ai/code/session_014uqobKexFs3DgwHJUvSSYy)_