### PR TITLE
feat(app): add full search icon to mobile top bar

### DIFF
--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -322,6 +322,9 @@ function CompactBar({ onOpenChat }: { onOpenChat: () => void }) {
 		<View style={[styles.compactBar, { paddingTop: insets.top + 12 }]}>
 			<HomeLink height={20} />
 			<View style={styles.compactRight}>
+				{/* Full search — the narrow counterpart to the top bar's search field, an
+				    icon button that opens the same customers-and-jobs dropdown. */}
+				<GlobalSearch variant="compact" />
 				{/* Chat with Rivus — sits right before the bell and opens the agent chat
 				    full screen (the mobile layout has no floating chat launcher). */}
 				<Pressable

--- a/packages/app/src/components/GlobalSearch.tsx
+++ b/packages/app/src/components/GlobalSearch.tsx
@@ -3,7 +3,9 @@ import { useRouter } from 'expo-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
 	ActivityIndicator,
+	KeyboardAvoidingView,
 	Modal,
+	Platform,
 	Pressable,
 	ScrollView,
 	StyleSheet,
@@ -22,6 +24,8 @@ const SEARCH_DEBOUNCE_MS = 250;
 const RESULT_LIMIT = 8;
 
 const EMPTY_RESULTS: SearchResults = { customers: [], jobs: [] };
+
+const IS_WEB = Platform.OS === 'web';
 
 /**
  * The dashboard's global search box. A trigger opens a dropdown that searches the
@@ -158,103 +162,112 @@ export function GlobalSearch({ variant = 'topbar' }: { variant?: 'topbar' | 'com
 				onRequestClose={close}
 				onShow={() => inputRef.current?.focus()}
 			>
-				<Pressable style={styles.backdrop} onPress={close}>
-					{/* Stop taps inside the panel from dismissing it. */}
-					<Pressable style={styles.panel} onPress={() => {}}>
-						<View style={styles.searchRow}>
-							<Feather name="search" size={15} color={colors.textFaint} />
-							<TextInput
-								ref={inputRef}
-								placeholder="Search customers and jobs…"
-								placeholderTextColor={colors.textHint}
-								value={query}
-								onChangeText={handleQuery}
-								autoCorrect={false}
-								autoCapitalize="none"
-								autoFocus
-								// Match the API's `q` cap (searchQuerySchema) so an over-long query is
-								// prevented here rather than rejected with a 400.
-								maxLength={200}
-								style={styles.searchInput}
-							/>
-							{loading ? <ActivityIndicator size="small" color={colors.brandPurple} /> : null}
-						</View>
+				{/* Lift the panel above the on-screen keyboard so the focused input and
+				    results stay visible on a phone (matches RivusChat's composer). */}
+				<KeyboardAvoidingView
+					style={styles.kav}
+					behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+				>
+					<Pressable style={styles.backdrop} onPress={close}>
+						{/* Stop taps inside the panel from dismissing it. */}
+						<Pressable style={styles.panel} onPress={() => {}}>
+							<View style={styles.searchRow}>
+								<Feather name="search" size={15} color={colors.textFaint} />
+								<TextInput
+									ref={inputRef}
+									placeholder="Search customers and jobs…"
+									placeholderTextColor={colors.textHint}
+									value={query}
+									onChangeText={handleQuery}
+									autoCorrect={false}
+									autoCapitalize="none"
+									autoFocus
+									// Match the API's `q` cap (searchQuerySchema) so an over-long query is
+									// prevented here rather than rejected with a 400.
+									maxLength={200}
+									style={[styles.searchInput, IS_WEB && styles.searchInputWeb]}
+								/>
+								{loading ? <ActivityIndicator size="small" color={colors.brandPurple} /> : null}
+							</View>
 
