### PR TITLE
fix(app): remove focus ring box around global search field

### DIFF
--- a/packages/app/src/components/GlobalSearch.tsx
+++ b/packages/app/src/components/GlobalSearch.tsx
@@ -27,6 +27,13 @@ const EMPTY_RESULTS: SearchResults = { customers: [], jobs: [] };
 
 const IS_WEB = Platform.OS === 'web';
 
+// react-native-web maps `dataSet` to data-* attributes (here `data-no-focus-ring`).
+// It opts the search field out of the global brand focus ring (see focusRing.ts):
+// the search row's own border already frames the focused input, so without this the
+// web build draws a second purple box around the box. The prop isn't in RN's
+// TextInput types, so this is cast; it's a no-op off the web.
+const WEB_NO_FOCUS_RING = (IS_WEB ? { dataSet: { noFocusRing: 'true' } } : null) as object | null;
+
 /**
  * The dashboard's global search box. A trigger opens a dropdown that searches the
  * account's customers and jobs (via `GET /v1/search`, backed by MongoDB) as you
@@ -186,6 +193,7 @@ export function GlobalSearch({ variant = 'topbar' }: { variant?: 'topbar' | 'com
 									// prevented here rather than rejected with a 400.
 									maxLength={200}
 									style={[styles.searchInput, IS_WEB && styles.searchInputWeb]}
+									{...WEB_NO_FOCUS_RING}
 								/>
 								{loading ? <ActivityIndicator size="small" color={colors.brandPurple} /> : null}
 							</View>

--- a/packages/app/src/components/GlobalSearch.tsx
+++ b/packages/app/src/components/GlobalSearch.tsx
@@ -32,7 +32,7 @@ const IS_WEB = Platform.OS === 'web';
 // the search row's own border already frames the focused input, so without this the
 // web build draws a second purple box around the box. The prop isn't in RN's
 // TextInput types, so this is cast; it's a no-op off the web.
-const WEB_NO_FOCUS_RING = (IS_WEB ? { dataSet: { noFocusRing: 'true' } } : null) as object | null;
+const WEB_NO_FOCUS_RING = (IS_WEB ? { dataSet: { noFocusRing: 'true' } } : {}) as object;
 
 /**
  * The dashboard's global search box. A trigger opens a dropdown that searches the

--- a/packages/app/src/theme/focusRing.ts
+++ b/packages/app/src/theme/focusRing.ts
@@ -33,6 +33,12 @@ export function installFocusRing(): void {
 		// Pointer focus (mouse/touch): no outline.
 		`${SELECTOR}:focus:not(:focus-visible){outline:none;}` +
 		// Keyboard focus: a 2px brand ring sitting just outside the control.
-		`${SELECTOR}:focus-visible{outline:2px solid ${colors.brandPurple};outline-offset:2px;}`;
+		`${SELECTOR}:focus-visible{outline:2px solid ${colors.brandPurple};outline-offset:2px;}` +
+		// Opt-out: controls carrying data-no-focus-ring never get the ring. Browsers
+		// treat text inputs as `:focus-visible` whenever focused, so a field that
+		// already lives inside a bordered container (e.g. the global search box)
+		// would otherwise draw a second purple box around itself. Appended last so it
+		// wins over the ring rule above at equal specificity.
+		`:where([data-no-focus-ring]):focus,:where([data-no-focus-ring]):focus-visible{outline:none;}`;
 	document.head.appendChild(style);
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

On the web build, the dashboard's global search field showed a purple highlighted box around the search input when the search dropdown opened. The box is the app's global brand focus ring (`focusRing.ts`): browsers always treat text inputs as `:focus-visible` whenever they're focused, so the auto-focused search input always drew the 2px brand ring with a 2px offset — a redundant second box around the already-bordered search row.

**Changes**
- `focusRing.ts`: add a `data-no-focus-ring` opt-out rule, appended after the ring rules so it wins at equal specificity. Controls carrying this attribute never get the brand ring.
- `GlobalSearch.tsx`: apply the opt-out to the search `TextInput` via react-native-web's `dataSet` (web-only, no-op on native). The search row's own border remains the focus affordance.

No behavior change on native. `pnpm lint`, `pnpm type-check`, and the app test suite (161 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKC8PeJsGP7eGa97BKVmDW)_