### PR TITLE
feat: add profile view with email re-verification

### DIFF
--- a/packages/agent/src/api.test.ts
+++ b/packages/agent/src/api.test.ts
@@ -43,6 +43,8 @@ const session = {
 		id: 'user_1',
 		email: 'owner@acme.example',
 		name: 'Pat Owner',
+		phone: '',
+		pendingEmail: '',
 		createdAt: '2026-01-01T00:00:00.000Z',
 		updatedAt: '2026-01-01T00:00:00.000Z',
 	},

--- a/packages/agent/src/api.ts
+++ b/packages/agent/src/api.ts
@@ -47,6 +47,8 @@ const userSchema = z.object({
 	id: branded<UserId>(),
 	email: z.string(),
 	name: z.string(),
+	phone: z.string(),
+	pendingEmail: z.string(),
 	createdAt: z.string(),
 	updatedAt: z.string(),
 }) satisfies z.ZodType<User>;

--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -67,6 +67,8 @@ function sessionBody(account = makeAccount()) {
 			id: 'user_1',
 			email: 'owner@acme.example',
 			name: 'Pat Owner',
+			phone: '',
+			pendingEmail: '',
 			createdAt: '2026-01-01T00:00:00.000Z',
 			updatedAt: '2026-01-01T00:00:00.000Z',
 		},

--- a/packages/agent/src/http.test.ts
+++ b/packages/agent/src/http.test.ts
@@ -230,6 +230,8 @@ describe('handleChat', () => {
 							id: 'user_1',
 							email: 'owner@acme.example',
 							name: 'Pat',
+							phone: '',
+							pendingEmail: '',
 							createdAt: account.createdAt,
 							updatedAt: account.updatedAt,
 						},

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -360,6 +360,177 @@
             }
           }
         }
+      },
+      "patch": {
+        "summary": "Update your profile (name, phone, email). Changing email re-verifies it",
+        "tags": [
+          "auth"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "email": {
+                    "type": "string"
+                  },
+                  "phone": {
+                    "type": "string",
+                    "maxLength": 40
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/auth/me/email/verify": {
+      "post": {
+        "summary": "Confirm a pending email change with its one-time code",
+        "tags": [
+          "auth"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "pattern": "^\\d{6}$"
+                  }
+                },
+                "required": [
+                  "code"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/auth/accept-invite": {

--- a/packages/api/src/db/models/user.model.ts
+++ b/packages/api/src/db/models/user.model.ts
@@ -3,6 +3,9 @@ import { model, Schema } from 'mongoose';
 export interface UserDocument {
 	email: string;
 	name: string;
+	phone: string;
+	/** A new email address awaiting verification, or `''` when none is pending. */
+	pendingEmail: string;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -11,6 +14,10 @@ const userSchema = new Schema<UserDocument>(
 	{
 		email: { type: String, required: true, unique: true, lowercase: true, trim: true, index: true },
 		name: { type: String, required: true, trim: true },
+		phone: { type: String, default: '', trim: true },
+		// Not unique: it defaults to '' (many users share that) and is just a staging
+		// slot — uniqueness is enforced on `email` when the change is actually applied.
+		pendingEmail: { type: String, default: '', lowercase: true, trim: true },
 	},
 	{ timestamps: true },
 );

--- a/packages/api/src/db/models/verification-code.model.ts
+++ b/packages/api/src/db/models/verification-code.model.ts
@@ -1,5 +1,9 @@
 import { model, Schema } from 'mongoose';
-import type { PendingSignup, VerificationPurpose } from '../../repositories/types';
+import type {
+	PendingEmailChange,
+	PendingSignup,
+	VerificationPurpose,
+} from '../../repositories/types';
 
 export interface VerificationCodeDocument {
 	email: string;
@@ -10,6 +14,8 @@ export interface VerificationCodeDocument {
 	attempts: number;
 	/** Account details captured at signup, applied once the code is verified. */
 	signup?: PendingSignup;
+	/** The user moving addresses, present only on `email_change` codes. */
+	emailChange?: PendingEmailChange;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -18,11 +24,12 @@ const verificationCodeSchema = new Schema<VerificationCodeDocument>(
 	{
 		// One active code per email — a new request replaces the previous code.
 		email: { type: String, required: true, unique: true, lowercase: true, trim: true, index: true },
-		purpose: { type: String, required: true, enum: ['login', 'signup'] },
+		purpose: { type: String, required: true, enum: ['login', 'signup', 'email_change'] },
 		codeHash: { type: String, required: true },
 		expiresAt: { type: Date, required: true },
 		attempts: { type: Number, required: true, default: 0 },
 		signup: { type: Schema.Types.Mixed },
+		emailChange: { type: Schema.Types.Mixed },
 	},
 	{ timestamps: true },
 );

--- a/packages/api/src/http-schemas.ts
+++ b/packages/api/src/http-schemas.ts
@@ -18,6 +18,9 @@ export const userResponseSchema = z
 		id: z.string(),
 		email: z.string(),
 		name: z.string(),
+		phone: z.string(),
+		/** A new email awaiting verification, or `''` when no change is pending. */
+		pendingEmail: z.string(),
 		createdAt: z.string(),
 		updatedAt: z.string(),
 	})

--- a/packages/api/src/presenters.ts
+++ b/packages/api/src/presenters.ts
@@ -7,6 +7,8 @@ export function toPublicUser(user: StoredUser): User {
 		id: user.id,
 		email: user.email,
 		name: user.name,
+		phone: user.phone,
+		pendingEmail: user.pendingEmail,
 		createdAt: user.createdAt,
 		updatedAt: user.updatedAt,
 	};

--- a/packages/api/src/repositories/memory.ts
+++ b/packages/api/src/repositories/memory.ts
@@ -73,6 +73,7 @@ import type {
 	StoredUser,
 	StoredVerificationCode,
 	UpdateAccount,
+	UpdateUser,
 	UserRepository,
 	VerificationCodeRepository,
 } from './types';
@@ -132,6 +133,8 @@ export class InMemoryUserRepository implements UserRepository {
 			id: randomUUID() as UserId,
 			email,
 			name: input.name,
+			phone: '',
+			pendingEmail: '',
 			createdAt: timestamp,
 			updatedAt: timestamp,
 		};
@@ -163,6 +166,37 @@ export class InMemoryUserRepository implements UserRepository {
 			}
 		}
 		return found;
+	}
+
+	async update(id: UserId, input: UpdateUser): Promise<StoredUser | null> {
+		const user = this.data.users.get(id);
+		if (!user) {
+			return null;
+		}
+		const patch: Partial<StoredUser> = {};
+		if (input.name !== undefined) {
+			patch.name = input.name;
+		}
+		if (input.email !== undefined) {
+			const normalized = input.email.trim().toLowerCase();
+			// Enforce the same uniqueness as `create`, ignoring the user's own row, so a
+			// verified email change can't collide with another account's address.
+			for (const existing of this.data.users.values()) {
+				if (existing.id !== id && existing.email === normalized) {
+					throw new ConflictError('email', 'An account with this email already exists');
+				}
+			}
+			patch.email = normalized;
+		}
+		if (input.phone !== undefined) {
+			patch.phone = input.phone;
+		}
+		if (input.pendingEmail !== undefined) {
+			patch.pendingEmail = input.pendingEmail.trim().toLowerCase();
+		}
+		const updated: StoredUser = { ...user, ...patch, updatedAt: now() };
+		this.data.users.set(id, updated);
+		return structuredClone(updated);
 	}
 }
 
@@ -426,6 +460,7 @@ export class InMemoryVerificationCodeRepository implements VerificationCodeRepos
 			codeHash: input.codeHash,
 			expiresAt: input.expiresAt,
 			signup: input.signup,
+			emailChange: input.emailChange,
 			attempts: 0,
 			createdAt: now(),
 		};

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -92,6 +92,7 @@ import type {
 	StoredUser,
 	StoredVerificationCode,
 	UpdateAccount,
+	UpdateUser,
 	UserRepository,
 	VerificationCodeRepository,
 } from './types';
@@ -108,6 +109,9 @@ function mapUser(doc: HydratedDocument<UserDocument>): StoredUser {
 		id: doc._id.toString() as UserId,
 		email: doc.email,
 		name: doc.name,
+		// `?? ''` keeps users created before these fields existed mapping cleanly.
+		phone: doc.phone ?? '',
+		pendingEmail: doc.pendingEmail ?? '',
 		createdAt: doc.createdAt.toISOString(),
 		updatedAt: doc.updatedAt.toISOString(),
 	};
@@ -124,6 +128,7 @@ function mapVerificationCode(
 		expiresAt: doc.expiresAt.toISOString(),
 		attempts: doc.attempts,
 		signup: doc.signup,
+		emailChange: doc.emailChange,
 		createdAt: doc.createdAt.toISOString(),
 	};
 }