-						{error ? (
-							<View style={styles.state}>
-								<Txt style={styles.stateTxt}>{error}</Txt>
-							</View>
-						) : trimmed === '' ? (
-							<View style={styles.state}>
-								<Txt style={styles.stateTxt}>Search your customers and jobs by name or detail.</Txt>
-							</View>
-						) : !hasResults && !loading ? (
-							<View style={styles.state}>
-								<Txt style={styles.stateTxt}>No matches for “{trimmed}”.</Txt>
-							</View>
-						) : (
-							<ScrollView style={styles.list} keyboardShouldPersistTaps="handled">
-								{results.customers.length > 0 ? (
-									<View style={styles.section}>
-										<Txt style={styles.sectionLabel}>Customers</Txt>
-										{results.customers.map((customer) => {
-											const detail = customer.email || customer.phone || customer.address;
-											return (
-												<Pressable
-													key={customer.id}
-													style={styles.row}
-													onPress={() => goTo('/customers', customer.id)}
-													accessibilityRole="button"
-												>
-													<Avatar initials={initialsOf(customer.name)} size={32} />
-													<View style={styles.rowText}>
-														<Txt style={styles.rowTitle} numberOfLines={1}>
-															{customer.name}
-														</Txt>
-														{detail ? (
-															<Txt style={styles.rowSub} numberOfLines={1}>
-																{detail}
+							{error ? (
+								<View style={styles.state}>
+									<Txt style={styles.stateTxt}>{error}</Txt>
+								</View>
+							) : trimmed === '' ? (
+								<View style={styles.state}>
+									<Txt style={styles.stateTxt}>
+										Search your customers and jobs by name or detail.
+									</Txt>
+								</View>
+							) : !hasResults && !loading ? (
+								<View style={styles.state}>
+									<Txt style={styles.stateTxt}>No matches for “{trimmed}”.</Txt>
+								</View>
+							) : (
+								<ScrollView style={styles.list} keyboardShouldPersistTaps="handled">
+									{results.customers.length > 0 ? (
+										<View style={styles.section}>
+											<Txt style={styles.sectionLabel}>Customers</Txt>
+											{results.customers.map((customer) => {
+												const detail = customer.email || customer.phone || customer.address;
+												return (
+													<Pressable
+														key={customer.id}
+														style={styles.row}
+														onPress={() => goTo('/customers', customer.id)}
+														accessibilityRole="button"
+													>
+														<Avatar initials={initialsOf(customer.name)} size={32} />
+														<View style={styles.rowText}>
+															<Txt style={styles.rowTitle} numberOfLines={1}>
+																{customer.name}
 															</Txt>
-														) : null}
-													</View>
-												</Pressable>
-											);
-										})}
-									</View>
-								) : null}
+															{detail ? (
+																<Txt style={styles.rowSub} numberOfLines={1}>
+																	{detail}
+																</Txt>
+															) : null}
+														</View>
+													</Pressable>
+												);
+											})}
+										</View>
+									) : null}
 
-								{results.jobs.length > 0 ? (
-									<View style={styles.section}>
-										<Txt style={styles.sectionLabel}>Jobs</Txt>
-										{results.jobs.map((job) => {
-											const start = new Date(job.startAt);
-											return (
-												<Pressable
-													key={job.id}
-													style={styles.row}
-													onPress={() => goTo('/schedule', localDateKey(start))}
-													accessibilityRole="button"
-												>
-													<View style={styles.jobIcon}>
-														<Icon name="calendar" size={16} color={colors.brandPurple} />
-													</View>
-													<View style={styles.rowText}>
-														<Txt style={styles.rowTitle} numberOfLines={1}>
-															{job.title}
-														</Txt>
-														<Txt style={styles.rowSub} numberOfLines={1}>
-															{formatDayLabel(start)} · {formatClock(job.startAt)}
-														</Txt>
-													</View>
-												</Pressable>
-											);
-										})}
-									</View>
-								) : null}
-							</ScrollView>
-						)}
+									{results.jobs.length > 0 ? (
+										<View style={styles.section}>
+											<Txt style={styles.sectionLabel}>Jobs</Txt>
+											{results.jobs.map((job) => {
+												const start = new Date(job.startAt);
+												return (
+													<Pressable
+														key={job.id}
+														style={styles.row}
+														onPress={() => goTo('/schedule', localDateKey(start))}
+														accessibilityRole="button"
+													>
+														<View style={styles.jobIcon}>
+															<Icon name="calendar" size={16} color={colors.brandPurple} />
+														</View>
+														<View style={styles.rowText}>
+															<Txt style={styles.rowTitle} numberOfLines={1}>
+																{job.title}
+															</Txt>
+															<Txt style={styles.rowSub} numberOfLines={1}>
+																{formatDayLabel(start)} · {formatClock(job.startAt)}
+															</Txt>
+														</View>
+													</Pressable>
+												);
+											})}
+										</View>
+									) : null}
+								</ScrollView>
+							)}
+						</Pressable>
 					</Pressable>
-				</Pressable>
+				</KeyboardAvoidingView>
 			</Modal>
 		</View>
 	);
@@ -291,6 +304,10 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		justifyContent: 'center',
 	},
