### PR TITLE
feat(api,app): gate the account seeder on RIVUS_ENV so it works on dev-app

### DIFF
--- a/.github/workflows/deploy-development.yaml
+++ b/.github/workflows/deploy-development.yaml
@@ -72,6 +72,9 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       # Selects the disallow-all robots.txt for the dev app (dev-app.rivus.ai).
       RIVUS_ENV: development
+      # Inlined into the Expo web bundle; lets the dev app show the staff-only
+      # account seeder in Settings (the API enforces the same gate server-side).
+      EXPO_PUBLIC_RIVUS_ENV: development
       # Baked into the Expo web bundle at export time.
       EXPO_PUBLIC_API_URL: https://dev-api.rivus.ai
       # The deployed app talks to the deployed agent.

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -82,6 +82,9 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       # Crawlable: emits an allow-all robots.txt for the production app.
       RIVUS_ENV: production
+      # Inlined into the Expo web bundle; the explicit `production` value keeps the
+      # staff-only account seeder out of the production app (it never renders).
+      EXPO_PUBLIC_RIVUS_ENV: production
       # Baked into the Expo web bundle at export time.
       EXPO_PUBLIC_API_URL: https://api.rivus.ai
       # The deployed app talks to the deployed agent.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -62,6 +62,24 @@ Production emits an explicit allow-all `robots.txt`; development emits
 crawlable UI in any environment (its Swagger UI is off under `NODE_ENV=production`,
 which is how the container always runs), so it does not emit a `robots.txt`.
 