@@ -313,6 +318,37 @@ export class MongoUserRepository implements UserRepository {
 		}
 		const docs = await UserModel.find({ _id: { $in: objectIds } }).exec();
 		return docs.map(mapUser);
+	}
+
+	async update(id: UserId, input: UpdateUser): Promise<StoredUser | null> {
+		if (!Types.ObjectId.isValid(id)) {
+			return null;
+		}
+		// `$set` only the provided keys, so a partial update never blanks a field.
+		const set: Record<string, string> = {};
+		if (input.name !== undefined) {
+			set.name = input.name;
+		}
+		if (input.email !== undefined) {
+			set.email = input.email.trim().toLowerCase();
+		}
+		if (input.phone !== undefined) {
+			set.phone = input.phone;
+		}
+		if (input.pendingEmail !== undefined) {
+			set.pendingEmail = input.pendingEmail.trim().toLowerCase();
+		}
+		try {
+			const doc = await UserModel.findByIdAndUpdate(id, { $set: set }, { new: true }).exec();
+			return doc ? mapUser(doc) : null;
+		} catch (error) {
+			// The unique index on `email` rejects a change that collides with another
+			// user, mirroring `create`.
+			if (isDuplicateKeyError(error)) {
+				throw new ConflictError('email', 'An account with this email already exists');
+			}
+			throw error;
+		}
 	}
 }
 
@@ -605,15 +641,26 @@ export class MongoVerificationCodeRepository implements VerificationCodeReposito
 		// A single atomic upsert (not delete-then-create) so two overlapping code
 		// requests for the same email can't both delete then collide on the unique
 		// index. Resets the attempt counter; clears any stale signup payload.
