### PR TITLE
feat: seed the current account from Settings (development only)

### DIFF
--- a/packages/api/src/http-schemas.ts
+++ b/packages/api/src/http-schemas.ts
@@ -355,6 +355,25 @@ export const accountListResponseSchema = z
 	.meta({ id: 'AccountList' });
 
 /**
+ * Tally returned by the development-only account seeder (`POST /v1/admin/seed`):
+ * how many of each entity were written, the FAQs skipped as duplicates, the
+ * member count the notifications were addressed to, and which generator produced
+ * the data.
+ */
+export const seedSummaryResponseSchema = z
+	.object({
+		customers: z.number().int(),
+		faqs: z.number().int(),
+		faqsSkipped: z.number().int(),
+		appointments: z.number().int(),
+		notifications: z.number().int(),
+		conversations: z.number().int(),
+		members: z.number().int(),
+		generation: z.enum(['ai', 'deterministic']),
+	})
+	.meta({ id: 'SeedSummary' });
+
+/**
  * Billing summary for the account (owner-only). Rivus has no payment provider
  * wired up yet, so this is a placeholder: every account is on the free plan and
  * `seats` reflects the current member count.

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -2,6 +2,7 @@ import {
 	type AccountId,
 	buildPaginationMeta,
 	paginationQuerySchema,
+	seedAccountSchema,
 	type UserId,
 } from '@rivus/core';
 import type { FastifyPluginAsync } from 'fastify';
@@ -12,8 +13,11 @@ import {
 	authResponseSchema,
 	errorResponseSchema,
 	idParamsSchema,
+	seedSummaryResponseSchema,
 } from '../http-schemas';
 import { toPublicAccount, toPublicUser } from '../presenters';
+import { createSeedGenerator, DeterministicSeedGenerator } from '../seed-ai';
+import { seedAccountData } from '../services/seed';
 import { issueSession } from '../services/session';
 
 /** List query: standard pagination plus an optional free-text company search. */
@@ -111,4 +115,59 @@ export const adminRoutes: FastifyPluginAsync = async (fastify) => {
 			});
 		},
 	);
+
+	// Development-only account seeder. The deployed dev and prod containers both run
+	// `NODE_ENV=production` (see app.ts), so this route is registered *only* when the
+	// API is running locally in development — it doesn't exist (404) anywhere else,
+	// and even then it's gated to Rivus staff (`@rivus.ai`). It fills the *current*
+	// account with demo customers, FAQs, appointments, notifications, and inbox
+	// conversations so staff can populate a fresh test account from the app's
+	// Settings screen without touching the CLI.
+	if (app.deps.config.NODE_ENV === 'development') {
+		const { customers, faqs, jobs, notifications, conversations } = app.deps;
+		app.post(
+			'/seed',
+			{
+				onRequest: [fastify.authenticate, fastify.requireStaff],
+				schema: {
+					tags: ['admin'],
+					summary: 'Seed the current account with demo data (development only, Rivus staff only)',
+					security: [{ bearerAuth: [] }],
+					body: seedAccountSchema,
+					response: {
+						200: seedSummaryResponseSchema,
+						401: errorResponseSchema,
+						403: errorResponseSchema,
+						404: errorResponseSchema,
+					},
+				},
+			},
+			async (request) => {
+				const account = await accounts.findById(request.user.accountId as AccountId);
+				if (!account) {
+					throw app.httpErrors.notFound('Account not found');
+				}
+				const body = request.body;
+				// `ai` opts into AI-tailored data when a provider key is set (it degrades to
+				// deterministic generation otherwise); without it the seed is fully
+				// deterministic, so a button press never makes a surprise external call.
+				const generator = body.ai
+					? createSeedGenerator(app.deps.config)
+					: new DeterministicSeedGenerator();
+				return seedAccountData(
+					{ customers, faqs, jobs, notifications, conversations, memberships },
+					generator,
+					account,
+					{
+						customers: body.customers,
+						faqs: body.faqs,
+						appointments: body.appointments,
+						notifications: body.notifications,
+						conversations: body.conversations,
+					},
+					{ seed: body.seed, log: (message) => request.log.info(message) },
+				);
+			},
+		);
+	}
 };

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -16,8 +16,6 @@ import {
 	seedSummaryResponseSchema,
 } from '../http-schemas';
 import { toPublicAccount, toPublicUser } from '../presenters';
-import { createSeedGenerator, DeterministicSeedGenerator } from '../seed-ai';
-import { seedAccountData } from '../services/seed';
 import { issueSession } from '../services/session';
 
 /** List query: standard pagination plus an optional free-text company search. */
