### PR TITLE
fix(agent): search the FAQ before falling back to company info

### DIFF
--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -225,6 +225,28 @@ describe('respond — knowledge base answering', () => {
 		expect(reply).toContain('How much does your service cost?');
 	});
 
+	it('searches the knowledge base for "business hours" instead of dumping company settings', async () => {
+		// Regression test for the reported bug: the bare word "business" in "business
+		// hours" was matching the generic company-info ask, so the agent replied with the
+		// whole settings record instead of searching the FAQ where the answer actually
+		// lived. It must route through the knowledge base first, same as any other question.
+		const reply = await ask('what are our business hours?', {
+			token: TOKEN,
+			fetchImpl: router([
+				{
+					when: onAnswerFaq,
+					body: {
+						answered: true,
+						answer: 'We’re open Monday–Friday, 9am–5pm.',
+						sources: [{ id: 'faq_1', question: 'What are your business hours?' }],
+					},
+				},
+			]),
+		});
+		expect(reply).toContain('9am–5pm');
+		expect(reply).not.toContain('Here’s what I have for');
+	});
+
 	it('returns just the answer when no source FAQ is given', async () => {
 		const reply = await ask('do you charge for travel?', {
 			token: TOKEN,

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -65,6 +65,15 @@ describe('parseIntent — company info', () => {
 		expect(parseIntent('tell me about my business')).toEqual({ kind: 'company_info', fields: [] });
 		expect(parseIntent('show my company info')).toEqual({ kind: 'company_info', fields: [] });
 	});
+
+	it('does not treat "business"/"company"/"account" as generic when it names a different topic', () => {
+		// Regression: "business hours" was matching the generic company-record ask via
+		// the bare word "business", so it returned the whole settings record instead of
+		// falling through to `unknown` — where the assistant searches the knowledge base,
+		// which is where an answer like this actually lives.
+		expect(parseIntent('what are our business hours?')).toEqual({ kind: 'unknown' });
+		expect(parseIntent('do we have a business license')).toEqual({ kind: 'unknown' });
+	});
 });
 
 describe('parseIntent — knowledge base', () => {

--- a/packages/agent/src/intent.test.ts
+++ b/packages/agent/src/intent.test.ts
@@ -64,15 +64,19 @@ describe('parseIntent — company info', () => {
 	it('treats a generic company ask as "everything" (empty fields)', () => {
 		expect(parseIntent('tell me about my business')).toEqual({ kind: 'company_info', fields: [] });
 		expect(parseIntent('show my company info')).toEqual({ kind: 'company_info', fields: [] });
+		expect(parseIntent('show my profile')).toEqual({ kind: 'company_info', fields: [] });
 	});
 
-	it('does not treat "business"/"company"/"account" as generic when it names a different topic', () => {
+	it('does not treat "business"/"company"/"account"/"profile" as generic when it names a different topic', () => {
 		// Regression: "business hours" was matching the generic company-record ask via
 		// the bare word "business", so it returned the whole settings record instead of
 		// falling through to `unknown` — where the assistant searches the knowledge base,
 		// which is where an answer like this actually lives.
 		expect(parseIntent('what are our business hours?')).toEqual({ kind: 'unknown' });
 		expect(parseIntent('do we have a business license')).toEqual({ kind: 'unknown' });
+		// "profile" modifying a different noun ("profile picture") must not match either —
+		// only a bare "my/our profile" (the company's own profile) should.
+		expect(parseIntent('how do I change my profile picture?')).toEqual({ kind: 'unknown' });
 	});
 });
 

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -84,9 +84,17 @@ const COMPANY_FIELD_PATTERNS: ReadonlyArray<readonly [CompanyField, RegExp]> = [
 	['status', /\b(account status|subscription|plan)\b/],
 ];
 
-/** Generic references to "the company" that mean "tell me everything". */
+/**
+ * Generic references to "the company" that mean "tell me everything" — e.g. "show my
+ * company info" or "tell me about my business". Requires a co-occurring noun
+ * ("info"/"details"/"profile") or an explicit "about my/our/the …" framing, rather than
+ * matching the bare word "company"/"business"/"account" anywhere in the message — those
+ * words also show up in asks that are NOT about the company record (e.g. "business
+ * hours", "business license"), which belong in the knowledge base instead, and a bare
+ * match here would steal them before they ever reach it.
+ */
 const COMPANY_GENERIC =
-	/\b(company|business|account|my (info|information|details)|our (info|information|details)|about (my|our|the) (company|business)|profile)\b/;
+	/\b(?:(?:company|business|account)\s+(?:info|information|details|profile)|my\s+(?:info|information|details)|our\s+(?:info|information|details)|about\s+(?:my|our|the)\s+(?:company|business|account)|profile)\b/;
 
 const UPDATE_VERB = /\b(update|change|edit|revise|modify|fix)\b/;
 const CREATE_VERB = /\b(add|create|new|make|insert)\b/;

--- a/packages/agent/src/intent.ts
+++ b/packages/agent/src/intent.ts
@@ -88,13 +88,15 @@ const COMPANY_FIELD_PATTERNS: ReadonlyArray<readonly [CompanyField, RegExp]> = [
  * Generic references to "the company" that mean "tell me everything" — e.g. "show my
  * company info" or "tell me about my business". Requires a co-occurring noun
  * ("info"/"details"/"profile") or an explicit "about my/our/the …" framing, rather than
- * matching the bare word "company"/"business"/"account" anywhere in the message — those
- * words also show up in asks that are NOT about the company record (e.g. "business
- * hours", "business license"), which belong in the knowledge base instead, and a bare
- * match here would steal them before they ever reach it.
+ * matching the bare word "company"/"business"/"account"/"profile" anywhere in the
+ * message — those words also show up in asks that are NOT about the company record
+ * (e.g. "business hours", "business license", "profile picture"), which belong in the
+ * knowledge base instead, and a bare match here would steal them before they ever reach
+ * it. The `(?!\s+\w)` after "profile" stops it matching when it's modifying a different
+ * noun ("profile picture") rather than standing alone as the company's profile/record.
  */
 const COMPANY_GENERIC =
-	/\b(?:(?:company|business|account)\s+(?:info|information|details|profile)|my\s+(?:info|information|details)|our\s+(?:info|information|details)|about\s+(?:my|our|the)\s+(?:company|business|account)|profile)\b/;
+	/\b(?:(?:company|business|account)\s+(?:info|information|details|profile(?!\s+\w))|my\s+(?:info|information|details|profile(?!\s+\w))|our\s+(?:info|information|details|profile(?!\s+\w))|about\s+(?:my|our|the)\s+(?:company|business|account|profile(?!\s+\w)))\b/;
 
 const UPDATE_VERB = /\b(update|change|edit|revise|modify|fix)\b/;
 const CREATE_VERB = /\b(add|create|new|make|insert)\b/;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** Bug fix

## Problem

Asking the Rivus chat assistant "what are our business hours?" replied with the full company settings record (business name, website, phone, address, etc.) instead of searching the knowledge base, even though the answer existed as an FAQ.

## Root cause

`packages/agent/src/intent.ts`'s `COMPANY_GENERIC` regex matched the bare word **"business"** (or "company"/"account") anywhere in a message. Since "business hours" contains "business", the rule-based router classified it as a generic company-info ask (`company_info` with empty `fields`, meaning "the whole record") and returned early — before the message ever had a chance to fall through to the `unknown` intent, which is what makes `assistant.ts` try the FAQ-grounded knowledge-base answer first.

## Fix

Tightened `COMPANY_GENERIC` to require a co-occurring noun ("info"/"details"/"profile") or an explicit "about my/our/the …" framing, instead of matching the bare word alone. This still recognizes genuine generic asks ("tell me about my business", "show my company info") but no longer steals topics like "business hours" or "business license" that belong in the knowledge base.

With the fix, "what are our business hours?" now falls through to the `unknown` intent, which `assistant.ts` already routes through the FAQ-grounded knowledge-base search before giving up — restoring "FAQ is searched first" behavior.

## Testing

- Added a regression unit test in `intent.test.ts` confirming "what are our business hours?" / "do we have a business license" no longer route to `company_info`.
- Added an end-to-end regression test in `assistant.test.ts` confirming the agent now answers "what are our business hours?" from the knowledge base instead of dumping the settings record.
- `pnpm lint && pnpm type-check && pnpm test` all pass across the monorepo.


---
_Generated by [Claude Code](https://claude.ai/code/session_013ZnAVrpYKKWzh3WoCJ9tUK)_