+## Staff account seeder
+
+`RIVUS_ENV` has a second consumer: the staff-only account seeder (`POST
+/v1/admin/seed`, surfaced as "Developer · seed account" in the app's Settings).
+It fills the *current* account with demo data so Rivus staff can populate a fresh
+test account from the UI. Because both deployed containers run
+`NODE_ENV=production`, `RIVUS_ENV` is the only thing that tells the development
+deployment apart from production:
+
+| Side  | How it reads `RIVUS_ENV`                                                   | Result |
+| ----- | ------------------------------------------------------------------------- | ------ |
+| API   | a `vars` entry in `packages/api/wrangler.jsonc` per environment, forwarded into the container by `worker/index.ts` | Registers the route only when `RIVUS_ENV=development` (or a local `NODE_ENV=development`). Production sets `RIVUS_ENV=production`, so the route 404s there. |
+| App   | the deploy workflows bake `EXPO_PUBLIC_RIVUS_ENV` into the Expo bundle     | The Settings card renders only when `EXPO_PUBLIC_RIVUS_ENV=development` (or a local dev build), and only for Rivus-staff (`@rivus.ai`) sessions. |
+
+The gate is an allowlist on both sides — it enables on an explicit
+`development`, so an unset or unexpected value in production fails safe (off).
+The route is always additionally guarded by `requireStaff`.
+
 ## One-time setup
 
 1. **Cloudflare account + zone.** Add the `rivus.ai` zone to the account so the

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -129,6 +129,13 @@ The deterministic generation, CLI parsing, and de-duplication live in
 `src/seed-data.ts`, and the AI layer in `src/seed-ai.ts` (both unit-tested);
 `src/seed.ts` is the thin database wrapper.
 
+The same seeder is also exposed over HTTP as `POST /v1/admin/seed` and surfaced
+in the app's Settings as "Developer · seed account". That route is registered
+only on a local dev API (`NODE_ENV=development`) or the deployed **development**
+environment (`RIVUS_ENV=development`) — never in production — and is gated to
+Rivus staff (`@rivus.ai`). See `isSeedingEnabled` in `src/config.ts` and the
+deployment note in [DEPLOYMENT.md](../../DEPLOYMENT.md#staff-account-seeder).
+
 ### Migrations
 
 The third role was renamed from `team_member` to `member`. Existing databases

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -5,6 +5,17 @@ const DEV_JWT_SECRET = 'dev-secret-change-me';
 const envSchema = z
 	.object({
 		NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+		// Which deployed Rivus environment this container is — `development`
+		// (dev-api.rivus.ai) or `production` (api.rivus.ai). It's distinct from
+		// NODE_ENV on purpose: both deployed containers run NODE_ENV=production, so
+		// this is the only signal that tells the dev deployment apart from prod. It
+		// gates the staff-only account seeder (`POST /v1/admin/seed`), which must
+		// exist on the dev deployment but never in production. Forwarded from the
+		// front-door Worker's `vars` (see worker/index.ts + wrangler.jsonc); unset in
+		// local development, where NODE_ENV=development already enables the seeder.
+		// Kept a free string (not an enum) so an unexpected value never blocks boot —
+		// the seeder gate matches `development` exactly, so anything else fails safe.
+		RIVUS_ENV: z.string().optional(),
 		API_HOST: z.string().default('0.0.0.0'),
 		API_PORT: z.coerce.number().int().positive().max(65535).default(4000),
 		MONGODB_URI: z
@@ -87,6 +98,21 @@ export type Config = z.infer<typeof envSchema>;
 /** Parse and validate process environment into a typed config object. */
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
 	return envSchema.parse(env);
+}
+
+/**
+ * Whether the development-only account seeder route (`POST /v1/admin/seed`)
+ * should be registered. The route is always additionally gated to Rivus staff.
+ *
+ * It must exist on a local dev API (`NODE_ENV=development`) and on the deployed
+ * Rivus *development* environment — where the container runs NODE_ENV=production
+ * just like prod, so `RIVUS_ENV=development` is what distinguishes it. Enabled
+ * when either signal says development; deliberately off in production, including
+ * the fail-safe case where `RIVUS_ENV` is unset or unexpected (then only a local
+ * `NODE_ENV=development` can turn it on, never a production container).
+ */
+export function isSeedingEnabled(config: Pick<Config, 'NODE_ENV' | 'RIVUS_ENV'>): boolean {
+	return config.RIVUS_ENV === 'development' || config.NODE_ENV === 'development';
 }
 
 /** What `@fastify/cors` accepts for its `origin` option. */

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -8,6 +8,7 @@ import {
 import type { FastifyPluginAsync } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
+import { isSeedingEnabled } from '../config';
 import {
 	accountListResponseSchema,
 	authResponseSchema,
@@ -114,19 +115,23 @@ export const adminRoutes: FastifyPluginAsync = async (fastify) => {
 		},
 	);
 
-	// Development-only account seeder. The deployed dev and prod containers both run
-	// `NODE_ENV=production` (see app.ts), so this route is registered *only* when the
-	// API is running locally in development — it doesn't exist (404) anywhere else,
-	// and even then it's gated to Rivus staff (`@rivus.ai`). It fills the *current*
-	// account with demo customers, FAQs, appointments, notifications, and inbox
-	// conversations so staff can populate a fresh test account from the app's
-	// Settings screen without touching the CLI.
-	if (app.deps.config.NODE_ENV === 'development') {
+	// Development-only account seeder. Both deployed containers run
+	// `NODE_ENV=production` (see app.ts), so this route keys off `RIVUS_ENV` instead:
+	// it's registered on a local dev API (`NODE_ENV=development`) and on the deployed
+	// `development` environment (`RIVUS_ENV=development`, dev-api.rivus.ai), but never
+	// in production — where it doesn't exist (404) — and even then it's gated to Rivus
+	// staff (`@rivus.ai`). It fills the *current* account with demo customers, FAQs,
+	// appointments, notifications, and inbox conversations so staff can populate a
+	// fresh test account from the app's Settings screen without touching the CLI.
+	if (isSeedingEnabled(app.deps.config)) {
 		// Lazy-load the seeder so its dev-only `@faker-js/faker` dependency (and the AI
-		// generation machinery) is split into a chunk loaded only here, in development —
-		// never pulled into the production startup bundle, where faker isn't a runtime
-		// dependency. `adminRoutes` is async, so awaiting an import during registration
-		// is fine.
+		// generation machinery) is split into a chunk imported only when seeding is
+		// enabled — never in the production startup bundle. faker is a devDependency, so
+		// tsdown *bundles* it into that chunk rather than leaving an external import;
+		// that's what lets the chunk load on the deployed dev container (which runs
+		// NODE_ENV=production, with devDependencies pruned from node_modules) without
+		// faker being a runtime dependency. `adminRoutes` is async, so awaiting an
+		// import during registration is fine.
 		const [{ createSeedGenerator, DeterministicSeedGenerator }, { seedAccountData }] =
 			await Promise.all([import('../seed-ai'), import('../services/seed')]);
 		const { customers, faqs, jobs, notifications, conversations } = app.deps;

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { loadConfig, parseCorsOrigin } from '../src/config';
+import { isSeedingEnabled, loadConfig, parseCorsOrigin } from '../src/config';
 
 describe('loadConfig', () => {
 	it('applies development defaults', () => {
@@ -43,6 +43,29 @@ describe('loadConfig', () => {
 		} as NodeJS.ProcessEnv);
 		expect(config.NODE_ENV).toBe('production');
 		expect(config.RESEND_API_KEY).toBe('re_live_xxx');
+	});
+});
+
+describe('isSeedingEnabled', () => {
+	it('is enabled on a local dev API (NODE_ENV=development), RIVUS_ENV unset', () => {
+		expect(isSeedingEnabled({ NODE_ENV: 'development' })).toBe(true);
+	});
+
+	it('is enabled on the deployed development environment (RIVUS_ENV) despite NODE_ENV=production', () => {
+		expect(isSeedingEnabled({ NODE_ENV: 'production', RIVUS_ENV: 'development' })).toBe(true);
+	});
+
+	it('is disabled in production (RIVUS_ENV=production)', () => {
+		expect(isSeedingEnabled({ NODE_ENV: 'production', RIVUS_ENV: 'production' })).toBe(false);
+	});
+
+	it('fails safe (off) for a production container with RIVUS_ENV unset or unexpected', () => {
+		expect(isSeedingEnabled({ NODE_ENV: 'production', RIVUS_ENV: undefined })).toBe(false);
+		expect(isSeedingEnabled({ NODE_ENV: 'production', RIVUS_ENV: 'staging' })).toBe(false);
+	});
+
+	it('is disabled under NODE_ENV=test with no RIVUS_ENV (the default test app)', () => {
+		expect(isSeedingEnabled({ NODE_ENV: 'test', RIVUS_ENV: undefined })).toBe(false);
 	});
 });
 

--- a/packages/api/test/seed-account.test.ts
+++ b/packages/api/test/seed-account.test.ts
@@ -227,8 +227,8 @@ describe('resolveSeedCounts', () => {
 	});
 });
 
-describe('POST /v1/admin/seed (development only)', () => {
-	/** A dev-mode app: the only environment where the seed route is registered. */
+describe('POST /v1/admin/seed (dev + deployed development only)', () => {
+	/** A local dev-mode app (NODE_ENV=development), where the seed route is registered. */
 	function buildDevApp(): Promise<FastifyInstance> {
 		return buildTestApp({
 			config: loadConfig({
@@ -345,6 +345,41 @@ describe('POST /v1/admin/seed (development only)', () => {
 			const staff = await signupOwner(app, { email: STAFF_EMAIL, businessName: 'Rivus HQ' });
 			const response = await seed(staff.token, { customers: 10_000 });
 			expect(response.statusCode).toBe(400);
+		});
+	});
+
+	describe('when RIVUS_ENV is development (the deployed dev environment)', () => {
+		let app: FastifyInstance;
+
+		// The deployed dev container runs NODE_ENV=production like prod; RIVUS_ENV is
+		// the only thing that distinguishes it. NODE_ENV=test stands in here for that
+		// "not development" container without tripping the production JWT/CORS/email
+		// boot gates, so it isolates the RIVUS_ENV path.
+		beforeEach(async () => {
+			app = await buildTestApp({
+				config: loadConfig({
+					NODE_ENV: 'test',
+					RIVUS_ENV: 'development',
+					JWT_SECRET: 'test-secret-value-1234',
+					LOG_LEVEL: 'silent',
+				} as NodeJS.ProcessEnv),
+			});
+		});
+
+		afterEach(async () => {
+			await app.close();
+		});
+
+		it('registers the route for staff even though NODE_ENV is not development', async () => {
+			const staff = await signupOwner(app, { email: STAFF_EMAIL, businessName: 'Rivus HQ' });
+			const response = await app.inject({
+				method: 'POST',
+				url: '/v1/admin/seed',
+				headers: authHeader(staff.token),
+				payload: { customers: 2, faqs: 0, appointments: 0, notifications: 0, conversations: 0 },
+			});
+			expect(response.statusCode).toBe(200);
+			expect(response.json().customers).toBe(2);
 		});
 	});
 });

--- a/packages/api/worker/index.ts
+++ b/packages/api/worker/index.ts
@@ -9,6 +9,11 @@ export interface Env {
 	RESEND_API_KEY: string;
 	EMAIL_FROM: string;
 	APP_URL: string;
+	// Which deployed Rivus environment this is (`development` | `production`). Set
+	// per environment in wrangler.jsonc `vars`; gates the staff-only account seeder
+	// (the deployed dev API exposes it, production never does). Optional so a local
+	// `wrangler dev` without it still boots.
+	RIVUS_ENV?: string;
 	// Optional: scopes the session cookie to a parent domain (e.g. `.rivus.ai`) so
 	// sibling subdomains (the app and the agent) receive it. Unset → host-only.
 	COOKIE_DOMAIN?: string;
@@ -40,6 +45,7 @@ export class ApiContainer extends Container<Env> {
 	// only when set so an unset secret never reaches the container as "undefined".
 	override envVars = {
 		NODE_ENV: 'production',
+		...(this.env.RIVUS_ENV ? { RIVUS_ENV: this.env.RIVUS_ENV } : {}),
 		...(this.env.MONGODB_URI ? { MONGODB_URI: this.env.MONGODB_URI } : {}),
 		...(this.env.JWT_SECRET ? { JWT_SECRET: this.env.JWT_SECRET } : {}),
 		...(this.env.CORS_ORIGIN ? { CORS_ORIGIN: this.env.CORS_ORIGIN } : {}),

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -36,6 +36,10 @@
 			"name": "rivus-api-dev",
 			"routes": [{ "pattern": "dev-api.rivus.ai", "custom_domain": true }],
 			"vars": {
+				// Marks this as the deployed development environment. Both containers run
+				// NODE_ENV=production, so this is what enables the staff-only account
+				// seeder (POST /v1/admin/seed) here while keeping it off in production.
+				"RIVUS_ENV": "development",
 				// The container runs NODE_ENV=production, where credentialed CORS forbids
 				// a `*` wildcard. List the exact dev origins that call the API from a
 				// browser (the app and the marketing site) rather than a `*.rivus.ai`
@@ -70,6 +74,9 @@
 			// session cookie, any subdomain it allowed could read cookie-authenticated
 			// responses. Only the app origin (APP_URL) is granted credentialed CORS.
 			"vars": {
+				// Marks this as production, where the staff-only account seeder is never
+				// registered — the explicit value is the fail-safe that keeps it off.
+				"RIVUS_ENV": "production",
 				"CORS_ORIGIN": "https://app.rivus.ai,https://rivus.ai,https://www.rivus.ai",
 				// Scope the session cookie to the shared parent domain so it reaches the
 				// app and the agent (app/agent.rivus.ai), enabling web chat with an

--- a/packages/app/app/settings.tsx
+++ b/packages/app/app/settings.tsx
@@ -8,7 +8,7 @@ import {
 	View,
 } from 'react-native';
 import { ApiError, type Billing, type SeedSummary } from '@/src/api/client';
-import { getGoogleMapsApiKey, isDevelopment } from '@/src/api/config';
+import { getGoogleMapsApiKey, isSeedingEnabled } from '@/src/api/config';
 import { deviceTimezone, listTimezones } from '@/src/api/timezones';
 import { useAuth } from '@/src/auth/AuthContext';
 import { AddressAutocomplete } from '@/src/components/AddressAutocomplete';
@@ -39,10 +39,10 @@ function messageFor(error: unknown, fallback: string): string {
  * A development-only, Rivus-staff-only affordance to fill the current account with
  * demo data (customers, FAQs, appointments, notifications, and inbox
  * conversations) so there's something to test against. It self-gates on
- * {@link isDevelopment} plus staff status and renders nothing otherwise — the API
- * enforces the same rules server-side (the seed route exists only when its
- * `NODE_ENV` is `development`, and rejects non-staff callers), so this is purely
- * about not showing a control that wouldn't work.
+ * {@link isSeedingEnabled} plus staff status and renders nothing otherwise — the
+ * API enforces the same rules server-side (the seed route exists only on a dev
+ * build or the deployed `development` environment, and rejects non-staff
+ * callers), so this is purely about not showing a control that wouldn't work.
  */
 function DevSeedCard() {
 	const { session, client, isStaff } = useAuth();
@@ -50,7 +50,7 @@ function DevSeedCard() {
 	const [summary, setSummary] = useState<SeedSummary | null>(null);
 	const [error, setError] = useState<string | null>(null);
 
-	const visible = Boolean(session) && isStaff && isDevelopment();
+	const visible = Boolean(session) && isStaff && isSeedingEnabled();
 
 	async function onSeed() {
 		if (seeding || !session) {

--- a/packages/app/src/api/config.test.ts
+++ b/packages/app/src/api/config.test.ts
@@ -6,7 +6,7 @@ import {
 	getApiBaseUrl,
 	getAppBaseUrl,
 	getGoogleMapsApiKey,
-	isDevelopment,
+	isSeedingEnabled,
 } from './config';
 
 /** Temporarily install a fake `window` (the test runner is Node, where it's absent). */
@@ -134,14 +134,33 @@ describe('buildInviteAcceptUrl', () => {
 	});
 });
 
-describe('isDevelopment', () => {
-	it('is true only when NODE_ENV is exactly "development"', () => {
-		expect(isDevelopment('development')).toBe(true);
+describe('isSeedingEnabled', () => {
+	it('is true on the deployed development environment (EXPO_PUBLIC_RIVUS_ENV), even when NODE_ENV is production', () => {
+		// dev-app.rivus.ai: built with `expo export` (NODE_ENV=production) but tagged
+		// as the development deployment.
+		expect(isSeedingEnabled({ EXPO_PUBLIC_RIVUS_ENV: 'development' }, 'production')).toBe(true);
 	});
 
-	it('is false for production, test, or an unset value', () => {
-		expect(isDevelopment('production')).toBe(false);
-		expect(isDevelopment('test')).toBe(false);
-		expect(isDevelopment(undefined)).toBe(false);
+	it('is true on a local dev build (NODE_ENV=development) with no RIVUS_ENV set', () => {
+		expect(isSeedingEnabled({}, 'development')).toBe(true);
+	});
+
+	it('trims surrounding whitespace from EXPO_PUBLIC_RIVUS_ENV', () => {
+		expect(isSeedingEnabled({ EXPO_PUBLIC_RIVUS_ENV: '  development  ' }, 'production')).toBe(true);
+	});
+
+	it('is false in production (RIVUS_ENV=production)', () => {
+		expect(isSeedingEnabled({ EXPO_PUBLIC_RIVUS_ENV: 'production' }, 'production')).toBe(false);
+	});
+
+	it('fails safe (off) when RIVUS_ENV is unset or unexpected and it is not a local dev build', () => {
+		expect(isSeedingEnabled({}, 'production')).toBe(false);
+		expect(isSeedingEnabled({}, 'test')).toBe(false);
+		expect(isSeedingEnabled({}, undefined)).toBe(false);
+		expect(isSeedingEnabled({ EXPO_PUBLIC_RIVUS_ENV: 'staging' }, 'production')).toBe(false);
+	});
+
+	it('reads from the ambient env by default without throwing', () => {
+		expect(typeof isSeedingEnabled()).toBe('boolean');
 	});
 });

--- a/packages/app/src/api/config.ts
+++ b/packages/app/src/api/config.ts
@@ -36,6 +36,7 @@ function ambientEnv(): Record<string, string | undefined> {
 		EXPO_PUBLIC_API_URL: process.env.EXPO_PUBLIC_API_URL,
 		EXPO_PUBLIC_APP_URL: process.env.EXPO_PUBLIC_APP_URL,
 		EXPO_PUBLIC_GOOGLE_MAPS_API_KEY: process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY,
+		EXPO_PUBLIC_RIVUS_ENV: process.env.EXPO_PUBLIC_RIVUS_ENV,
 	};
 }
 
@@ -57,15 +58,27 @@ function ambientNodeEnv(): string | undefined {
 }
 
 /**
- * Whether the app is running a development build. The development-only account
- * seeder in Settings is gated on this (together with Rivus-staff status) so it
- * never appears in a production build — mirroring the API, which only registers
- * `POST /v1/admin/seed` when its own `NODE_ENV` is `development`. Expo/Metro
- * inlines `process.env.NODE_ENV` at build time; the `nodeEnv` parameter keeps
- * this hermetically testable.
+ * Whether the development-only account seeder in Settings should be available
+ * (it's still additionally gated to Rivus staff at the call site).
+ *
+ * It has to surface in two distinct places: a local dev build (`expo start`,
+ * where `NODE_ENV` is `development`) and the deployed Rivus *development*
+ * environment (`dev-app.rivus.ai`). The latter is produced by `expo export`,
+ * which forces `NODE_ENV=production`, so `NODE_ENV` alone can't tell it apart
+ * from the production app. The deploy workflow bakes `EXPO_PUBLIC_RIVUS_ENV`
+ * into the bundle (`development` vs `production`) to mark which deployment this
+ * is — the same `RIVUS_ENV` signal the API and robots.txt use. Seeding turns on
+ * when either input says development and stays off everywhere else; an unset or
+ * unexpected `EXPO_PUBLIC_RIVUS_ENV` fails safe (off) unless this is a local
+ * `NODE_ENV=development` build. Both inputs are injectable so this stays
+ * hermetically testable; Expo/Metro inlines the literal `process.env.*` reads at
+ * build time.
  */
-export function isDevelopment(nodeEnv: string | undefined = ambientNodeEnv()): boolean {
-	return nodeEnv === 'development';
+export function isSeedingEnabled(
+	env: Record<string, string | undefined> = ambientEnv(),
+	nodeEnv: string | undefined = ambientNodeEnv(),
+): boolean {
+	return env.EXPO_PUBLIC_RIVUS_ENV?.trim() === 'development' || nodeEnv === 'development';
 }
 
 export function getApiBaseUrl(env: Record<string, string | undefined> = ambientEnv()): string {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix — the staff-only account seeder was unreachable on the deployed **development** environment (`dev-app.rivus.ai`), even though it was meant to be available there.

## The problem

The Settings "Developer · seed account" card and the `POST /v1/admin/seed` route were both gated on `NODE_ENV === 'development'`. That's only ever true when running locally — **both** deployed containers (dev *and* prod) run `NODE_ENV=production` (the API container hardcodes it in `worker/index.ts`; the Expo web export forces it). So on `dev-app.rivus.ai` the card never rendered and the route 404'd, even for Rivus staff.

`NODE_ENV` can't distinguish the dev deployment from prod. `RIVUS_ENV` already does — it's the per-environment deployment marker the deploy workflows set (`development` vs `production`), today used for `robots.txt` — but the seeder didn't read it.

## The fix

Switch both gates from `NODE_ENV` to an **allowlist** on `RIVUS_ENV`: seeding is enabled when `RIVUS_ENV` is `development`, or (locally) when `NODE_ENV` is `development`. An unset or unexpected `RIVUS_ENV` in production fails safe (off), and the route stays guarded by `requireStaff`.

| Environment | API (`RIVUS_ENV` / `NODE_ENV`) | App bundle | Seeder |
| --- | --- | --- | --- |
| Local dev | unset / `development` | `expo start` → `NODE_ENV=development` | **on** |
| Deployed dev (`dev-app.rivus.ai`) | `development` / `production` | `EXPO_PUBLIC_RIVUS_ENV=development` | **on** (staff only) |
| Production | `production` / `production` | `EXPO_PUBLIC_RIVUS_ENV=production` | off (404) |

### Changes

- **api**: add `RIVUS_ENV` to config + an `isSeedingEnabled()` helper; register `/seed` off it; forward `RIVUS_ENV` through the front-door Worker into the container; set it per environment in `wrangler.jsonc` (`development` / `production`).
- **app**: read `EXPO_PUBLIC_RIVUS_ENV` (inlined into the bundle at export) via a new `isSeedingEnabled()` replacing `isDevelopment()`.
- **ci**: bake `EXPO_PUBLIC_RIVUS_ENV` into the app bundle in both deploy workflows.
- **docs**: document the seeder's `RIVUS_ENV` gating in `DEPLOYMENT.md` and the API README.

### Why it's safe on a `NODE_ENV=production` container

Enabling the route on the deployed dev container means its lazy `import('../seed-ai')` / `import('../services/seed')` chunks now actually load there. `@faker-js/faker` is a **devDependency**, so tsdown **bundles** it into the seed chunk (verified: no external `@faker-js/faker` import survives in `dist/`) — it loads even though `--prod` prunes devDependencies from the image. The AI-SDK packages those chunks import are runtime `dependencies` (already used by the production FAQ features), so they survive pruning too.

## Testing

`pnpm lint && pnpm type-check && pnpm test` all pass (1,175 tests); coverage thresholds hold for the changed packages. Added unit tests for `isSeedingEnabled` on both sides (including the production fail-safe) and an integration test proving the route registers when `RIVUS_ENV=development` while `NODE_ENV` is not `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017Pg2KCJPwTGizY5PFAoShd)_