-		const set = {
+		const set: Record<string, unknown> = {
 			purpose: input.purpose,
 			codeHash: input.codeHash,
 			expiresAt: new Date(input.expiresAt),
 			attempts: 0,
 		};
-		const update = input.signup
-			? { $set: { ...set, signup: input.signup } }
-			: { $set: set, $unset: { signup: '' } };
+		// Each optional payload is either set or cleared, so a reused row never carries
+		// a stale signup/email-change from a previous request for the same address.
+		const unset: Record<string, ''> = {};
+		if (input.signup) {
+			set.signup = input.signup;
+		} else {
+			unset.signup = '';
+		}
+		if (input.emailChange) {
+			set.emailChange = input.emailChange;
+		} else {
+			unset.emailChange = '';
+		}
+		const update = Object.keys(unset).length > 0 ? { $set: set, $unset: unset } : { $set: set };
 		const doc = await VerificationCodeModel.findOneAndUpdate({ email }, update, {
 			upsert: true,
 			new: true,

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -49,22 +49,46 @@ export interface NewUser {
 	name: string;
 }
 
+/**
+ * Editable profile fields for the signed-in user. Every field is optional so a
+ * partial update only touches what the caller sent. `email` is the live sign-in
+ * address (only set once a change is verified); `pendingEmail` holds an address
+ * awaiting confirmation (set to `''` to clear it).
+ */
+export interface UpdateUser {
+	name?: string;
+	email?: string;
+	phone?: string;
+	pendingEmail?: string;
+}
+
 export interface UserRepository {
 	create(input: NewUser): Promise<StoredUser>;
 	findByEmail(email: string): Promise<StoredUser | null>;
 	findById(id: UserId): Promise<StoredUser | null>;
 	/** Fetch many users in one query (the order of the result is not guaranteed). */
 	findByIds(ids: UserId[]): Promise<StoredUser[]>;
+	/**
+	 * Apply a partial profile update; returns the updated user or null when the id
+	 * is unknown. Throws {@link ConflictError} on `email` if another user already
+	 * owns the address being moved to.
+	 */
+	update(id: UserId, input: UpdateUser): Promise<StoredUser | null>;
 }
 
 // --- Passwordless verification codes -----------------------------------------
 
-export type VerificationPurpose = 'login' | 'signup';
+export type VerificationPurpose = 'login' | 'signup' | 'email_change';
 
 /** Account details captured at signup, stashed on the code until it's verified. */
 export interface PendingSignup {
 	name: string;
 	business: AccountBusinessInput;
+}
+
+/** Who an `email_change` code belongs to, so only that user can redeem it. */
+export interface PendingEmailChange {
+	userId: UserId;
 }
 
 export interface NewVerificationCode {
@@ -76,6 +100,8 @@ export interface NewVerificationCode {
 	expiresAt: string;
 	/** Present for `signup` codes; carries the account to create on verification. */
 	signup?: PendingSignup;
+	/** Present for `email_change` codes; identifies the user moving addresses. */
+	emailChange?: PendingEmailChange;
 }
 
 export interface StoredVerificationCode extends NewVerificationCode {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1,10 +1,13 @@
 import {
 	type AccountId,
 	acceptInviteSchema,
+	isRivusStaffEmail,
 	loginSchema,
 	signupSchema,
 	type UserId,
+	updateProfileSchema,
 	verifyCodeSchema,
+	verifyEmailChangeSchema,
 } from '@rivus/core';
 import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
@@ -14,11 +17,18 @@ import {
 	errorResponseSchema,
 	sessionResponseSchema,
 	signedOutResponseSchema,
+	userResponseSchema,
 } from '../http-schemas';
 import { SESSION_COOKIE, sessionCookieOptions } from '../plugins/auth';
 import { toPublicAccount, toPublicUser } from '../presenters';
 import { ConflictError } from '../repositories/errors';
-import type { PendingSignup, SignupResult, VerificationPurpose } from '../repositories/types';
+import type {
+	PendingEmailChange,
+	PendingSignup,
+	SignupResult,
+	UpdateUser,
+	VerificationPurpose,
+} from '../repositories/types';
 import { generateUniqueSlug } from '../services/accounts';
 import { hashSecret, verifySecret } from '../services/hash';
 import { issueSession } from '../services/session';
@@ -57,11 +67,18 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 		request: FastifyRequest,
 		email: string,
 		purpose: VerificationPurpose,
-		signup?: PendingSignup,
+		payload: { signup?: PendingSignup; emailChange?: PendingEmailChange } = {},
 	): Promise<void> {
 		const code = generateVerificationCode();
 		const codeHash = await hashSecret(code);
-		await verificationCodes.upsert({ email, purpose, codeHash, expiresAt: codeExpiry(), signup });
+		await verificationCodes.upsert({
+			email,
+			purpose,
+			codeHash,
+			expiresAt: codeExpiry(),
+			signup: payload.signup,
+			emailChange: payload.emailChange,
+		});
 		deliverCode(request, email, code, purpose);
 	}
 
@@ -120,7 +137,7 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 			if (await users.findByEmail(email)) {
 				throw app.httpErrors.conflict('A user with this email already exists');
 			}
-			await issueCode(request, email, 'signup', { name, business });
+			await issueCode(request, email, 'signup', { signup: { name, business } });
 			return reply.code(202).send({ status: 'code_sent', email });
 		},
 	);
@@ -261,6 +278,176 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 				account: toPublicAccount(account),
 				role: request.user.role,
 			};
+		},
+	);
+
+	app.patch(
+		'/me',
+		{
+			onRequest: [fastify.authenticate],
+			schema: {
+				tags: ['auth'],
+				summary: 'Update your profile (name, phone, email). Changing email re-verifies it',
+				security: [{ bearerAuth: [] }],
+				body: updateProfileSchema,
+				response: {
+					200: userResponseSchema,
+					400: errorResponseSchema,
+					401: errorResponseSchema,
+					403: errorResponseSchema,
+					409: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const userId = request.user.sub as UserId;
+			const current = await users.findById(userId);
+			if (!current) {
+				throw app.httpErrors.unauthorized('Account no longer exists');
+			}
+
+			const { name, email, phone } = request.body;
+			const patch: UpdateUser = {};
+			if (name !== undefined) {
+				patch.name = name;
+			}
+			if (phone !== undefined) {
+				patch.phone = phone;
+			}
+
+			// A new email isn't applied here — it's staged on `pendingEmail` and becomes
+			// the live address only once the code we email confirms it (see
+			// `POST /me/email/verify`). Comparing against the live email (both normalized)
+			// means re-submitting the same pending address just resends the code, and
+			// submitting your current email is a no-op.
+			let pendingChange: string | null = null;
+			if (email !== undefined && email !== current.email) {
+				// Staff status is derived solely from the email domain (`isRivusStaffEmail`),
+				// so a self-service email change must never cross the staff boundary: moving
+				// *to* the staff domain would self-elevate a regular user, and moving a staff
+				// member *off* it would leave their other still-valid sessions carrying a
+				// stale staff email claim until those tokens expire. Either direction is
+				// refused here — staff email changes go through an administrator instead.
+				if (isRivusStaffEmail(email) || isRivusStaffEmail(current.email)) {
+					throw app.httpErrors.forbidden(
+						'Rivus staff email addresses must be changed by an administrator.',
+					);
+				}
+				const existing = await users.findByEmail(email);
+				if (existing && existing.id !== userId) {
+					throw app.httpErrors.conflict('A user with this email already exists');
+				}
+				patch.pendingEmail = email;
+				pendingChange = email;
+			}
+
+			const updated = Object.keys(patch).length > 0 ? await users.update(userId, patch) : current;
+			if (!updated) {
+				throw app.httpErrors.unauthorized('Account no longer exists');
+			}
+
+			// Deliver the confirmation code only after the pending address is persisted,
+			// so a live code never points at a change we failed to save.
+			if (pendingChange) {
+				await issueCode(request, pendingChange, 'email_change', {
+					emailChange: { userId },
+				});
+			}
+			return toPublicUser(updated);
+		},
+	);
+
+	app.post(
+		'/me/email/verify',
+		{
+			onRequest: [fastify.authenticate],
+			schema: {
+				tags: ['auth'],
+				summary: 'Confirm a pending email change with its one-time code',
+				security: [{ bearerAuth: [] }],
+				body: verifyEmailChangeSchema,
+				response: {
+					200: authResponseSchema,
+					400: errorResponseSchema,
+					401: errorResponseSchema,
+					409: errorResponseSchema,
+					429: errorResponseSchema,
+				},
+			},
+		},
+		async (request, reply) => {
+			const userId = request.user.sub as UserId;
+			const user = await users.findById(userId);
+			if (!user) {
+				throw app.httpErrors.unauthorized('Account no longer exists');
+			}
+			if (!user.pendingEmail) {
+				throw app.httpErrors.badRequest('No email change is pending');
+			}
+
+			const { code } = request.body;
+			const newEmail = user.pendingEmail;
+			const record = await verificationCodes.findByEmail(newEmail);
+			// The code must exist, be an email-change code minted for *this* user, and be
+			// unexpired — otherwise it's treated exactly like a bad code.
+			if (
+				record?.purpose !== 'email_change' ||
+				record.emailChange?.userId !== userId ||
+				new Date(record.expiresAt).getTime() < Date.now()
+			) {
+				throw app.httpErrors.unauthorized('Invalid or expired code');
+			}
+			// Same attempt budget as `/verify`: a spent code is locked until it expires,
+			// and the attempt is reserved with an atomic increment *before* the slow
+			// scrypt compare so concurrent requests can't brute-force the 6-digit code.
+			if (record.attempts >= MAX_VERIFICATION_ATTEMPTS) {
+				throw app.httpErrors.tooManyRequests('Too many incorrect attempts — request a new code');
+			}
+			if ((await verificationCodes.incrementAttempts(newEmail)) > MAX_VERIFICATION_ATTEMPTS) {
+				throw app.httpErrors.tooManyRequests('Too many incorrect attempts — request a new code');
+			}
+			if (!(await verifySecret(code, record.codeHash))) {
+				throw app.httpErrors.unauthorized('Invalid or expired code');
+			}
+			// Claim the code atomically so it can't be redeemed twice.
+			if (!(await verificationCodes.delete(newEmail))) {
+				throw app.httpErrors.unauthorized('Invalid or expired code');
+			}
+
+			// Apply the change. Uniqueness is re-checked here because the address could
+			// have been claimed in the window since the change was requested.
+			let updated: Awaited<ReturnType<typeof users.update>>;
+			try {
+				updated = await users.update(userId, { email: newEmail, pendingEmail: '' });
+			} catch (error) {
+				if (error instanceof ConflictError) {
+					throw app.httpErrors.conflict('A user with this email already exists');
+				}
+				throw error;
+			}
+			if (!updated) {
+				throw app.httpErrors.unauthorized('Account no longer exists');
+			}
+
+			// Re-issue the session so the JWT (and the web cookie) carry the new email —
+			// the previous token still embeds the old address. Mirrors the login path.
+			const membership = await memberships.findByUserId(userId);
+			const account = membership ? await accounts.findById(membership.accountId) : null;
+			if (!membership || !account) {
+				throw app.httpErrors.unauthorized('Account no longer exists');
+			}
+			const token = await issueSession(app, reply, {
+				sub: updated.id,
+				email: updated.email,
+				accountId: account.id,
+				role: membership.role,
+			});
+			return reply.send({
+				token,
+				user: toPublicUser(updated),
+				account: toPublicAccount(account),
+				role: membership.role,
+			});
 		},
 	);
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -189,6 +189,15 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 			if (!record || new Date(record.expiresAt).getTime() < Date.now()) {
 				throw app.httpErrors.unauthorized('Invalid or expired code');
 			}
+			// This public endpoint only consumes login and signup codes. An `email_change`
+			// code lives in the same email-keyed store but is confirmed via the
+			// authenticated `POST /me/email/verify`; reject it here *before* the attempt
+			// counter is bumped or the code is deleted, so a sign-in attempt at the pending
+			// address (a stranger guessing, or the owner entering the code on the wrong
+			// screen) can't burn the budget or consume the pending change.
+			if (record.purpose !== 'login' && record.purpose !== 'signup') {
+				throw app.httpErrors.unauthorized('Invalid or expired code');
+			}
 			// Fast path: a code whose budget is already spent is locked until it expires.
 			if (record.attempts >= MAX_VERIFICATION_ATTEMPTS) {
 				throw app.httpErrors.tooManyRequests('Too many incorrect attempts — request a new code');

--- a/packages/api/src/services/email.ts
+++ b/packages/api/src/services/email.ts
@@ -22,8 +22,11 @@ export interface VerificationEmail {
 	to: string;
 	/** The 6-digit code (plaintext — this email is the only place it appears). */
 	code: string;
-	/** Whether the code finishes a new signup or signs in an existing user. */
-	purpose: 'login' | 'signup';
+	/**
+	 * What the code does: finish a new signup, sign in an existing user, or confirm
+	 * a change to the recipient's account email.
+	 */
+	purpose: 'login' | 'signup' | 'email_change';
 }
 
 /** A fully rendered email body — what a transport actually sends. */
@@ -108,7 +111,9 @@ export function renderVerificationEmail(email: VerificationEmail): RenderedEmail
 	const lead =
 		email.purpose === 'signup'
 			? 'Use this code to finish creating your Rivus account:'
-			: 'Use this code to sign in to Rivus:';
+			: email.purpose === 'email_change'
+				? 'Use this code to confirm your new Rivus email address:'
+				: 'Use this code to sign in to Rivus:';
 	const subject = `Your Rivus verification code is ${email.code}`;
 
 	const text = [

--- a/packages/api/test/auth.test.ts
+++ b/packages/api/test/auth.test.ts
@@ -578,6 +578,26 @@ describe('profile (update + email re-verify)', () => {
 		expect(response.statusCode).toBe(403);
 	});
 
+	it('does not let the public /verify endpoint consume or burn an email-change code', async () => {
+		const owner = await signupOwner(app, { email: 'owner@example.com' });
+		await updateProfile(owner.token, { email: 'new@example.com' });
+		const code = latestCodeFor(app, 'new@example.com');
+
+		// The generic passwordless sign-in must not touch an email-change code, even
+		// with the correct value: it's rejected before the attempt counter or delete.
+		const viaVerify = await app.inject({
+			method: 'POST',
+			url: '/v1/auth/verify',
+			payload: { email: 'new@example.com', code },
+		});
+		expect(viaVerify.statusCode).toBe(401);
+
+		// So the authenticated confirm still succeeds with that same, un-burned code.
+		const confirm = await verifyEmailChange(owner.token, code);
+		expect(confirm.statusCode).toBe(200);
+		expect(confirm.json().user.email).toBe('new@example.com');
+	});
+
 	it('cannot replay a confirmation code after it succeeds', async () => {
 		const owner = await signupOwner(app, { email: 'owner@example.com' });
 		await updateProfile(owner.token, { email: 'new@example.com' });

--- a/packages/api/test/auth.test.ts
+++ b/packages/api/test/auth.test.ts
@@ -8,6 +8,7 @@ import { createInMemoryRepositories } from '../src/repositories/memory';
 import { hashSecret } from '../src/services/hash';
 import { MAX_VERIFICATION_ATTEMPTS } from '../src/services/verification';
 import {
+	addMember,
 	authHeader,
 	buildTestApp,
 	buildTestAppWithRepos,
@@ -380,6 +381,210 @@ describe('me', () => {
 			headers: authHeader('garbage.token.value'),
 		});
 		expect(response.statusCode).toBe(401);
+	});
+
+	it('exposes the new profile fields (phone, pendingEmail) defaulting to empty', async () => {
+		const { token } = await signupOwner(app);
+		const response = await app.inject({
+			method: 'GET',
+			url: '/v1/auth/me',
+			headers: authHeader(token),
+		});
+		expect(response.json().user).toMatchObject({ phone: '', pendingEmail: '' });
+	});
+});
+
+describe('profile (update + email re-verify)', () => {
+	let app: FastifyInstance;
+
+	beforeEach(async () => {
+		app = await buildTestApp();
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	function updateProfile(token: string, payload: Record<string, unknown>) {
+		return app.inject({ method: 'PATCH', url: '/v1/auth/me', headers: authHeader(token), payload });
+	}
+
+	function verifyEmailChange(token: string, code: string) {
+		return app.inject({
+			method: 'POST',
+			url: '/v1/auth/me/email/verify',
+			headers: authHeader(token),
+			payload: { code },
+		});
+	}
+
+	function getMe(token: string) {
+		return app.inject({ method: 'GET', url: '/v1/auth/me', headers: authHeader(token) });
+	}
+
+	it('requires authentication', async () => {
+		const response = await app.inject({
+			method: 'PATCH',
+			url: '/v1/auth/me',
+			payload: { name: 'Nobody' },
+		});
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('updates name and phone and reflects them on /me', async () => {
+		const owner = await signupOwner(app);
+		const response = await updateProfile(owner.token, {
+			name: 'Marcus Thompson',
+			phone: '+1 206 555 0100',
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toMatchObject({
+			name: 'Marcus Thompson',
+			phone: '+1 206 555 0100',
+			pendingEmail: '',
+		});
+		expect((await getMe(owner.token)).json().user).toMatchObject({
+			name: 'Marcus Thompson',
+			phone: '+1 206 555 0100',
+		});
+	});
+
+	it('applies a partial update without blanking untouched fields', async () => {
+		const owner = await signupOwner(app);
+		await updateProfile(owner.token, { phone: '+1 555 0001' });
+		const response = await updateProfile(owner.token, { name: 'Renamed Person' });
+
+		expect(response.statusCode).toBe(200);
+		// The earlier phone survives a name-only update.
+		expect(response.json()).toMatchObject({ name: 'Renamed Person', phone: '+1 555 0001' });
+	});
+
+	it('rejects an empty update (400)', async () => {
+		const owner = await signupOwner(app);
+		expect((await updateProfile(owner.token, {})).statusCode).toBe(400);
+	});
+
+	it('lets a non-owner member update their own profile', async () => {
+		const owner = await signupOwner(app);
+		const member = await addMember(app, owner.token, 'member', 'tm@example.com');
+		const response = await updateProfile(member.token, { name: 'Team Member' });
+		expect(response.statusCode).toBe(200);
+		expect(response.json().name).toBe('Team Member');
+	});
+
+	it('submitting your current email is a no-op (no code sent)', async () => {
+		const owner = await signupOwner(app, { email: 'owner@example.com' });
+		const mailer = app.deps.mailer as RecordingMailer;
+		const sentBefore = mailer.codes.length;
+
+		const response = await updateProfile(owner.token, { email: 'owner@example.com' });
+		expect(response.statusCode).toBe(200);
+		expect(response.json().pendingEmail).toBe('');
+		// No verification code was emailed for a same-address "change".
+		expect(mailer.codes.length).toBe(sentBefore);
+	});
+
+	it('does not change the email immediately — it stages it and emails a code', async () => {
+		const owner = await signupOwner(app, { email: 'owner@example.com' });
+		const response = await updateProfile(owner.token, { email: 'new@example.com' });
+
+		expect(response.statusCode).toBe(200);
+		// Live email is unchanged; the new address is staged as pending.
+		expect(response.json()).toMatchObject({
+			email: 'owner@example.com',
+			pendingEmail: 'new@example.com',
+		});
+		// The code goes to the NEW address, with the email-change purpose.
+		expect(latestCodeFor(app, 'new@example.com')).toMatch(/^\d{6}$/);
+		const mailer = app.deps.mailer as RecordingMailer;
+		expect(mailer.codes.at(-1)).toMatchObject({ to: 'new@example.com', purpose: 'email_change' });
+		// /me still reports the old email plus the pending one.
+		expect((await getMe(owner.token)).json().user).toMatchObject({
+			email: 'owner@example.com',
+			pendingEmail: 'new@example.com',
+		});
+	});
+
+	it('confirms the change with the code, swaps the email, and clears pendingEmail', async () => {
+		const owner = await signupOwner(app, { email: 'owner@example.com' });
+		await updateProfile(owner.token, { email: 'new@example.com' });
+		const response = await verifyEmailChange(owner.token, latestCodeFor(app, 'new@example.com'));
+
+		expect(response.statusCode).toBe(200);
+		const body = response.json();
+		// A fresh session is returned so the token/cookie carry the new email.
+		expect(body.token).toBeTypeOf('string');
+		expect(body.user).toMatchObject({ email: 'new@example.com', pendingEmail: '' });
+		expect(body.role).toBe('owner');
+		expect((await getMe(body.token)).json().user.email).toBe('new@example.com');
+	});
+
+	it('moves the address so the old email no longer resolves and the new one does', async () => {
+		const owner = await signupOwner(app, { email: 'old@example.com' });
+		await updateProfile(owner.token, { email: 'fresh@example.com' });
+		await verifyEmailChange(owner.token, latestCodeFor(app, 'fresh@example.com'));
+
+		expect(await app.deps.users.findByEmail('old@example.com')).toBeNull();
+		expect((await app.deps.users.findByEmail('fresh@example.com'))?.id).toBe(owner.user.id);
+	});
+
+	it('rejects a wrong confirmation code (401) and locks after too many attempts (429)', async () => {
+		const owner = await signupOwner(app, { email: 'owner@example.com' });
+		await updateProfile(owner.token, { email: 'new@example.com' });
+		const code = latestCodeFor(app, 'new@example.com');
+
+		for (let i = 0; i < MAX_VERIFICATION_ATTEMPTS; i++) {
+			expect((await verifyEmailChange(owner.token, wrongCode(code))).statusCode).toBe(401);
+		}
+		// Budget spent: even the correct code is now locked out.
+		expect((await verifyEmailChange(owner.token, code)).statusCode).toBe(429);
+	});
+
+	it('returns 400 when confirming with no pending change', async () => {
+		const owner = await signupOwner(app);
+		expect((await verifyEmailChange(owner.token, '123456')).statusCode).toBe(400);
+	});
+
+	it('rejects confirmation when the code was consumed or never arrived (401)', async () => {
+		const owner = await signupOwner(app, { email: 'owner@example.com' });
+		await updateProfile(owner.token, { email: 'new@example.com' });
+		// Drop the outstanding code, then try to confirm: the pending change remains but
+		// there's no code to match.
+		await app.deps.verificationCodes.delete('new@example.com');
+		expect((await verifyEmailChange(owner.token, '123456')).statusCode).toBe(401);
+	});
+
+	it('refuses to start a change to an email another user already owns (409)', async () => {
+		const owner = await signupOwner(app, { email: 'owner@example.com' });
+		await signupOwner(app, { email: 'taken@example.com' });
+		expect((await updateProfile(owner.token, { email: 'taken@example.com' })).statusCode).toBe(409);
+	});
+
+	it('refuses to move a regular account onto the Rivus staff domain (403, no self-elevation)', async () => {
+		const owner = await signupOwner(app, { email: 'owner@example.com' });
+		const response = await updateProfile(owner.token, { email: 'sneaky@rivus.ai' });
+		expect(response.statusCode).toBe(403);
+		// Nothing was staged and no code was emailed to the staff address.
+		expect((await getMe(owner.token)).json().user.pendingEmail).toBe('');
+		expect(() => latestCodeFor(app, 'sneaky@rivus.ai')).toThrow();
+	});
+
+	it('refuses to change a staff member off the staff domain via the profile (403)', async () => {
+		// A staff account (its email is on the staff domain) can't self-service an email
+		// change here — that would strand a stale staff claim on its other sessions.
+		const staff = await signupOwner(app, { email: 'ops@rivus.ai' });
+		const response = await updateProfile(staff.token, { email: 'ops-personal@example.com' });
+		expect(response.statusCode).toBe(403);
+	});
+
+	it('cannot replay a confirmation code after it succeeds', async () => {
+		const owner = await signupOwner(app, { email: 'owner@example.com' });
+		await updateProfile(owner.token, { email: 'new@example.com' });
+		const code = latestCodeFor(app, 'new@example.com');
+		expect((await verifyEmailChange(owner.token, code)).statusCode).toBe(200);
+		// The change is done and pendingEmail cleared, so the same code now 400s.
+		expect((await verifyEmailChange(owner.token, code)).statusCode).toBe(400);
 	});
 });
 

--- a/packages/api/test/email.test.ts
+++ b/packages/api/test/email.test.ts
@@ -88,6 +88,11 @@ describe('renderVerificationEmail', () => {
 		const { text } = renderVerificationEmail({ ...code, purpose: 'signup' });
 		expect(text).toContain('finish creating your Rivus account');
 	});
+
+	it('uses email-change wording for an email_change code', () => {
+		const { text } = renderVerificationEmail({ ...code, purpose: 'email_change' });
+		expect(text).toContain('confirm your new Rivus email address');
+	});
 });
 
 describe('NoopMailer', () => {

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -60,6 +60,7 @@ const NAV: NavItem[] = [
 	{ href: '/marketing', label: 'Marketing', icon: 'trending-up' },
 	{ href: '/knowledge', label: 'Knowledge', icon: 'book' },
 	{ href: '/team', label: 'Team', icon: 'user-check' },
+	{ href: '/profile', label: 'Profile', icon: 'user' },
 	{ href: '/settings', label: 'Settings', icon: 'settings', ownerOnly: true },
 ];
 
@@ -282,19 +283,33 @@ function Sidebar() {
 			</View>
 
 			<View style={styles.sidebarFooter}>
-				<Pressable style={styles.userRow} onPress={signOut}>
-					<Avatar
-						initials={userName ? initialsOf(userName) : '–'}
-						size={30}
-						background="#2a2a3a"
-						color="#cfd0dc"
-					/>
-					<View style={{ flex: 1 }}>
-						<Txt style={styles.userName}>{userName}</Txt>
-						<Txt style={styles.userRole}>{role}</Txt>
-					</View>
-					<Feather name="log-out" size={15} color={colors.sidebarDim} />
-				</Pressable>
+				<View style={styles.userRow}>
+					<Pressable
+						style={styles.userIdentity}
+						onPress={() => router.push('/profile')}
+						accessibilityRole="link"
+						accessibilityLabel="Your profile"
+					>
+						<Avatar
+							initials={userName ? initialsOf(userName) : '–'}
+							size={30}
+							background="#2a2a3a"
+							color="#cfd0dc"
+						/>
+						<View style={{ flex: 1 }}>
+							<Txt style={styles.userName}>{userName}</Txt>
+							<Txt style={styles.userRole}>{role}</Txt>
+						</View>
+					</Pressable>
+					<Pressable
+						onPress={signOut}
+						accessibilityRole="button"
+						accessibilityLabel="Sign out"
+						hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+					>
+						<Feather name="log-out" size={15} color={colors.sidebarDim} />
+					</Pressable>
+				</View>
 			</View>
 		</View>
 	);
@@ -625,6 +640,12 @@ const styles = StyleSheet.create({
 		paddingVertical: 8,
 		paddingHorizontal: 8,
 		borderRadius: radii.md,
+	},
+	userIdentity: {
+		flex: 1,
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 12,
 	},
 	userName: {
 		fontFamily: font.semibold,

--- a/packages/app/app/profile.tsx
+++ b/packages/app/app/profile.tsx
@@ -264,6 +264,12 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		alignItems: 'center',
 		justifyContent: 'space-between',
+		// Let the label/role pill wrap instead of overflowing when the row is too
+		// narrow (small screens, large text scaling); React Native defaults
+		// flexShrink to 0, so set it explicitly. `gap` spaces them once wrapped.
+		flexShrink: 1,
+		flexWrap: 'wrap',
+		gap: 8,
 	},
 	form: {
 		gap: 13,

--- a/packages/app/app/profile.tsx
+++ b/packages/app/app/profile.tsx
@@ -1,0 +1,299 @@
+import type { UpdateProfileInput } from '@rivus/core';
+import { useEffect, useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { ApiError } from '@/src/api/client';
+import { roleLabel, useAuth } from '@/src/auth/AuthContext';
+import {
+	Card,
+	GradientButton,
+	OutlineButton,
+	Pill,
+	SectionLabel,
+	TextField,
+	Txt,
+} from '@/src/components/ui';
+import { colors, font } from '@/src/theme/tokens';
+
+function messageFor(error: unknown, fallback: string): string {
+	if (error instanceof ApiError || error instanceof Error) {
+		return error.message;
+	}
+	return fallback;
+}
+
+/**
+ * The signed-in user's personal profile — name, contact phone, and sign-in email.
+ * Available to every member (unlike account Settings, which is owner-only).
+ *
+ * Email is special: changing it doesn't take effect immediately. The API stages
+ * the new address on `user.pendingEmail` and emails a one-time code; the live
+ * email only switches once that code is confirmed below. While a change is
+ * pending, a second card collects the code (with a resend).
+ */
+export default function ProfileScreen() {
+	const { session, updateProfile, verifyEmailChange } = useAuth();
+	const user = session?.user;
+
+	const [name, setName] = useState(user?.name ?? '');
+	const [phone, setPhone] = useState(user?.phone ?? '');
+	const [email, setEmail] = useState(user?.email ?? '');
+
+	const [saving, setSaving] = useState(false);
+	const [saved, setSaved] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const [code, setCode] = useState('');
+	const [verifying, setVerifying] = useState(false);
+	const [verifyError, setVerifyError] = useState<string | null>(null);
+	const [resent, setResent] = useState(false);
+
+	// Re-sync the editable fields whenever the *server* values change (after a save,
+	// or after a verified email change resets the live email and clears the pending
+	// one). Local edits never change the server values until saved, so in-progress
+	// typing is not clobbered. After an email change is staged, this resets the email
+	// field to the still-current address while the pending card shows the new one.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: keyed on server values only, by design
+	useEffect(() => {
+		if (!user) {
+			return;
+		}
+		setName(user.name);
+		setPhone(user.phone);
+		setEmail(user.email);
+	}, [user?.name, user?.phone, user?.email, user?.pendingEmail]);
+
+	if (!session || !user) {
+		return null;
+	}
+
+	const pendingEmail = user.pendingEmail;
+	const liveEmail = user.email;
+
+	async function onSave() {
+		if (saving || !user) {
+			return;
+		}
+		setError(null);
+		setSaved(false);
+		// Send only the fields that actually changed (a partial update), mirroring the
+		// account-settings form. An unchanged form is a no-op.
+		const patch: UpdateProfileInput = {};
+		const nextName = name.trim();
+		const nextPhone = phone.trim();
+		const nextEmail = email.trim().toLowerCase();
+		if (nextName !== user.name) {
+			patch.name = nextName;
+		}
+		if (nextPhone !== user.phone) {
+			patch.phone = nextPhone;
+		}
+		if (nextEmail !== user.email) {
+			patch.email = nextEmail;
+		}
+		if (Object.keys(patch).length === 0) {
+			return;
+		}
+		setSaving(true);
+		try {
+			await updateProfile(patch);
+			setSaved(true);
+		} catch (caught) {
+			setError(messageFor(caught, 'Could not save your changes.'));
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	async function onVerifyEmail() {
+		if (verifying) {
+			return;
+		}
+		setVerifyError(null);
+		setResent(false);
+		setVerifying(true);
+		try {
+			// On success the session adopts the new email and `pendingEmail` clears, so
+			// this card unmounts.
+			await verifyEmailChange({ code: code.trim() });
+			setCode('');
+		} catch (caught) {
+			setVerifyError(messageFor(caught, 'Could not verify your new email.'));
+		} finally {
+			setVerifying(false);
+		}
+	}
+
+	async function onResend() {
+		if (!pendingEmail) {
+			return;
+		}
+		setVerifyError(null);
+		setResent(false);
+		try {
+			// Re-submitting the pending address re-issues the code to it.
+			await updateProfile({ email: pendingEmail });
+			setResent(true);
+		} catch (caught) {
+			setVerifyError(messageFor(caught, 'Could not resend the code.'));
+		}
+	}
+
+	return (
+		<ScrollView
+			contentContainerStyle={styles.content}
+			keyboardShouldPersistTaps="handled"
+			showsVerticalScrollIndicator={false}
+		>
+			<Txt style={styles.h1}>Your profile</Txt>
+			<Txt style={styles.subtitle}>Manage your personal details and sign-in email.</Txt>
+
+			<Card style={styles.card}>
+				<View style={styles.headerRow}>
+					<SectionLabel>Personal information</SectionLabel>
+					<Pill
+						label={roleLabel(session.role)}
+						color={colors.brandPurpleInk}
+						background="rgba(110,30,200,0.08)"
+					/>
+				</View>
+				<View style={styles.form}>
+					<TextField
+						label="Name"
+						value={name}
+						onChangeText={(next) => {
+							setName(next);
+							setSaved(false);
+						}}
+						placeholder="Marcus Thompson"
+						autoCapitalize="words"
+					/>
+					<TextField
+						label="Phone"
+						value={phone}
+						onChangeText={(next) => {
+							setPhone(next);
+							setSaved(false);
+						}}
+						placeholder="+1 (206) 555-0100"
+						keyboardType="phone-pad"
+					/>
+					<TextField
+						label="Email"
+						value={email}
+						onChangeText={(next) => {
+							setEmail(next);
+							setSaved(false);
+						}}
+						placeholder="you@business.com"
+						autoCapitalize="none"
+						autoComplete="email"
+						keyboardType="email-address"
+						hint="Changing your email sends a verification code to the new address — it stays the same until you confirm."
+					/>
+
+					{error ? <Txt style={styles.errorTxt}>{error}</Txt> : null}
+					{saved ? <Txt style={styles.savedTxt}>Saved.</Txt> : null}
+
+					<GradientButton
+						label={saving ? 'Saving…' : 'Save changes'}
+						icon="check"
+						onPress={onSave}
+					/>
+				</View>
+			</Card>
+
+			{pendingEmail ? (
+				<Card style={[styles.card, styles.pendingCard]}>
+					<SectionLabel style={styles.pendingLabel}>Verify your new email</SectionLabel>
+					<Txt style={styles.rowSub}>
+						We emailed a 6-digit code to {pendingEmail}. Enter it to switch your sign-in email from{' '}
+						{liveEmail}. The code expires in 10 minutes.
+					</Txt>
+					<View style={styles.form}>
+						<TextField
+							label="Verification code"
+							value={code}
+							onChangeText={(next) => setCode(next.replace(/\D/g, '').slice(0, 6))}
+							placeholder="123456"
+							keyboardType="number-pad"
+							autoComplete="one-time-code"
+							textContentType="oneTimeCode"
+							maxLength={6}
+							style={styles.codeInput}
+						/>
+
+						{verifyError ? <Txt style={styles.errorTxt}>{verifyError}</Txt> : null}
+						{resent ? <Txt style={styles.savedTxt}>A new code is on its way.</Txt> : null}
+
+						<GradientButton
+							label={verifying ? 'Verifying…' : 'Verify new email'}
+							icon="check"
+							onPress={onVerifyEmail}
+						/>
+						<OutlineButton label="Resend code" onPress={onResend} />
+					</View>
+				</Card>
+			) : null}
+		</ScrollView>
+	);
+}
+
+const styles = StyleSheet.create({
+	content: {
+		padding: 26,
+		gap: 16,
+		maxWidth: 760,
+		width: '100%',
+		alignSelf: 'center',
+	},
+	h1: {
+		fontFamily: font.bold,
+		fontSize: 22,
+		color: colors.text,
+	},
+	subtitle: {
+		fontFamily: font.regular,
+		fontSize: 13.5,
+		color: colors.textMuted,
+		marginTop: -8,
+	},
+	card: {
+		gap: 12,
+	},
+	headerRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+	},
+	form: {
+		gap: 13,
+	},
+	rowSub: {
+		fontFamily: font.regular,
+		fontSize: 12.5,
+		color: colors.textMuted,
+	},
+	errorTxt: {
+		fontFamily: font.medium,
+		fontSize: 12.5,
+		color: colors.redInk,
+	},
+	savedTxt: {
+		fontFamily: font.medium,
+		fontSize: 12.5,
+		color: colors.green,
+	},
+	// A violet-tinted border marks the "action needed" verification card (the accent
+	// colour, not the signature gradient), matching how Settings sets cards apart.
+	pendingCard: {
+		borderColor: 'rgba(110,30,200,0.30)',
+	},
+	pendingLabel: {
+		color: colors.brandPurpleInk,
+	},
+	codeInput: {
+		fontFamily: font.semibold,
+		fontSize: 20,
+		letterSpacing: 6,
+	},
+});

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -28,6 +28,8 @@ function makeUser() {
 		id: faker.string.uuid(),
 		email: faker.internet.email().toLowerCase(),
 		name: faker.person.fullName(),
+		phone: '',
+		pendingEmail: '',
 		createdAt: now,
 		updatedAt: now,
 	};
@@ -334,6 +336,83 @@ describe('createApiClient', () => {
 			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
 			expect(url).toBe(`${BASE}/v1/auth/me`);
 			expect(init.headers).toMatchObject({ Authorization: `Bearer ${token}` });
+		});
+	});
+
+	describe('updateProfile', () => {
+		it('PATCHes the profile with the bearer token and returns the updated user', async () => {
+			const updated = { ...makeUser(), name: 'Marcus Thompson', phone: '+1 206 555 0100' };
+			fetchMock.mockResolvedValueOnce(jsonResponse(updated));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.updateProfile('tok', {
+				name: 'Marcus Thompson',
+				phone: '+1 206 555 0100',
+			});
+
+			expect(result).toEqual(updated);
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/auth/me`);
+			expect(init.method).toBe('PATCH');
+			expect(init.headers).toMatchObject({
+				Authorization: 'Bearer tok',
+				'Content-Type': 'application/json',
+			});
+			expect(JSON.parse(init.body as string)).toEqual({
+				name: 'Marcus Thompson',
+				phone: '+1 206 555 0100',
+			});
+		});
+
+		it('normalizes a changed email and surfaces the pending address it returns', async () => {
+			const pending = { ...makeUser(), email: 'old@example.com', pendingEmail: 'new@example.com' };
+			fetchMock.mockResolvedValueOnce(jsonResponse(pending));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.updateProfile('tok', { email: '  New@Example.com ' });
+
+			expect(result.pendingEmail).toBe('new@example.com');
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(JSON.parse(init.body as string)).toEqual({ email: 'new@example.com' });
+		});
+
+		it('rejects an empty update before hitting the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.updateProfile('tok', {})).rejects.toThrow(ValidationError);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('rejects a malformed email before hitting the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.updateProfile('tok', { email: 'not-an-email' })).rejects.toThrow(
+				ValidationError,
+			);
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('verifyEmailChange', () => {
+		it('POSTs the code and returns the fresh session', async () => {
+			const auth = makeAuthResponse('owner');
+			fetchMock.mockResolvedValueOnce(jsonResponse(auth));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.verifyEmailChange('tok', { code: '123456' });
+
+			expect(result).toEqual(auth);
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/auth/me/email/verify`);
+			expect(init.method).toBe('POST');
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer tok' });
+			expect(JSON.parse(init.body as string)).toEqual({ code: '123456' });
+		});
+
+		it('rejects a malformed code before hitting the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.verifyEmailChange('tok', { code: '12' })).rejects.toThrow(
+				ValidationError,
+			);
+			expect(fetchMock).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -57,6 +57,7 @@ import {
 	type UpdateCustomerInput,
 	type UpdateFaqInput,
 	type UpdateJobInput,
+	type UpdateProfileInput,
 	type User,
 	type UserId,
 	updateAccountSchema,
@@ -64,8 +65,11 @@ import {
 	updateCustomerSchema,
 	updateFaqSchema,
 	updateJobSchema,
+	updateProfileSchema,
 	type VerifyCodeInput,
+	type VerifyEmailChangeInput,
 	verifyCodeSchema,
+	verifyEmailChangeSchema,
 } from '@rivus/core';
 import { z } from 'zod';
 
@@ -165,9 +169,13 @@ const userResponseSchema = z.object({
 	id: z.string(),
 	email: z.string(),
 	name: z.string(),
+	phone: z.string(),
+	pendingEmail: z.string(),
 	createdAt: z.string(),
 	updatedAt: z.string(),
 });
+/** The signed-in user as returned by the API (id is a plain string on the wire). */
+export type ProfileUser = z.infer<typeof userResponseSchema>;
 
 const accountResponseSchema = z.object({
 	id: accountId(),
@@ -548,6 +556,17 @@ export interface RivusApiClient {
 	me(token?: string): Promise<Session>;
 	/** Clear the server-side session cookie (web sign-out). */
 	logout(): Promise<void>;
+	/**
+	 * Update your own profile (name, phone, email). Changing the email doesn't take
+	 * effect immediately: the API stages it on `pendingEmail` and emails a one-time
+	 * code, which {@link RivusApiClient.verifyEmailChange} confirms.
+	 */
+	updateProfile(token: string, input: UpdateProfileInput): Promise<ProfileUser>;
+	/**
+	 * Confirm a pending email change with the code sent to the new address. Returns
+	 * a fresh session (the new token/cookie carry the updated email).
+	 */
+	verifyEmailChange(token: string, input: VerifyEmailChangeInput): Promise<AuthResponse>;
 	listMembers(token: string): Promise<MemberList>;
 	inviteMember(token: string, input: InviteMemberInput): Promise<Invite>;
 	/** Update the account's business settings (owner only). */
@@ -771,6 +790,20 @@ export function createApiClient(
 
 		async logout() {
 			await request('/v1/auth/logout', signedOutResponseSchema, { method: 'POST' });
+		},
+
+		async updateProfile(token: string, input: UpdateProfileInput) {
+			const payload = parseInput(updateProfileSchema, input);
+			return request('/v1/auth/me', userResponseSchema, jsonInit('PATCH', payload, token));
+		},
+
+		async verifyEmailChange(token: string, input: VerifyEmailChangeInput) {
+			const payload = parseInput(verifyEmailChangeSchema, input);
+			return request(
+				'/v1/auth/me/email/verify',
+				authResponseSchema,
+				jsonInit('POST', payload, token),
+			);
 		},
 
 		listMembers(token: string) {

--- a/packages/app/src/auth/AuthContext.tsx
+++ b/packages/app/src/auth/AuthContext.tsx
@@ -3,7 +3,9 @@ import {
 	isRivusStaffEmail,
 	type LoginInput,
 	type UpdateAccountInput,
+	type UpdateProfileInput,
 	type VerifyCodeInput,
+	type VerifyEmailChangeInput,
 } from '@rivus/core';
 import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from 'react';
 import { Platform } from 'react-native';
@@ -48,6 +50,14 @@ export interface AuthContextValue {
 	acceptInvite: (token: string) => Promise<void>;
 	/** Update the account's business settings, keeping the session in sync (owner only). */
 	updateAccount: (input: UpdateAccountInput) => Promise<void>;
+	/**
+	 * Update your own profile (name, phone, email), keeping the session in sync.
+	 * Changing the email stages it on `session.user.pendingEmail` and emails a code;
+	 * the live email only changes once {@link verifyEmailChange} confirms it.
+	 */
+	updateProfile: (input: UpdateProfileInput) => Promise<void>;
+	/** Confirm a pending email change with its code, adopting the re-issued session. */
+	verifyEmailChange: (input: VerifyEmailChangeInput) => Promise<void>;
 	/** Switch the active company and adopt the new session (Rivus staff only). */
 	switchCompany: (accountId: AccountId) => Promise<void>;
 	/** Cancel (soft-delete) the account, then sign out since it's now locked (owner only). */
@@ -128,6 +138,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 				}
 				const account = await client.updateAccount(session.token, input);
 				setSession({ ...session, account });
+			},
+			async updateProfile(input) {
+				if (!session) {
+					return;
+				}
+				const user = await client.updateProfile(session.token, input);
+				setSession({ ...session, user });
+			},
+			async verifyEmailChange(input) {
+				if (!session) {
+					return;
+				}
+				// The API re-issues the session (new token/cookie carry the new email).
+				setSession(adopt(await client.verifyEmailChange(session.token, input)));
 			},
 			async switchCompany(accountId) {
 				if (!session) {

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -35,7 +35,9 @@ import {
 	updateItemSchema,
 	updateJobSchema,
 	updateMemberRoleSchema,
+	updateProfileSchema,
 	verifyCodeSchema,
+	verifyEmailChangeSchema,
 } from './schemas';
 
 const FUTURE_ISO = '2026-06-24T21:00:00.000Z';
@@ -201,6 +203,42 @@ describe('updateAccountSchema', () => {
 
 	it('rejects a malformed website', () => {
 		expect(() => updateAccountSchema.parse({ website: 'not a url' })).toThrow();
+	});
+});
+
+describe('updateProfileSchema', () => {
+	it('accepts a partial update of one field', () => {
+		expect(updateProfileSchema.parse({ name: 'Marcus Thompson' })).toEqual({
+			name: 'Marcus Thompson',
+		});
+	});
+
+	it('normalizes a changed email (trim + lowercase)', () => {
+		expect(updateProfileSchema.parse({ email: '  New@Example.com ' }).email).toBe(
+			'new@example.com',
+		);
+	});
+
+	it('accepts clearing the phone with an empty string', () => {
+		expect(updateProfileSchema.parse({ phone: '' })).toEqual({ phone: '' });
+	});
+
+	it('rejects an empty update', () => {
+		expect(() => updateProfileSchema.parse({})).toThrow();
+	});
+
+	it('rejects a malformed email', () => {
+		expect(() => updateProfileSchema.parse({ email: 'not-an-email' })).toThrow();
+	});
+});
+
+describe('verifyEmailChangeSchema', () => {
+	it('accepts a 6-digit code', () => {
+		expect(verifyEmailChangeSchema.parse({ code: '123456' })).toEqual({ code: '123456' });
+	});
+
+	it('rejects a non 6-digit code', () => {
+		expect(() => verifyEmailChangeSchema.parse({ code: '12' })).toThrow();
 	});
 });
 

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -159,6 +159,35 @@ export const updateAccountSchema = z
 	});
 export type UpdateAccountInput = z.infer<typeof updateAccountSchema>;
 
+// --- Profile (the signed-in user's own account) -------------------------------
+
+/**
+ * Update your own profile: name, sign-in email, and contact phone. Every field is
+ * optional — like {@link updateAccountSchema}, a partial update only touches what
+ * the caller sends — but at least one must be present. Changing `email` doesn't
+ * apply immediately: the server emails a one-time code to the new address and the
+ * change lands only once {@link verifyEmailChangeSchema} confirms it.
+ */
+export const updateProfileSchema = z
+	.object({
+		name: nameSchema.optional(),
+		email: emailSchema.optional(),
+		phone: phoneSchema.optional(),
+	})
+	.refine((value) => Object.values(value).some((field) => field !== undefined), {
+		error: 'Provide at least one field to update.',
+	});
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
+
+/**
+ * Confirm a pending email change with the one-time code sent to the new address.
+ * The signed-in session identifies whose change it is, so only the code is needed.
+ */
+export const verifyEmailChangeSchema = z.object({
+	code: verificationCodeSchema,
+});
+export type VerifyEmailChangeInput = z.infer<typeof verifyEmailChangeSchema>;
+
 export const itemStatusSchema = z.enum(['active', 'archived'], {
 	error: 'Status must be either active or archived.',
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -23,6 +23,15 @@ export interface User {
 	id: UserId;
 	email: string;
 	name: string;
+	/** Personal contact phone; empty string when not provided. */
+	phone: string;
+	/**
+	 * A new email address awaiting confirmation, or `''` when none is pending.
+	 * Changing your email doesn't take effect until you verify a one-time code
+	 * sent to the new address — until then the live `email` is unchanged and this
+	 * holds the address being moved to.
+	 */
+	pendingEmail: string;
 	createdAt: IsoDateString;
 	updatedAt: IsoDateString;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — a profile view in the app and API so a signed-in user can update their **name, email, and phone**. If they change their email, it is re-verified before taking effect.

---

### What changed

**`@rivus/core`**
- `User` gains `phone` and `pendingEmail`.
- New `updateProfileSchema` (partial: name / email / phone, at least one) and `verifyEmailChangeSchema`.

**`@rivus/api`**
- `PATCH /v1/auth/me` — updates name/phone immediately. An email change is **staged** on `pendingEmail` and a one-time code is emailed to the new address; the live `email` is untouched until confirmed.
- `POST /v1/auth/me/email/verify` — confirms the code (same attempt-budget, atomic-increment-before-compare, and single-use guarding as `/verify`), swaps the email, clears `pendingEmail`, and **re-issues the session** so the token/cookie carry the new address. The code is bound to the requesting user.
- New `email_change` verification purpose, `UserRepository.update` across the in-memory and Mongo repositories + models, presenters/http-schemas, and email copy for the new purpose. Regenerated `openapi.json`.

**`@rivus/app`**
- New `/profile` screen — name/phone/email plus a "verify your new email" card (with resend) shown while a change is pending. Reachable from the sidebar identity (tap your name/avatar) and from nav; sign-out is now a separate control.
- `updateProfile` / `verifyEmailChange` on the API client and in `AuthContext` (keeping the session in sync; the re-issued session is adopted on confirm).

**`@rivus/agent`** — `User` schema/fixtures updated to match.

### Re-verification flow
1. `PATCH /v1/auth/me` with a new `email` → response shows the old `email` plus the staged `pendingEmail`; a code is mailed to the new address.
2. `POST /v1/auth/me/email/verify` with the code → email swapped, `pendingEmail` cleared, fresh session returned.

The new address isn't accepted until the code is confirmed, so an account email is never left unverified.

### Security
An adversarial self-review surfaced (and this PR closes) a privilege-escalation gap: Rivus **staff status is derived solely from the email domain** (`@rivus.ai`), so making email mutable could let a regular user self-elevate by moving their email onto the staff domain — or strand a stale staff claim on a staff member's other sessions after they move off it. The profile flow therefore **refuses any email change where the target or current address is on the staff domain** (`403`); staff email changes go through an administrator instead. Regular ↔ regular changes carry no privilege, so a momentarily-stale email claim on another session is harmless.

### Testing
`pnpm lint && pnpm type-check && pnpm test` and `pnpm test:coverage` all pass. Added tests in `core` (schemas), `api` (profile update, the two-step email re-verify, wrong-code/lockout, conflict, and the staff-domain guard), and `app` (client methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NN4pqYW9rbm3KfdVCeDL4c)_