+	// Keyboard-avoiding wrapper that fills the modal; the backdrop centers within it.
+	kav: {
+		flex: 1,
+	},
 	// Anchor the dropdown near the top center, approximating the trigger's place.
 	backdrop: {
 		flex: 1,
@@ -325,6 +342,10 @@ const styles = StyleSheet.create({
 		fontSize: 13.5,
 		color: colors.text,
 		paddingVertical: 9,
+	},
+	// 16px is the threshold below which mobile Safari auto-zooms a focused input.
+	searchInputWeb: {
+		fontSize: 16,
 	},
 	list: {
 		flexGrow: 0,

--- a/packages/app/src/components/GlobalSearch.tsx
+++ b/packages/app/src/components/GlobalSearch.tsx
@@ -24,13 +24,16 @@ const RESULT_LIMIT = 8;
 const EMPTY_RESULTS: SearchResults = { customers: [], jobs: [] };
 
 /**
- * The dashboard's global search box. A field-styled trigger in the top bar opens
- * a dropdown that searches the account's customers and jobs (via `GET /v1/search`,
- * backed by MongoDB) as you type, debounced. Selecting a result deep-links to the
- * relevant screen — a customer focuses their CRM record, a job opens the schedule
- * on its day.
+ * The dashboard's global search box. A trigger opens a dropdown that searches the
+ * account's customers and jobs (via `GET /v1/search`, backed by MongoDB) as you
+ * type, debounced. Selecting a result deep-links to the relevant screen — a
+ * customer focuses their CRM record, a job opens the schedule on its day.
+ *
+ * The trigger adapts to the layout: `topbar` (the default) is the wide layout's
+ * field-styled search bar, while `compact` is a bare icon button that sits beside
+ * the chat and bell icons in the narrow top bar. Both open the same dropdown.
  */
-export function GlobalSearch() {
+export function GlobalSearch({ variant = 'topbar' }: { variant?: 'topbar' | 'compact' }) {
 	const { session, client } = useAuth();
 	const router = useRouter();
 
@@ -120,20 +123,33 @@ export function GlobalSearch() {
 
 	const trimmed = query.trim();
 	const hasResults = results.customers.length > 0 || results.jobs.length > 0;
+	const isCompact = variant === 'compact';
 
 	return (
-		<View style={styles.wrap}>
-			<Pressable
-				style={styles.trigger}
-				onPress={() => setOpen(true)}
-				accessibilityRole="button"
-				accessibilityLabel="Search customers and jobs"
-			>
-				<Icon name="search" size={16} color={colors.textFaint} />
-				<Txt style={styles.triggerTxt} numberOfLines={1}>
-					Search customers and jobs…
-				</Txt>
-			</Pressable>
+		<View style={isCompact ? undefined : styles.wrap}>
+			{isCompact ? (
+				<Pressable
+					style={styles.compactTrigger}
+					onPress={() => setOpen(true)}
+					accessibilityRole="button"
+					accessibilityLabel="Search customers and jobs"
+					hitSlop={{ top: 5, bottom: 5, left: 5, right: 5 }}
+				>
+					<Feather name="search" size={18} color="#cfd0dc" />
+				</Pressable>
+			) : (
+				<Pressable
+					style={styles.trigger}
+					onPress={() => setOpen(true)}
+					accessibilityRole="button"
+					accessibilityLabel="Search customers and jobs"
+				>
+					<Icon name="search" size={16} color={colors.textFaint} />
+					<Txt style={styles.triggerTxt} numberOfLines={1}>
+						Search customers and jobs…
+					</Txt>
+				</Pressable>
+			)}
 
 			<Modal
 				visible={open}
@@ -266,6 +282,14 @@ const styles = StyleSheet.create({
 		flex: 1,
 		fontSize: 13,
 		color: colors.textFaint,
+	},
+	// Bare icon button for the narrow top bar, sized to match the chat icon and
+	// notifications bell it sits beside.
+	compactTrigger: {
+		width: 34,
+		height: 34,
+		alignItems: 'center',
+		justifyContent: 'center',
 	},
 	// Anchor the dropdown near the top center, approximating the trigger's place.
 	backdrop: {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature.

On mobile (narrow layout) the global search was only available on the wide top bar, so phone users had no way to search. This adds a search icon button right next to the chat icon in the `CompactBar`, giving the mobile view full search capabilities.

**Changes**
- `GlobalSearch` now takes a `variant` prop (`topbar` — the default field-styled search bar; `compact` — a bare icon button). Both triggers open the exact same customers-and-jobs search dropdown, so all search/debounce/deep-link logic is shared.
- The `compact` search icon is sized (34×34) and colored (`#cfd0dc`) to match the chat icon and notifications bell it sits beside in the mobile top bar.
- Wired `<GlobalSearch variant="compact" />` into `CompactBar` immediately before the chat icon.

**Notes on tests/coverage**
The repo's existing test suite is logic-focused (API/util) — there are no component/render tests for the layout or `GlobalSearch`, and the search behavior reused here is unchanged. `pnpm lint`, `pnpm type-check`, and `pnpm test` (161 app tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019M8nWXk6wjr9EWk7pEvbCu)_