@@ -124,6 +122,13 @@ export const adminRoutes: FastifyPluginAsync = async (fastify) => {
 	// conversations so staff can populate a fresh test account from the app's
 	// Settings screen without touching the CLI.
 	if (app.deps.config.NODE_ENV === 'development') {
+		// Lazy-load the seeder so its dev-only `@faker-js/faker` dependency (and the AI
+		// generation machinery) is split into a chunk loaded only here, in development —
+		// never pulled into the production startup bundle, where faker isn't a runtime
+		// dependency. `adminRoutes` is async, so awaiting an import during registration
+		// is fine.
+		const [{ createSeedGenerator, DeterministicSeedGenerator }, { seedAccountData }] =
+			await Promise.all([import('../seed-ai'), import('../services/seed')]);
 		const { customers, faqs, jobs, notifications, conversations } = app.deps;
 		app.post(
 			'/seed',

--- a/packages/api/src/seed.ts
+++ b/packages/api/src/seed.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import type { Account, AccountId, UserId } from '@rivus/core';
+import type { Account, AccountId } from '@rivus/core';
 import { loadConfig } from './config';
 import { connectMongoose, disconnectMongoose } from './db/mongoose';
 import {
@@ -11,45 +11,16 @@ import {
 	MongoMembershipRepository,
 	MongoNotificationRepository,
 } from './repositories/mongo';
-import type {
-	AccountRepository,
-	ConversationRepository,
-	CustomerRepository,
-	FaqRepository,
-	JobRepository,
-	NotificationRepository,
-} from './repositories/types';
-import {
-	type BusinessContext,
-	createSeedGenerator,
-	DeterministicSeedGenerator,
-	type SeedGenerator,
-} from './seed-ai';
-import {
-	type ConversationContact,
-	generateConversations,
-	generateNotifications,
-	parseSeedArgs,
-	SEED_APPOINTMENT_MAX,
-	SEED_APPOINTMENT_MIN,
-	SEED_CONVERSATION_MAX,
-	SEED_CONVERSATION_MIN,
-	SEED_CUSTOMER_MAX,
-	SEED_CUSTOMER_MIN,
-	SEED_FAQ_DEFAULT,
-	SEED_NOTIFICATION_MAX,
-	SEED_NOTIFICATION_MIN,
-	SEED_USAGE,
-	SeedArgError,
-	type SeedOptions,
-	selectNewFaqs,
-} from './seed-data';
+import type { AccountRepository } from './repositories/types';
+import { createSeedGenerator, DeterministicSeedGenerator, type SeedGenerator } from './seed-ai';
+import { parseSeedArgs, SEED_USAGE, SeedArgError, type SeedOptions } from './seed-data';
+import { resolveSeedCounts, type SeedAccountCounts, seedAccountData } from './services/seed';
 
 /**
  * Seed a single account with demo data: CRM customers, a business-FAQ knowledge
- * base, and scheduled appointments (Jobs). It points at an account by slug or id
- * and writes through the same Mongo repositories and Zod schemas the API uses, so
- * seeded rows are identical to ones created over HTTP.
+ * base, scheduled appointments (Jobs), per-member notifications, and inbox
+ * conversations. It points at an account by slug or id and writes through the
+ * Mongo repositories, so seeded rows are identical to ones created over HTTP.
  *
  * Data is generated with AI when a provider key is configured (tailored to the
  * account's business), and falls back to deterministic faker/curated generation
@@ -59,8 +30,9 @@ import {
  *   pnpm --filter @rivus/api seed --account <slug-or-id> [--customers n] [--faqs n] [--appointments n]
  *
  * The pure data generation, CLI parsing, de-duplication, and AI layer live in
- * `seed-data.ts` / `seed-ai.ts` (and are unit-tested); this module is just the
- * database wrapper.
+ * `seed-data.ts` / `seed-ai.ts`, and the repository orchestration lives in
+ * `services/seed.ts` (which the development-only seed route reuses). This module
+ * is just the database wrapper around them.
  */
 
 /** Resolve an account by id first (when the identifier is a valid id), then by slug. */
@@ -77,173 +49,19 @@ async function resolveAccount(
 	return accounts.findBySlug(identifier);
 }
 
-/** Gather every existing FAQ question for an account, paging through the repository. */
-async function collectExistingFaqQuestions(
-	faqs: FaqRepository,
-	accountId: AccountId,
-): Promise<string[]> {
-	const pageSize = 100;
-	const questions: string[] = [];
-	let page = 1;
-	// Page until we've collected `total`; the generous guard stops a runaway loop
-	// if the count and the returned rows ever disagree.
-	for (let guard = 0; guard < 1000; guard += 1) {
-		const { faqs: batch, total } = await faqs.list({ accountId, page, pageSize });
-		for (const faq of batch) {
-			questions.push(faq.question);
-		}
-		if (batch.length === 0 || questions.length >= total) {
-			break;
-		}
-		page += 1;
-	}
-	return questions;
-}
-
 function write(message: string): void {
 	process.stdout.write(`${message}\n`);
 }
 
-/** Create `count` customers via the generator; returns the new customers' ids. */
-async function seedCustomers(
-	customers: CustomerRepository,
-	generator: SeedGenerator,
-	account: Account,
-	context: BusinessContext,
-	count: number,
-): Promise<string[]> {
-	if (count === 0) {
-		write('Customers: skipped (count 0).');
-		return [];
-	}
-	const inputs = await generator.generateCustomers(count, context);
-	const ids: string[] = [];
-	for (const input of inputs) {
-		const created = await customers.create(account.id, input);
-		ids.push(created.id);
-	}
-	write(`Customers: created ${ids.length}.`);
-	return ids;
-}
-
-/** Create up to `count` FAQs, skipping any whose question already exists. */
-async function seedFaqs(
-	faqs: FaqRepository,
-	generator: SeedGenerator,
-	account: Account,
-	context: BusinessContext,
-	count: number,
-): Promise<void> {
-	if (count === 0) {
-		write('FAQs: skipped (count 0).');
-		return;
-	}
-	const candidates = await generator.generateFaqs(count, context);
-	const existing = await collectExistingFaqQuestions(faqs, account.id);
-	const { toCreate, skipped } = selectNewFaqs(candidates, existing);
-	const skipNote = skipped.length > 0 ? ` (${skipped.length} already present, skipped)` : '';
-	for (const input of toCreate) {
-		await faqs.create(account.id, input);
-	}
-	write(`FAQs: created ${toCreate.length}${skipNote}.`);
-}
-
-/** Create `count` appointments (Jobs) linked to the given customers and members. */
-async function seedAppointments(
-	jobs: JobRepository,
-	generator: SeedGenerator,
-	account: Account,
-	context: BusinessContext,
-	count: number,
-	customerIds: string[],
-	memberIds: string[],
-): Promise<void> {
-	if (count === 0) {
-		write('Appointments: skipped (count 0).');
-		return;
-	}
-	const inputs = await generator.generateAppointments(
-		{ count, customerIds, memberIds, referenceDate: new Date() },
-		context,
-	);
-	for (const input of inputs) {
-		await jobs.create(account.id, input);
-	}
-	const linkNote = customerIds.length === 0 ? ' (no customers to link)' : '';
-	write(`Appointments: created ${inputs.length}${linkNote}.`);
-}
-
-/**
- * Create `countPerMember` demo notifications for each of the account's members so
- * their bell looks lived-in, then mark the older half read so the unread badge
- * shows a realistic subset rather than every row glowing.
- */
-async function seedNotifications(
-	notifications: NotificationRepository,
-	account: Account,
-	memberIds: string[],
-	countPerMember: number,
-): Promise<void> {
-	if (countPerMember === 0) {
-		write('Notifications: skipped (count 0).');
-		return;
-	}
-	if (memberIds.length === 0) {
-		write('Notifications: skipped (no members to notify).');
-		return;
-	}
-	let created = 0;
-	for (const memberId of memberIds) {
-		const ids = [];
-		for (const input of generateNotifications(countPerMember)) {
-			const notification = await notifications.create(account.id, memberId as UserId, input);
-			ids.push(notification.id);
-		}
-		// The list is newest-first, so marking the first (oldest) half read leaves the
-		// most recent notifications unread — the natural "haven't seen these yet" state.
-		const readCount = Math.floor(ids.length / 2);
-		for (let i = 0; i < readCount; i += 1) {
-			const id = ids[i];
-			if (id) {
-				await notifications.markRead(account.id, memberId as UserId, id);
-			}
-		}
-		created += ids.length;
-	}
-	write(`Notifications: created ${created} across ${memberIds.length} member(s).`);
-}
-
-/**
- * Create `count` inbox conversations linked to the account's customers, replaying
- * each scripted message through the repository (and setting the review state for
- * the flagged thread) so the seeded inbox is identical to one built over HTTP.
- */
-async function seedConversations(
-	conversations: ConversationRepository,
-	account: Account,
-	contacts: ConversationContact[],
-	count: number,
-): Promise<void> {
-	if (count === 0) {
-		write('Conversations: skipped (count 0).');
-		return;
-	}
-	const seeds = generateConversations(count, contacts);
-	for (const seed of seeds) {
-		const created = await conversations.create(account.id, seed.conversation);
-		for (const message of seed.messages) {
-			await conversations.addMessage(account.id, created.id, message);
-		}
-		if (seed.review) {
-			await conversations.setReviewState(account.id, created.id, {
-				status: 'needs_attention',
-				pendingReply: seed.review.pendingReply,
-				flagReason: seed.review.flagReason,
-			});
-		}
-	}
-	const linkNote = contacts.length === 0 ? ' (no customers to link)' : '';
-	write(`Conversations: created ${seeds.length}${linkNote}.`);
+/** Map the CLI options onto the seeder's per-entity count shape. */
+function countsFrom(options: SeedOptions): SeedAccountCounts {
+	return {
+		customers: options.customers,
+		faqs: options.faqs,
+		appointments: options.appointments,
+		notifications: options.notifications,
+		conversations: options.conversations,
+	};
 }
 
 async function run(options: SeedOptions): Promise<void> {
@@ -256,20 +74,6 @@ async function run(options: SeedOptions): Promise<void> {
 	const generator: SeedGenerator = options.ai
 		? createSeedGenerator(config)
 		: new DeterministicSeedGenerator();
-
-	// Resolve the planned counts up front so a dry run can report them without work.
-	const customerCount =
-		options.customers ?? faker.number.int({ min: SEED_CUSTOMER_MIN, max: SEED_CUSTOMER_MAX });
-	const faqCount = options.faqs ?? SEED_FAQ_DEFAULT;
-	const appointmentCount =
-		options.appointments ??
-		faker.number.int({ min: SEED_APPOINTMENT_MIN, max: SEED_APPOINTMENT_MAX });
-	const notificationCount =
-		options.notifications ??
-		faker.number.int({ min: SEED_NOTIFICATION_MIN, max: SEED_NOTIFICATION_MAX });
-	const conversationCount =
-		options.conversations ??
-		faker.number.int({ min: SEED_CONVERSATION_MIN, max: SEED_CONVERSATION_MAX });
 
 	await connectMongoose(config.MONGODB_URI);
 	try {
@@ -300,73 +104,29 @@ async function run(options: SeedOptions): Promise<void> {
 		}
 
 		if (options.dryRun) {
-			write(`Customers: would create ${customerCount}.`);
-			write(`FAQs: would create up to ${faqCount} (new questions only).`);
-			write(`Appointments: would create ${appointmentCount}.`);
-			write(`Notifications: would create ${notificationCount} per member.`);
-			write(`Conversations: would create ${conversationCount}.`);
+			const planned = resolveSeedCounts(countsFrom(options));
+			write(`Customers: would create ${planned.customers}.`);
+			write(`FAQs: would create up to ${planned.faqs} (new questions only).`);
+			write(`Appointments: would create ${planned.appointments}.`);
+			write(`Notifications: would create ${planned.notifications} per member.`);
+			write(`Conversations: would create ${planned.conversations}.`);
 			write('Dry run complete — no AI calls, nothing written.');
 			return;
 		}
 
-		const context: BusinessContext = {
-			businessName: account.name,
-			website: account.website,
-			address: account.address,
-		};
-		const customers = new MongoCustomerRepository();
-		const memberIds = (await new MongoMembershipRepository().listByAccount(account.id)).map(
-			(membership) => membership.userId,
-		);
-
-		const newCustomerIds = await seedCustomers(
-			customers,
+		await seedAccountData(
+			{
+				customers: new MongoCustomerRepository(),
+				faqs: new MongoFaqRepository(),
+				jobs: new MongoJobRepository(),
+				notifications: new MongoNotificationRepository(),
+				conversations: new MongoConversationRepository(),
+				memberships: new MongoMembershipRepository(),
+			},
 			generator,
 			account,
-			context,
-			customerCount,
-		);
-		await seedFaqs(new MongoFaqRepository(), generator, account, context, faqCount);
-
-		// Link appointments to the customers we just created; if none were (e.g.
-		// `--customers 0`), fall back to the account's existing customers.
-		let customerIds = newCustomerIds;
-		if (customerIds.length === 0 && appointmentCount > 0) {
-			const existing = await customers.list({ accountId: account.id, page: 1, pageSize: 100 });
-			customerIds = existing.customers.map((customer) => customer.id);
-		}
-		await seedAppointments(
-			new MongoJobRepository(),
-			generator,
-			account,
-			context,
-			appointmentCount,
-			customerIds,
-			memberIds,
-		);
-		await seedNotifications(
-			new MongoNotificationRepository(),
-			account,
-			memberIds,
-			notificationCount,
-		);
-
-		// Link conversations to the account's customers (the ones just seeded, or the
-		// existing roster when customers were skipped) so each thread has a real contact.
-		let contacts: ConversationContact[] = [];
-		if (conversationCount > 0) {
-			const roster = await customers.list({ accountId: account.id, page: 1, pageSize: 100 });
-			contacts = roster.customers.map((customer) => ({
-				customerId: customer.id,
-				name: customer.name,
-				phone: customer.phone,
-			}));
-		}
-		await seedConversations(
-			new MongoConversationRepository(),
-			account,
-			contacts,
-			conversationCount,
+			countsFrom(options),
+			{ log: write },
 		);
 
 		write('Seeding complete.');

--- a/packages/api/src/services/seed.ts
+++ b/packages/api/src/services/seed.ts
@@ -1,0 +1,386 @@
+import { faker } from '@faker-js/faker';
+import type { Account, AccountId, UserId } from '@rivus/core';
+import type {
+	ConversationRepository,
+	CustomerRepository,
+	FaqRepository,
+	JobRepository,
+	MembershipRepository,
+	NotificationRepository,
+} from '../repositories/types';
+import type { BusinessContext, SeedGenerator } from '../seed-ai';
+import {
+	type ConversationContact,
+	generateConversations,
+	generateNotifications,
+	SEED_APPOINTMENT_MAX,
+	SEED_APPOINTMENT_MIN,
+	SEED_CONVERSATION_MAX,
+	SEED_CONVERSATION_MIN,
+	SEED_CUSTOMER_MAX,
+	SEED_CUSTOMER_MIN,
+	SEED_FAQ_DEFAULT,
+	SEED_NOTIFICATION_MAX,
+	SEED_NOTIFICATION_MIN,
+	selectNewFaqs,
+} from '../seed-data';
+
+/**
+ * The account seeder, expressed against the repository interfaces so it runs
+ * over either the Mongo repositories (the `seed` CLI) or the in-memory ones (the
+ * development-only `POST /v1/admin/seed` route and its tests). It writes through
+ * the same repositories and Zod schemas the API uses, so seeded rows are
+ * identical to ones created over HTTP.
+ *
+ * The data itself is produced by an injected {@link SeedGenerator} — AI-tailored
+ * when a provider key is configured, deterministic faker/curated otherwise — and
+ * the pure generators live in `seed-data.ts` / `seed-ai.ts`. This module is just
+ * the orchestration: resolve the counts, fan out to each entity, and report what
+ * was written.
+ */
+
+/** The repositories the seeder writes through (a subset of `AppDeps`). */
+export interface SeedRepositories {
+	customers: CustomerRepository;
+	faqs: FaqRepository;
+	jobs: JobRepository;
+	notifications: NotificationRepository;
+	conversations: ConversationRepository;
+	memberships: MembershipRepository;
+}
+
+/** Per-entity counts to seed; an absent count means "use the seeder's default". */
+export interface SeedAccountCounts {
+	customers?: number;
+	faqs?: number;
+	appointments?: number;
+	notifications?: number;
+	conversations?: number;
+}
+
+/** The concrete counts after every absent one is filled with its default. */
+export interface ResolvedSeedCounts {
+	customers: number;
+	faqs: number;
+	appointments: number;
+	notifications: number;
+	conversations: number;
+}
+
+/** A tally of what a seeding run created, for reporting back to the caller. */
+export interface SeedAccountResult {
+	customers: number;
+	/** FAQs newly created (excludes any whose question already existed). */
+	faqs: number;
+	/** FAQs skipped because the question was already present on the account. */
+	faqsSkipped: number;
+	appointments: number;
+	notifications: number;
+	conversations: number;
+	/** How many account members the notifications were addressed to. */
+	members: number;
+	/** Which generator produced the data. */
+	generation: 'ai' | 'deterministic';
+}
+
+export interface SeedAccountOptions {
+	/** Optional faker seed for a reproducible batch. */
+	seed?: number;
+	/** Optional progress sink (the CLI passes stdout; the route passes nothing). */
+	log?: (message: string) => void;
+}
+
+/**
+ * Resolve each requested count to a concrete number, filling an absent count with
+ * the seeder's default (the full curated FAQ set, or a random value in a small
+ * range). Seed faker first (`faker.seed(n)`) for a reproducible result.
+ */
+export function resolveSeedCounts(counts: SeedAccountCounts): ResolvedSeedCounts {
+	return {
+		customers:
+			counts.customers ?? faker.number.int({ min: SEED_CUSTOMER_MIN, max: SEED_CUSTOMER_MAX }),
+		faqs: counts.faqs ?? SEED_FAQ_DEFAULT,
+		appointments:
+			counts.appointments ??
+			faker.number.int({ min: SEED_APPOINTMENT_MIN, max: SEED_APPOINTMENT_MAX }),
+		notifications:
+			counts.notifications ??
+			faker.number.int({ min: SEED_NOTIFICATION_MIN, max: SEED_NOTIFICATION_MAX }),
+		conversations:
+			counts.conversations ??
+			faker.number.int({ min: SEED_CONVERSATION_MIN, max: SEED_CONVERSATION_MAX }),
+	};
+}
+
+/** Gather every existing FAQ question for an account, paging through the repository. */
+async function collectExistingFaqQuestions(
+	faqs: FaqRepository,
+	accountId: AccountId,
+): Promise<string[]> {
+	const pageSize = 100;
+	const questions: string[] = [];
+	let page = 1;
+	// Page until we've collected `total`; the generous guard stops a runaway loop
+	// if the count and the returned rows ever disagree.
+	for (let guard = 0; guard < 1000; guard += 1) {
+		const { faqs: batch, total } = await faqs.list({ accountId, page, pageSize });
+		for (const faq of batch) {
+			questions.push(faq.question);
+		}
+		if (batch.length === 0 || questions.length >= total) {
+			break;
+		}
+		page += 1;
+	}
+	return questions;
+}
+
+/** Create `count` customers via the generator; returns the new customers' ids. */
+async function seedCustomers(
+	customers: CustomerRepository,
+	generator: SeedGenerator,
+	account: Account,
+	context: BusinessContext,
+	count: number,
+	log: (message: string) => void,
+): Promise<string[]> {
+	if (count === 0) {
+		log('Customers: skipped (count 0).');
+		return [];
+	}
+	const inputs = await generator.generateCustomers(count, context);
+	const ids: string[] = [];
+	for (const input of inputs) {
+		const created = await customers.create(account.id, input);
+		ids.push(created.id);
+	}
+	log(`Customers: created ${ids.length}.`);
+	return ids;
+}
+
+/** Create up to `count` FAQs, skipping any whose question already exists. */
+async function seedFaqs(
+	faqs: FaqRepository,
+	generator: SeedGenerator,
+	account: Account,
+	context: BusinessContext,
+	count: number,
+	log: (message: string) => void,
+): Promise<{ created: number; skipped: number }> {
+	if (count === 0) {
+		log('FAQs: skipped (count 0).');
+		return { created: 0, skipped: 0 };
+	}
+	const candidates = await generator.generateFaqs(count, context);
+	const existing = await collectExistingFaqQuestions(faqs, account.id);
+	const { toCreate, skipped } = selectNewFaqs(candidates, existing);
+	const skipNote = skipped.length > 0 ? ` (${skipped.length} already present, skipped)` : '';
+	for (const input of toCreate) {
+		await faqs.create(account.id, input);
+	}
+	log(`FAQs: created ${toCreate.length}${skipNote}.`);
+	return { created: toCreate.length, skipped: skipped.length };
+}
+
+/** Create `count` appointments (Jobs) linked to the given customers and members. */
+async function seedAppointments(
+	jobs: JobRepository,
+	generator: SeedGenerator,
+	account: Account,
+	context: BusinessContext,
+	count: number,
+	customerIds: string[],
+	memberIds: string[],
+	log: (message: string) => void,
+): Promise<number> {
+	if (count === 0) {
+		log('Appointments: skipped (count 0).');
+		return 0;
+	}
+	const inputs = await generator.generateAppointments(
+		{ count, customerIds, memberIds, referenceDate: new Date() },
+		context,
+	);
+	for (const input of inputs) {
+		await jobs.create(account.id, input);
+	}
+	const linkNote = customerIds.length === 0 ? ' (no customers to link)' : '';
+	log(`Appointments: created ${inputs.length}${linkNote}.`);
+	return inputs.length;
+}
+
+/**
+ * Create `countPerMember` demo notifications for each of the account's members so
+ * their bell looks lived-in, then mark the older half read so the unread badge
+ * shows a realistic subset rather than every row glowing. Returns the total created.
+ */
+async function seedNotifications(
+	notifications: NotificationRepository,
+	account: Account,
+	memberIds: UserId[],
+	countPerMember: number,
+	log: (message: string) => void,
+): Promise<number> {
+	if (countPerMember === 0) {
+		log('Notifications: skipped (count 0).');
+		return 0;
+	}
+	if (memberIds.length === 0) {
+		log('Notifications: skipped (no members to notify).');
+		return 0;
+	}
+	let created = 0;
+	for (const memberId of memberIds) {
+		const ids = [];
+		for (const input of generateNotifications(countPerMember)) {
+			const notification = await notifications.create(account.id, memberId, input);
+			ids.push(notification.id);
+		}
+		// The list is newest-first, so marking the first (oldest) half read leaves the
+		// most recent notifications unread — the natural "haven't seen these yet" state.
+		const readCount = Math.floor(ids.length / 2);
+		for (let i = 0; i < readCount; i += 1) {
+			const id = ids[i];
+			if (id) {
+				await notifications.markRead(account.id, memberId, id);
+			}
+		}
+		created += ids.length;
+	}
+	log(`Notifications: created ${created} across ${memberIds.length} member(s).`);
+	return created;
+}
+
+/**
+ * Create `count` inbox conversations linked to the account's customers, replaying
+ * each scripted message through the repository (and setting the review state for
+ * the flagged thread) so the seeded inbox is identical to one built over HTTP.
+ * Returns the number of conversations created.
+ */
+async function seedConversations(
+	conversations: ConversationRepository,
+	account: Account,
+	contacts: ConversationContact[],
+	count: number,
+	log: (message: string) => void,
+): Promise<number> {
+	if (count === 0) {
+		log('Conversations: skipped (count 0).');
+		return 0;
+	}
+	const seeds = generateConversations(count, contacts);
+	for (const seed of seeds) {
+		const created = await conversations.create(account.id, seed.conversation);
+		for (const message of seed.messages) {
+			await conversations.addMessage(account.id, created.id, message);
+		}
+		if (seed.review) {
+			await conversations.setReviewState(account.id, created.id, {
+				status: 'needs_attention',
+				pendingReply: seed.review.pendingReply,
+				flagReason: seed.review.flagReason,
+			});
+		}
+	}
+	const linkNote = contacts.length === 0 ? ' (no customers to link)' : '';
+	log(`Conversations: created ${seeds.length}${linkNote}.`);
+	return seeds.length;
+}
+
+/**
+ * Seed one account with demo data: CRM customers, a business-FAQ knowledge base,
+ * scheduled appointments (Jobs), per-member notifications, and inbox
+ * conversations. Each entity links to the ones before it (appointments and
+ * conversations to the seeded customers; notifications to the account's members),
+ * so the result reads like a real, lived-in account.
+ *
+ * Returns a tally of what was written. Pass `options.log` to stream progress
+ * (the CLI does); the route omits it and uses the returned summary instead.
+ */
+export async function seedAccountData(
+	repos: SeedRepositories,
+	generator: SeedGenerator,
+	account: Account,
+	counts: SeedAccountCounts,
+	options: SeedAccountOptions = {},
+): Promise<SeedAccountResult> {
+	const log = options.log ?? (() => {});
+	if (options.seed !== undefined) {
+		faker.seed(options.seed);
+	}
+	const resolved = resolveSeedCounts(counts);
+
+	const context: BusinessContext = {
+		businessName: account.name,
+		website: account.website,
+		address: account.address,
+	};
+	const memberIds = (await repos.memberships.listByAccount(account.id)).map(
+		(membership) => membership.userId,
+	);
+
+	const newCustomerIds = await seedCustomers(
+		repos.customers,
+		generator,
+		account,
+		context,
+		resolved.customers,
+		log,
+	);
+	const faqResult = await seedFaqs(repos.faqs, generator, account, context, resolved.faqs, log);
+
+	// Link appointments to the customers we just created; if none were (e.g.
+	// `customers: 0`), fall back to the account's existing customers.
+	let customerIds = newCustomerIds;
+	if (customerIds.length === 0 && resolved.appointments > 0) {
+		const existing = await repos.customers.list({ accountId: account.id, page: 1, pageSize: 100 });
+		customerIds = existing.customers.map((customer) => customer.id);
+	}
+	const appointments = await seedAppointments(
+		repos.jobs,
+		generator,
+		account,
+		context,
+		resolved.appointments,
+		customerIds,
+		memberIds,
+		log,
+	);
+	const notifications = await seedNotifications(
+		repos.notifications,
+		account,
+		memberIds,
+		resolved.notifications,
+		log,
+	);
+
+	// Link conversations to the account's customers (the ones just seeded, or the
+	// existing roster when customers were skipped) so each thread has a real contact.
+	let contacts: ConversationContact[] = [];
+	if (resolved.conversations > 0) {
+		const roster = await repos.customers.list({ accountId: account.id, page: 1, pageSize: 100 });
+		contacts = roster.customers.map((customer) => ({
+			customerId: customer.id,
+			name: customer.name,
+			phone: customer.phone,
+		}));
+	}
+	const conversations = await seedConversations(
+		repos.conversations,
+		account,
+		contacts,
+		resolved.conversations,
+		log,
+	);
+
+	return {
+		customers: newCustomerIds.length,
+		faqs: faqResult.created,
+		faqsSkipped: faqResult.skipped,
+		appointments,
+		notifications,
+		conversations,
+		members: memberIds.length,
+		generation: generator.usesAi ? 'ai' : 'deterministic',
+	};
+}

--- a/packages/api/test/seed-account.test.ts
+++ b/packages/api/test/seed-account.test.ts
@@ -1,0 +1,350 @@
+import { faker } from '@faker-js/faker';
+import type { Account } from '@rivus/core';
+import type { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadConfig } from '../src/config';
+import { createInMemoryRepositories, type InMemoryRepositories } from '../src/repositories/memory';
+import { DeterministicSeedGenerator } from '../src/seed-ai';
+import { SEED_CUSTOMER_MAX, SEED_CUSTOMER_MIN, SEED_FAQ_DEFAULT } from '../src/seed-data';
+import { resolveSeedCounts, seedAccountData } from '../src/services/seed';
+import { authHeader, buildTestApp, signupOwner } from './helpers';
+
+const STAFF_EMAIL = 'ops@rivus.ai';
+
+const generator = new DeterministicSeedGenerator();
+
+/** An account with a single owner membership, over fresh in-memory repositories. */
+async function accountWithOwner(): Promise<{ repos: InMemoryRepositories; account: Account }> {
+	const repos = createInMemoryRepositories();
+	const { account } = await repos.onboarding.signup({
+		user: { email: 'owner@acme.test', name: 'Acme Owner' },
+		account: {
+			name: 'Acme Co',
+			slug: 'acme-co',
+			phone: '',
+			address: '',
+			website: '',
+			timezone: 'UTC',
+		},
+	});
+	return { repos, account };
+}
+
+describe('seedAccountData', () => {
+	it('seeds the requested counts and links them to the account', async () => {
+		const { repos, account } = await accountWithOwner();
+
+		const summary = await seedAccountData(
+			repos,
+			generator,
+			account,
+			{ customers: 3, faqs: 4, appointments: 5, notifications: 2, conversations: 2 },
+			{ seed: 7 },
+		);
+
+		expect(summary).toEqual({
+			customers: 3,
+			faqs: 4,
+			faqsSkipped: 0,
+			appointments: 5,
+			// 2 per member × 1 member.
+			notifications: 2,
+			conversations: 2,
+			members: 1,
+			generation: 'deterministic',
+		});
+
+		const customers = await repos.customers.list({ accountId: account.id, page: 1, pageSize: 100 });
+		expect(customers.total).toBe(3);
+		const faqs = await repos.faqs.list({ accountId: account.id, page: 1, pageSize: 100 });
+		expect(faqs.total).toBe(4);
+		const jobs = await repos.jobs.list({ accountId: account.id, page: 1, pageSize: 100 });
+		expect(jobs.total).toBe(5);
+		// Every seeded appointment is linked to one of the seeded customers.
+		expect(jobs.jobs.every((job) => job.customerId !== '')).toBe(true);
+		const conversations = await repos.conversations.list({
+			accountId: account.id,
+			page: 1,
+			pageSize: 100,
+		});
+		expect(conversations.total).toBe(2);
+	});
+
+	it('addresses notifications to each member and leaves the newest unread', async () => {
+		const { repos, account } = await accountWithOwner();
+		const ownerId = (await repos.memberships.listByAccount(account.id))[0]?.userId;
+		if (!ownerId) {
+			throw new Error('expected an owner membership');
+		}
+
+		await seedAccountData(repos, generator, account, {
+			customers: 0,
+			faqs: 0,
+			appointments: 0,
+			notifications: 4,
+			conversations: 0,
+		});
+
+		const list = await repos.notifications.list({
+			accountId: account.id,
+			userId: ownerId,
+			page: 1,
+			pageSize: 100,
+			unreadOnly: false,
+		});
+		expect(list.total).toBe(4);
+		// The older half is marked read, so the unread count is the remaining newest.
+		const unread = await repos.notifications.unreadCount(account.id, ownerId);
+		expect(unread).toBe(2);
+	});
+
+	it('flags the seeded billing thread for human review', async () => {
+		const { repos, account } = await accountWithOwner();
+		await seedAccountData(repos, generator, account, {
+			customers: 3,
+			faqs: 0,
+			appointments: 0,
+			notifications: 0,
+			conversations: 5,
+		});
+		const needsAttention = await repos.conversations.needsAttentionCount(account.id);
+		expect(needsAttention).toBe(1);
+	});
+
+	it('skips FAQs whose question already exists on a re-run', async () => {
+		const { repos, account } = await accountWithOwner();
+		const counts = { customers: 0, faqs: 4, appointments: 0, notifications: 0, conversations: 0 };
+
+		const first = await seedAccountData(repos, generator, account, counts);
+		expect(first.faqs).toBe(4);
+		expect(first.faqsSkipped).toBe(0);
+
+		const second = await seedAccountData(repos, generator, account, counts);
+		expect(second.faqs).toBe(0);
+		expect(second.faqsSkipped).toBe(4);
+		// No duplicates were written.
+		const faqs = await repos.faqs.list({ accountId: account.id, page: 1, pageSize: 100 });
+		expect(faqs.total).toBe(4);
+	});
+
+	it('links appointments to existing customers when customers are skipped', async () => {
+		const { repos, account } = await accountWithOwner();
+		await seedAccountData(repos, generator, account, {
+			customers: 3,
+			faqs: 0,
+			appointments: 0,
+			notifications: 0,
+			conversations: 0,
+		});
+
+		const summary = await seedAccountData(repos, generator, account, {
+			customers: 0,
+			faqs: 0,
+			appointments: 4,
+			notifications: 0,
+			conversations: 0,
+		});
+		expect(summary.appointments).toBe(4);
+		const jobs = await repos.jobs.list({ accountId: account.id, page: 1, pageSize: 100 });
+		expect(jobs.jobs.every((job) => job.customerId !== '')).toBe(true);
+	});
+
+	it('skips every entity when all counts are 0', async () => {
+		const { repos, account } = await accountWithOwner();
+		const summary = await seedAccountData(repos, generator, account, {
+			customers: 0,
+			faqs: 0,
+			appointments: 0,
+			notifications: 0,
+			conversations: 0,
+		});
+		expect(summary).toEqual({
+			customers: 0,
+			faqs: 0,
+			faqsSkipped: 0,
+			appointments: 0,
+			notifications: 0,
+			conversations: 0,
+			members: 1,
+			generation: 'deterministic',
+		});
+	});
+
+	it('skips notifications when the account has no members', async () => {
+		const repos = createInMemoryRepositories();
+		const account = await repos.accounts.create({
+			name: 'No Members',
+			slug: 'no-members',
+			phone: '',
+			address: '',
+			website: '',
+			timezone: 'UTC',
+		});
+		const summary = await seedAccountData(repos, generator, account, {
+			customers: 1,
+			faqs: 0,
+			appointments: 0,
+			notifications: 3,
+			conversations: 0,
+		});
+		expect(summary.members).toBe(0);
+		expect(summary.notifications).toBe(0);
+	});
+
+	it('falls back to default counts when they are omitted', async () => {
+		const { repos, account } = await accountWithOwner();
+		const summary = await seedAccountData(repos, generator, account, {}, { seed: 3 });
+		expect(summary.faqs).toBe(SEED_FAQ_DEFAULT);
+		expect(summary.customers).toBeGreaterThanOrEqual(SEED_CUSTOMER_MIN);
+		expect(summary.customers).toBeLessThanOrEqual(SEED_CUSTOMER_MAX);
+	});
+
+	it('streams progress to the log callback', async () => {
+		const { repos, account } = await accountWithOwner();
+		const messages: string[] = [];
+		await seedAccountData(
+			repos,
+			generator,
+			account,
+			{ customers: 2, faqs: 0, appointments: 0, notifications: 0, conversations: 0 },
+			{ log: (message) => messages.push(message) },
+		);
+		expect(messages).toContain('Customers: created 2.');
+		expect(messages).toContain('FAQs: skipped (count 0).');
+	});
+});
+
+describe('resolveSeedCounts', () => {
+	it('keeps explicit counts and fills absent ones with in-range defaults', () => {
+		faker.seed(11);
+		const resolved = resolveSeedCounts({ faqs: 2, appointments: 0 });
+		expect(resolved.faqs).toBe(2);
+		expect(resolved.appointments).toBe(0);
+		expect(resolved.customers).toBeGreaterThanOrEqual(SEED_CUSTOMER_MIN);
+		expect(resolved.customers).toBeLessThanOrEqual(SEED_CUSTOMER_MAX);
+		expect(Number.isInteger(resolved.notifications)).toBe(true);
+		expect(Number.isInteger(resolved.conversations)).toBe(true);
+	});
+});
+
+describe('POST /v1/admin/seed (development only)', () => {
+	/** A dev-mode app: the only environment where the seed route is registered. */
+	function buildDevApp(): Promise<FastifyInstance> {
+		return buildTestApp({
+			config: loadConfig({
+				NODE_ENV: 'development',
+				JWT_SECRET: 'test-secret-value-1234',
+				LOG_LEVEL: 'silent',
+			} as NodeJS.ProcessEnv),
+		});
+	}
+
+	describe('when NODE_ENV is not development', () => {
+		let app: FastifyInstance;
+
+		beforeEach(async () => {
+			// The default test app runs with NODE_ENV=test, so the route is never registered.
+			app = await buildTestApp();
+		});
+
+		afterEach(async () => {
+			await app.close();
+		});
+
+		it('does not register the route (404), even for staff', async () => {
+			const staff = await signupOwner(app, { email: STAFF_EMAIL, businessName: 'Rivus HQ' });
+			const response = await app.inject({
+				method: 'POST',
+				url: '/v1/admin/seed',
+				headers: authHeader(staff.token),
+				payload: {},
+			});
+			expect(response.statusCode).toBe(404);
+		});
+	});
+
+	describe('when NODE_ENV is development', () => {
+		let app: FastifyInstance;
+
+		beforeEach(async () => {
+			app = await buildDevApp();
+		});
+
+		afterEach(async () => {
+			await app.close();
+		});
+
+		function seed(token: string, payload: Record<string, unknown> = {}) {
+			return app.inject({
+				method: 'POST',
+				url: '/v1/admin/seed',
+				headers: authHeader(token),
+				payload,
+			});
+		}
+
+		it('seeds the current account for staff and reports a summary', async () => {
+			const staff = await signupOwner(app, { email: STAFF_EMAIL, businessName: 'Rivus HQ' });
+
+			const response = await seed(staff.token, {
+				customers: 4,
+				faqs: 3,
+				appointments: 2,
+				notifications: 0,
+				conversations: 0,
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(response.json()).toEqual({
+				customers: 4,
+				faqs: 3,
+				faqsSkipped: 0,
+				appointments: 2,
+				notifications: 0,
+				conversations: 0,
+				members: 1,
+				generation: 'deterministic',
+			});
+
+			// The data really landed on the account: read it back over the API.
+			const customers = await app.inject({
+				method: 'GET',
+				url: '/v1/customers?page=1&pageSize=100',
+				headers: authHeader(staff.token),
+			});
+			expect(customers.json().meta.total).toBe(4);
+			const faqs = await app.inject({
+				method: 'GET',
+				url: '/v1/faqs?page=1&pageSize=100',
+				headers: authHeader(staff.token),
+			});
+			expect(faqs.json().meta.total).toBe(3);
+		});
+
+		it('applies sensible defaults when no counts are given', async () => {
+			const staff = await signupOwner(app, { email: STAFF_EMAIL, businessName: 'Rivus HQ' });
+			const response = await seed(staff.token, {});
+			expect(response.statusCode).toBe(200);
+			const body = response.json();
+			expect(body.faqs).toBe(SEED_FAQ_DEFAULT);
+			expect(body.customers).toBeGreaterThanOrEqual(SEED_CUSTOMER_MIN);
+		});
+
+		it('rejects a non-staff user with 403', async () => {
+			const owner = await signupOwner(app, { businessName: 'Acme Plumbing' });
+			const response = await seed(owner.token);
+			expect(response.statusCode).toBe(403);
+		});
+
+		it('rejects an unauthenticated request with 401', async () => {
+			const response = await app.inject({ method: 'POST', url: '/v1/admin/seed', payload: {} });
+			expect(response.statusCode).toBe(401);
+		});
+
+		it('rejects a count above the cap with 400', async () => {
+			const staff = await signupOwner(app, { email: STAFF_EMAIL, businessName: 'Rivus HQ' });
+			const response = await seed(staff.token, { customers: 10_000 });
+			expect(response.statusCode).toBe(400);
+		});
+	});
+});

--- a/packages/app/app/settings.tsx
+++ b/packages/app/app/settings.tsx
@@ -7,8 +7,8 @@ import {
 	useWindowDimensions,
 	View,
 } from 'react-native';
-import { ApiError, type Billing } from '@/src/api/client';
-import { getGoogleMapsApiKey } from '@/src/api/config';
+import { ApiError, type Billing, type SeedSummary } from '@/src/api/client';
+import { getGoogleMapsApiKey, isDevelopment } from '@/src/api/config';
 import { deviceTimezone, listTimezones } from '@/src/api/timezones';
 import { useAuth } from '@/src/auth/AuthContext';
 import { AddressAutocomplete } from '@/src/components/AddressAutocomplete';
@@ -33,6 +33,71 @@ function messageFor(error: unknown, fallback: string): string {
 		return error.message;
 	}
 	return fallback;
+}
+
+/**
+ * A development-only, Rivus-staff-only affordance to fill the current account with
+ * demo data (customers, FAQs, appointments, notifications, and inbox
+ * conversations) so there's something to test against. It self-gates on
+ * {@link isDevelopment} plus staff status and renders nothing otherwise — the API
+ * enforces the same rules server-side (the seed route exists only when its
+ * `NODE_ENV` is `development`, and rejects non-staff callers), so this is purely
+ * about not showing a control that wouldn't work.
+ */
+function DevSeedCard() {
+	const { session, client, isStaff } = useAuth();
+	const [seeding, setSeeding] = useState(false);
+	const [summary, setSummary] = useState<SeedSummary | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const visible = Boolean(session) && isStaff && isDevelopment();
+
+	async function onSeed() {
+		if (seeding || !session) {
+			return;
+		}
+		setError(null);
+		setSummary(null);
+		setSeeding(true);
+		try {
+			const result = await client.seedAccount(session.token);
+			setSummary(result);
+		} catch (caught) {
+			setError(messageFor(caught, 'Could not seed the account.'));
+		} finally {
+			setSeeding(false);
+		}
+	}
+
+	if (!visible || !session) {
+		return null;
+	}
+
+	return (
+		<Card style={[styles.card, styles.devCard]}>
+			<SectionLabel style={styles.devLabel}>Developer · seed account</SectionLabel>
+			<Txt style={styles.rowSub}>
+				Fill {session.account.name} with demo customers, FAQs, appointments, notifications, and
+				inbox conversations so you have realistic data to test against. Visible only in development,
+				to Rivus staff.
+			</Txt>
+
+			{error ? <Txt style={styles.errorTxt}>{error}</Txt> : null}
+			{summary ? (
+				<Txt style={styles.savedTxt}>
+					Seeded {summary.customers} customers, {summary.faqs} FAQs, {summary.appointments}{' '}
+					appointments, {summary.notifications} notifications, and {summary.conversations}{' '}
+					conversations.
+				</Txt>
+			) : null}
+
+			<GradientButton
+				label={seeding ? 'Seeding…' : 'Seed this account'}
+				icon="database"
+				onPress={onSeed}
+			/>
+		</Card>
+	);
 }
 
 export default function SettingsScreen() {
@@ -125,6 +190,7 @@ export default function SettingsScreen() {
 						something updated.
 					</Txt>
 				</Card>
+				<DevSeedCard />
 			</ScrollView>
 		);
 	}
@@ -290,6 +356,8 @@ export default function SettingsScreen() {
 					/>
 				)}
 			</Card>
+
+			<DevSeedCard />
 		</ScrollView>
 	);
 }
@@ -375,6 +443,14 @@ const styles = StyleSheet.create({
 	},
 	dangerLabel: {
 		color: colors.redInk,
+	},
+	// A violet-tinted border marks the dev-only seeder as a distinct, internal tool
+	// (mirrors how the danger zone is set apart), without using the signature gradient.
+	devCard: {
+		borderColor: 'rgba(110,30,200,0.30)',
+	},
+	devLabel: {
+		color: colors.brandPurpleInk,
 	},
 	dangerBtn: {
 		borderColor: 'rgba(240,88,75,0.45)',

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -1706,4 +1706,68 @@ describe('createApiClient', () => {
 			expect(init.credentials).toBeUndefined();
 		});
 	});
+
+	describe('seedAccount', () => {
+		function makeSummary(overrides: Record<string, unknown> = {}) {
+			return {
+				customers: 25,
+				faqs: 14,
+				faqsSkipped: 0,
+				appointments: 18,
+				notifications: 6,
+				conversations: 6,
+				members: 1,
+				generation: 'deterministic' as const,
+				...overrides,
+			};
+		}
+
+		it('posts the seed options and returns the parsed summary', async () => {
+			const summary = makeSummary();
+			fetchMock.mockResolvedValueOnce(jsonResponse(summary));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.seedAccount('staff-token', { customers: 25, faqs: 14 });
+
+			expect(result).toEqual(summary);
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/admin/seed`);
+			expect(init.method).toBe('POST');
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer staff-token' });
+			// `ai` carries its schema default; the explicit counts pass through.
+			expect(JSON.parse(init.body as string)).toEqual({ customers: 25, faqs: 14, ai: false });
+		});
+
+		it('defaults to an empty (all-defaults) body', async () => {
+			fetchMock.mockResolvedValueOnce(jsonResponse(makeSummary()));
+
+			const client = createApiClient(BASE, fetchMock);
+			await client.seedAccount('staff-token');
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(JSON.parse(init.body as string)).toEqual({ ai: false });
+		});
+
+		it('rejects an out-of-range count before any network call', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.seedAccount('staff-token', { customers: 100_000 })).rejects.toThrow(
+				ValidationError,
+			);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('surfaces a 404 (route absent outside development) as an ApiError', async () => {
+			fetchMock.mockResolvedValueOnce(
+				jsonResponse(
+					{ error: 'Not Found', message: 'Route POST:/v1/admin/seed not found', statusCode: 404 },
+					{ status: 404 },
+				),
+			);
+
+			const client = createApiClient(BASE, fetchMock);
+			const error = await client.seedAccount('staff-token').catch((caught) => caught);
+			expect(error).toBeInstanceOf(ApiError);
+			expect(error).toMatchObject({ status: 404 });
+		});
+	});
 });

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -49,6 +49,7 @@ import {
 	roleSchema,
 	type SendMessageInput,
 	searchQuerySchema,
+	seedAccountSchema,
 	sendMessageSchema,
 	signupSchema,
 	type UpdateAccountInput,
@@ -462,6 +463,9 @@ export type CreateConversationBody = z.input<typeof createConversationSchema>;
 /** approveReply accepts the schema's *input* (`body` optional — omit to send the held draft). */
 export type ApproveReplyBody = z.input<typeof approveReplySchema>;
 
+/** seedAccount accepts the schema's *input* — every count, `ai`, and `seed` optional. */
+export type SeedAccountBody = z.input<typeof seedAccountSchema>;
+
 const faqSimilarityResponseSchema = z.object({
 	match: faqResponseSchema.nullable(),
 	reason: z.string(),
@@ -495,6 +499,20 @@ export interface CompanyListResponse {
 
 /** Query for {@link RivusApiClient.listCompanies}: pagination plus a name/slug search. */
 export type CompanyListQuery = Partial<PaginationQuery> & { search?: string };
+
+// Tally returned by the development-only account seeder (mirrors the API's
+// `seedSummaryResponseSchema`).
+const seedSummaryResponseSchema = z.object({
+	customers: z.number().int(),
+	faqs: z.number().int(),
+	faqsSkipped: z.number().int(),
+	appointments: z.number().int(),
+	notifications: z.number().int(),
+	conversations: z.number().int(),
+	members: z.number().int(),
+	generation: z.enum(['ai', 'deterministic']),
+});
+export type SeedSummary = z.infer<typeof seedSummaryResponseSchema>;
 
 const healthResponseSchema = z.object({
 	status: z.literal('ok'),
@@ -642,6 +660,15 @@ export interface RivusApiClient {
 	 * it (Rivus staff only). On web the API also sets the new session cookie.
 	 */
 	switchCompany(token: string, accountId: AccountId): Promise<AuthResponse>;
+	/**
+	 * Seed the current account with demo data (customers, FAQs, appointments,
+	 * notifications, conversations) and return a tally of what was created.
+	 *
+	 * Development + Rivus-staff only: the API registers this route solely when its
+	 * `NODE_ENV` is `development`, so it 404s in any deployed environment and 403s
+	 * for non-staff callers. The app gates the Settings affordance the same way.
+	 */
+	seedAccount(token: string, input?: SeedAccountBody): Promise<SeedSummary>;
 }
 
 /** Strip a single trailing slash so `${base}${path}` never doubles up. */
@@ -1108,6 +1135,11 @@ export function createApiClient(
 				authResponseSchema,
 				{ method: 'POST', headers: authHeaders(token) },
 			);
+		},
+
+		async seedAccount(token: string, input: SeedAccountBody = {}) {
+			const payload = parseInput(seedAccountSchema, input);
+			return request('/v1/admin/seed', seedSummaryResponseSchema, jsonInit('POST', payload, token));
 		},
 	};
 }

--- a/packages/app/src/api/config.test.ts
+++ b/packages/app/src/api/config.test.ts
@@ -6,6 +6,7 @@ import {
 	getApiBaseUrl,
 	getAppBaseUrl,
 	getGoogleMapsApiKey,
+	isDevelopment,
 } from './config';
 
 /** Temporarily install a fake `window` (the test runner is Node, where it's absent). */
@@ -130,5 +131,17 @@ describe('buildInviteAcceptUrl', () => {
 		// No base argument → resolves via getAppBaseUrl(); the path/token are stable
 		// regardless of which base wins, so assert on the suffix.
 		expect(buildInviteAcceptUrl('abc').endsWith('/accept-invite?token=abc')).toBe(true);
+	});
+});
+
+describe('isDevelopment', () => {
+	it('is true only when NODE_ENV is exactly "development"', () => {
+		expect(isDevelopment('development')).toBe(true);
+	});
+
+	it('is false for production, test, or an unset value', () => {
+		expect(isDevelopment('production')).toBe(false);
+		expect(isDevelopment('test')).toBe(false);
+		expect(isDevelopment(undefined)).toBe(false);
 	});
 });

--- a/packages/app/src/api/config.ts
+++ b/packages/app/src/api/config.ts
@@ -44,6 +44,30 @@ function stripTrailingSlash(value: string): string {
 	return value.replace(/\/+$/, '');
 }
 
+/**
+ * The build-time `NODE_ENV`, guarded like {@link ambientEnv} — in some React
+ * Native / Expo (or edge) JS engines `process` may be undefined or shimmed
+ * without an `env`, which would crash a direct property read.
+ */
+function ambientNodeEnv(): string | undefined {
+	if (typeof process === 'undefined' || typeof process.env === 'undefined') {
+		return undefined;
+	}
+	return process.env.NODE_ENV;
+}
+
+/**
+ * Whether the app is running a development build. The development-only account
+ * seeder in Settings is gated on this (together with Rivus-staff status) so it
+ * never appears in a production build — mirroring the API, which only registers
+ * `POST /v1/admin/seed` when its own `NODE_ENV` is `development`. Expo/Metro
+ * inlines `process.env.NODE_ENV` at build time; the `nodeEnv` parameter keeps
+ * this hermetically testable.
+ */
+export function isDevelopment(nodeEnv: string | undefined = ambientNodeEnv()): boolean {
+	return nodeEnv === 'development';
+}
+
 export function getApiBaseUrl(env: Record<string, string | undefined> = ambientEnv()): string {
 	const fromEnv = env.EXPO_PUBLIC_API_URL?.trim();
 	return fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_API_URL;

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -24,6 +24,8 @@ import {
 	notificationReadStateSchema,
 	notificationTypeSchema,
 	paginationQuerySchema,
+	SEED_COUNT_MAX,
+	seedAccountSchema,
 	sendMessageSchema,
 	signupSchema,
 	updateAccountSchema,
@@ -747,5 +749,50 @@ describe('conversationListQuerySchema', () => {
 
 	it('rejects an invalid status filter', () => {
 		expect(conversationListQuerySchema.safeParse({ status: 'spam' }).success).toBe(false);
+	});
+});
+
+describe('seedAccountSchema', () => {
+	it('defaults ai to false and leaves every count absent', () => {
+		expect(seedAccountSchema.parse({})).toEqual({ ai: false });
+	});
+
+	it('keeps explicit counts (including 0) and coerces numeric strings', () => {
+		expect(
+			seedAccountSchema.parse({
+				customers: 0,
+				faqs: '12',
+				appointments: 5,
+				notifications: 3,
+				conversations: 4,
+				ai: true,
+				seed: '42',
+			}),
+		).toEqual({
+			customers: 0,
+			faqs: 12,
+			appointments: 5,
+			notifications: 3,
+			conversations: 4,
+			ai: true,
+			seed: 42,
+		});
+	});
+
+	it('rejects a negative count', () => {
+		expect(seedAccountSchema.safeParse({ customers: -1 }).success).toBe(false);
+	});
+
+	it('rejects a non-integer count', () => {
+		expect(seedAccountSchema.safeParse({ faqs: 2.5 }).success).toBe(false);
+	});
+
+	it(`rejects a count above the ${SEED_COUNT_MAX} cap`, () => {
+		expect(seedAccountSchema.safeParse({ customers: SEED_COUNT_MAX + 1 }).success).toBe(false);
+		expect(seedAccountSchema.safeParse({ customers: SEED_COUNT_MAX }).success).toBe(true);
+	});
+
+	it('rejects a non-boolean ai flag', () => {
+		expect(seedAccountSchema.safeParse({ ai: 'yes' }).success).toBe(false);
 	});
 });

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -543,3 +543,46 @@ export const conversationListQuerySchema = paginationQuerySchema.extend({
 	status: conversationStatusSchema.optional(),
 });
 export type ConversationListQuery = z.infer<typeof conversationListQuerySchema>;
+
+// --- Account seeding (development only) ---------------------------------------
+
+/**
+ * Upper bound on any single seed count. The seeder is a development convenience
+ * (see `POST /v1/admin/seed`), so a generous cap keeps a stray request from
+ * ballooning the store while still allowing a healthy demo dataset.
+ */
+export const SEED_COUNT_MAX = 200;
+
+/** One optional, bounded entity count for the seeder (omit ⇒ a sensible default). */
+function seedCountSchema(label: string) {
+	return z.coerce
+		.number({ error: `${label} must be a number.` })
+		.int({ error: `${label} must be a whole number.` })
+		.min(0, { error: `${label} must be 0 or greater.` })
+		.max(SEED_COUNT_MAX, { error: `${label} must be ${SEED_COUNT_MAX} or fewer.` })
+		.optional();
+}
+
+/**
+ * Request body for the development-only account seeder (`POST /v1/admin/seed`).
+ *
+ * Every count is optional — omit it to let the seeder pick a sensible default (a
+ * curated set, or a random count in a small range). Passing `0` explicitly skips
+ * that entity. `ai` opts into AI-tailored data when a provider key is configured
+ * (it degrades to the built-in faker/curated generators otherwise); `seed` fixes
+ * the random generator so a batch is reproducible.
+ */
+export const seedAccountSchema = z.object({
+	customers: seedCountSchema('Customers'),
+	faqs: seedCountSchema('FAQs'),
+	appointments: seedCountSchema('Appointments'),
+	notifications: seedCountSchema('Notifications'),
+	conversations: seedCountSchema('Conversations'),
+	ai: z.boolean({ error: 'AI must be true or false.' }).default(false),
+	seed: z.coerce
+		.number({ error: 'Seed must be a number.' })
+		.int({ error: 'Seed must be a whole number.' })
+		.min(0, { error: 'Seed must be 0 or greater.' })
+		.optional(),
+});
+export type SeedAccountInput = z.infer<typeof seedAccountSchema>;


### PR DESCRIPTION
Exposes the existing `pnpm --filter @rivus/api seed` script through the app so Rivus staff can populate a test account from the UI — log in, open **Settings**, and press **Seed this account**. The box appears only in a development build, only for staff, mirroring the script's own rules.

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature.

### What it does

A development-only, staff-only "Developer · seed account" card on the Settings screen fills the **current** account with demo customers, FAQs, appointments, notifications, and inbox conversations, then reports a tally of what was created.

Two gates, both enforced independently:

1. **`NODE_ENV === 'development'`** — the API registers `POST /v1/admin/seed` *only* in development, so it 404s in every deployed environment (the deployed dev and prod containers both run `NODE_ENV=production`). The Settings card renders only in a development build (`isDevelopment()`), so it never ships in a production bundle.
2. **`@rivus.ai` (Rivus staff)** — the route is guarded by `requireStaff`; the card is gated on `isStaff`.

The endpoint seeds the caller's own account (`request.user.accountId`); staff who want to seed another company switch into it first via the existing company switcher.

### How it's built

- **`@rivus/core`** — new `seedAccountSchema` (optional, bounded per-entity counts plus `ai`/`seed`), shared by the API route and the app client.
- **`@rivus/api`** — the repository orchestration is extracted out of the `seed` CLI into `services/seed.ts` (`seedAccountData` + `resolveSeedCounts`), now reused by both the CLI and the new route. The CLI keeps its exact prior behaviour (same flags, dry-run output, and stdout messages); it's just a thin Mongo wrapper around the shared service. `seedSummaryResponseSchema` types the response.
- **`@rivus/app`** — `client.seedAccount()`, an `isDevelopment()` config helper, and the Settings card (built from existing design-system components).

### Tests

- `core`: schema bounds, defaults, coercion, and the `SEED_COUNT_MAX` cap.
- `api`: the orchestrator (count defaults, FAQ de-duplication on re-run, customer/appointment/conversation linking and fallbacks, notification read-marking, count-0 skips) and the route's gating (404 outside development, 401 unauthenticated, 403 for non-staff, 200 + verified data for staff, 400 over the cap).
- `app`: the `seedAccount` client method (request shape, parsed summary, validation, 404 handling) and the `isDevelopment` helper.

`pnpm lint && pnpm type-check && pnpm test` all pass across the monorepo; the API package stays above its coverage thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LHyQKJxojKiMyX8TP2zQb)_