### PR TITLE
feat: add Gravatar avatars and a profile image editor

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -171,8 +171,10 @@ A single dashboard metric.
 
 ### Avatar
 
-- **Props:** `initials` · `size`
-- Circular (`999px`), shows 2-letter initials (e.g. "MT", "PA").
+- **Props:** `initials` · `imageUrl` (optional) · `size`
+- Circular (`999px`). Shows `imageUrl` when given (e.g. a user's Gravatar);
+  falls back to 2-letter initials (e.g. "MT", "PA") when there's no image, or
+  it fails to load.
 
 ### Buttons
 

--- a/packages/agent/src/api.test.ts
+++ b/packages/agent/src/api.test.ts
@@ -43,6 +43,7 @@ const session = {
 		id: 'user_1',
 		email: 'owner@acme.example',
 		name: 'Pat Owner',
+		avatarUrl: 'https://www.gravatar.com/avatar/abc?s=200&d=404',
 		createdAt: '2026-01-01T00:00:00.000Z',
 		updatedAt: '2026-01-01T00:00:00.000Z',
 	},

--- a/packages/agent/src/api.ts
+++ b/packages/agent/src/api.ts
@@ -47,6 +47,7 @@ const userSchema = z.object({
 	id: branded<UserId>(),
 	email: z.string(),
 	name: z.string(),
+	avatarUrl: z.string(),
 	createdAt: z.string(),
 	updatedAt: z.string(),
 }) satisfies z.ZodType<User>;

--- a/packages/agent/src/assistant.test.ts
+++ b/packages/agent/src/assistant.test.ts
@@ -67,6 +67,7 @@ function sessionBody(account = makeAccount()) {
 			id: 'user_1',
 			email: 'owner@acme.example',
 			name: 'Pat Owner',
+			avatarUrl: 'https://www.gravatar.com/avatar/abc?s=200&d=404',
 			createdAt: '2026-01-01T00:00:00.000Z',
 			updatedAt: '2026-01-01T00:00:00.000Z',
 		},

--- a/packages/agent/src/http.test.ts
+++ b/packages/agent/src/http.test.ts
@@ -230,6 +230,7 @@ describe('handleChat', () => {
 							id: 'user_1',
 							email: 'owner@acme.example',
 							name: 'Pat',
+							avatarUrl: 'https://www.gravatar.com/avatar/abc?s=200&d=404',
 							createdAt: account.createdAt,
 							updatedAt: account.updatedAt,
 						},

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -360,6 +360,78 @@
             }
           }
         }
+      },
+      "patch": {
+        "summary": "Update the signed-in user's own profile image",
+        "tags": [
+          "auth"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "avatarUrl": {
+                    "type": "string",
+                    "maxLength": 2048
+                  }
+                },
+                "required": [
+                  "avatarUrl"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/auth/accept-invite": {

--- a/packages/api/src/db/models/user.model.ts
+++ b/packages/api/src/db/models/user.model.ts
@@ -3,6 +3,8 @@ import { model, Schema } from 'mongoose';
 export interface UserDocument {
 	email: string;
 	name: string;
+	/** Custom avatar override; unset falls back to the Gravatar derived from `email`. */
+	avatarUrl?: string;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -11,6 +13,7 @@ const userSchema = new Schema<UserDocument>(
 	{
 		email: { type: String, required: true, unique: true, lowercase: true, trim: true, index: true },
 		name: { type: String, required: true, trim: true },
+		avatarUrl: { type: String, required: false, trim: true },
 	},
 	{ timestamps: true },
 );

--- a/packages/api/src/http-schemas.ts
+++ b/packages/api/src/http-schemas.ts
@@ -18,6 +18,7 @@ export const userResponseSchema = z
 		id: z.string(),
 		email: z.string(),
 		name: z.string(),
+		avatarUrl: z.string(),
 		createdAt: z.string(),
 		updatedAt: z.string(),
 	})
@@ -83,6 +84,7 @@ export const memberResponseSchema = z
 		userId: z.string(),
 		email: z.string(),
 		name: z.string(),
+		avatarUrl: z.string(),
 		role: roleSchema,
 		joinedAt: z.string(),
 	})

--- a/packages/api/src/presenters.ts
+++ b/packages/api/src/presenters.ts
@@ -1,5 +1,10 @@
-import type { Account, Invite, Membership, User } from '@rivus/core';
+import { type Account, gravatarUrl, type Invite, type Membership, type User } from '@rivus/core';
 import type { StoredUser } from './repositories/types';
+
+/** The user's custom avatar override, or their Gravatar if none is set. */
+function resolveAvatarUrl(user: StoredUser): string {
+	return user.avatarUrl?.trim() || gravatarUrl(user.email);
+}
 
 /** Strip the password hash before a user ever leaves the API. */
 export function toPublicUser(user: StoredUser): User {
@@ -7,6 +12,7 @@ export function toPublicUser(user: StoredUser): User {
 		id: user.id,
 		email: user.email,
 		name: user.name,
+		avatarUrl: resolveAvatarUrl(user),
 		createdAt: user.createdAt,
 		updatedAt: user.updatedAt,
 	};
@@ -35,6 +41,7 @@ export function toMember(user: StoredUser, membership: Membership) {
 		userId: user.id,
 		email: user.email,
 		name: user.name,
+		avatarUrl: resolveAvatarUrl(user),
 		role: membership.role,
 		joinedAt: membership.createdAt,
 	};

--- a/packages/api/src/repositories/memory.ts
+++ b/packages/api/src/repositories/memory.ts
@@ -73,6 +73,7 @@ import type {
 	StoredUser,
 	StoredVerificationCode,
 	UpdateAccount,
+	UpdateUserProfile,
 	UserRepository,
 	VerificationCodeRepository,
 } from './types';
@@ -163,6 +164,22 @@ export class InMemoryUserRepository implements UserRepository {
 			}
 		}
 		return found;
+	}
+
+	async update(id: UserId, input: UpdateUserProfile): Promise<StoredUser | null> {
+		const user = this.data.users.get(id);
+		if (!user) {
+			return null;
+		}
+		const updated: StoredUser = { ...user, updatedAt: now() };
+		if (input.avatarUrl !== undefined) {
+			const trimmed = input.avatarUrl.trim();
+			// An empty override clears back to the Gravatar default — `undefined`,
+			// not `''`, so the presenter's `||` fallback actually kicks in.
+			updated.avatarUrl = trimmed === '' ? undefined : trimmed;
+		}
+		this.data.users.set(id, updated);
+		return structuredClone(updated);
 	}
 }
 

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -92,6 +92,7 @@ import type {
 	StoredUser,
 	StoredVerificationCode,
 	UpdateAccount,
+	UpdateUserProfile,
 	UserRepository,
 	VerificationCodeRepository,
 } from './types';
@@ -108,6 +109,7 @@ function mapUser(doc: HydratedDocument<UserDocument>): StoredUser {
 		id: doc._id.toString() as UserId,
 		email: doc.email,
 		name: doc.name,
+		avatarUrl: doc.avatarUrl,
 		createdAt: doc.createdAt.toISOString(),
 		updatedAt: doc.updatedAt.toISOString(),
 	};
@@ -313,6 +315,28 @@ export class MongoUserRepository implements UserRepository {
 		}
 		const docs = await UserModel.find({ _id: { $in: objectIds } }).exec();
 		return docs.map(mapUser);
+	}
+
+	async update(id: UserId, input: UpdateUserProfile): Promise<StoredUser | null> {
+		if (!Types.ObjectId.isValid(id)) {
+			return null;
+		}
+		// `avatarUrl: undefined` (the field wasn't sent) must leave the existing
+		// override untouched — only a present-but-empty string clears it — so this
+		// can't collapse to a single truthy check the way `trimmed ? set : unset`
+		// would (that treats "omitted" and "explicitly cleared" identically and
+		// diverges from `InMemoryUserRepository.update`, which guards on `!== undefined`).
+		let update: Record<string, unknown> | undefined;
+		if (input.avatarUrl !== undefined) {
+			const trimmed = input.avatarUrl.trim();
+			// An empty override clears the field rather than storing `''`, so `mapUser`
+			// (and the presenter's fallback) see it as unset.
+			update = trimmed ? { $set: { avatarUrl: trimmed } } : { $unset: { avatarUrl: 1 } };
+		}
+		const doc = update
+			? await UserModel.findByIdAndUpdate(id, update, { new: true }).exec()
+			: await UserModel.findById(id).exec();
+		return doc ? mapUser(doc) : null;
 	}
 }
 

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -40,13 +40,21 @@ import type {
 
 /**
  * A user as persisted. Auth is passwordless (one-time email codes), so there is
- * no secret stored on the user record — `StoredUser` is just the public `User`.
+ * no secret stored on the user record. `avatarUrl` is only the custom override
+ * (unset unless the user has set one) — unlike the public `User.avatarUrl`,
+ * which is never empty because the presenter falls back to a Gravatar URL.
  */
-export type StoredUser = User;
+export type StoredUser = Omit<User, 'avatarUrl'> & { avatarUrl?: string };
 
 export interface NewUser {
 	email: string;
 	name: string;
+}
+
+/** A partial update to the signed-in user's own profile. */
+export interface UpdateUserProfile {
+	/** Custom avatar override; an empty string clears it back to the Gravatar default. */
+	avatarUrl?: string;
 }
 
 export interface UserRepository {
@@ -55,6 +63,8 @@ export interface UserRepository {
 	findById(id: UserId): Promise<StoredUser | null>;
 	/** Fetch many users in one query (the order of the result is not guaranteed). */
 	findByIds(ids: UserId[]): Promise<StoredUser[]>;
+	/** Apply a partial profile update; returns the updated user or null. */
+	update(id: UserId, input: UpdateUserProfile): Promise<StoredUser | null>;
 }
 
 // --- Passwordless verification codes -----------------------------------------

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -4,6 +4,7 @@ import {
 	loginSchema,
 	signupSchema,
 	type UserId,
+	updateProfileSchema,
 	verifyCodeSchema,
 } from '@rivus/core';
 import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
@@ -14,6 +15,7 @@ import {
 	errorResponseSchema,
 	sessionResponseSchema,
 	signedOutResponseSchema,
+	userResponseSchema,
 } from '../http-schemas';
 import { SESSION_COOKIE, sessionCookieOptions } from '../plugins/auth';
 import { toPublicAccount, toPublicUser } from '../presenters';
@@ -261,6 +263,32 @@ export const authRoutes: FastifyPluginAsync = async (fastify) => {
 				account: toPublicAccount(account),
 				role: request.user.role,
 			};
+		},
+	);
+
+	app.patch(
+		'/me',
+		{
+			onRequest: [fastify.authenticate],
+			schema: {
+				tags: ['auth'],
+				summary: "Update the signed-in user's own profile image",
+				security: [{ bearerAuth: [] }],
+				body: updateProfileSchema,
+				response: {
+					200: userResponseSchema,
+					400: errorResponseSchema,
+					401: errorResponseSchema,
+					404: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const updated = await users.update(request.user.sub as UserId, request.body);
+			if (!updated) {
+				throw app.httpErrors.notFound('User not found');
+			}
+			return toPublicUser(updated);
 		},
 	);
 

--- a/packages/api/test/auth.test.ts
+++ b/packages/api/test/auth.test.ts
@@ -1,4 +1,4 @@
-import type { AccountId, UserId } from '@rivus/core';
+import { type AccountId, gravatarUrl, type UserId } from '@rivus/core';
 import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { loadConfig } from '../src/config';
@@ -368,6 +368,18 @@ describe('me', () => {
 		expect(body.role).toBe('owner');
 	});
 
+	it('defaults the user avatar to their Gravatar when no custom image is set', async () => {
+		const { credentials, token } = await signupOwner(app);
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/v1/auth/me',
+			headers: authHeader(token),
+		});
+
+		expect(response.json().user.avatarUrl).toBe(gravatarUrl(credentials.email));
+	});
+
 	it('rejects /me without a token (401)', async () => {
 		const response = await app.inject({ method: 'GET', url: '/v1/auth/me' });
 		expect(response.statusCode).toBe(401);
@@ -380,6 +392,133 @@ describe('me', () => {
 			headers: authHeader('garbage.token.value'),
 		});
 		expect(response.statusCode).toBe(401);
+	});
+});
+
+describe('update profile (PATCH /v1/auth/me)', () => {
+	let app: FastifyInstance;
+
+	beforeEach(async () => {
+		app = await buildTestApp();
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	it('sets a custom avatar image, overriding the Gravatar default', async () => {
+		const { token } = await signupOwner(app);
+
+		const response = await app.inject({
+			method: 'PATCH',
+			url: '/v1/auth/me',
+			headers: authHeader(token),
+			payload: { avatarUrl: 'https://example.com/me.jpg' },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().avatarUrl).toBe('https://example.com/me.jpg');
+	});
+
+	it('clears a custom avatar with an empty string, reverting to the Gravatar default', async () => {
+		const { credentials, token } = await signupOwner(app);
+		await app.inject({
+			method: 'PATCH',
+			url: '/v1/auth/me',
+			headers: authHeader(token),
+			payload: { avatarUrl: 'https://example.com/me.jpg' },
+		});
+
+		const cleared = await app.inject({
+			method: 'PATCH',
+			url: '/v1/auth/me',
+			headers: authHeader(token),
+			payload: { avatarUrl: '' },
+		});
+
+		expect(cleared.statusCode).toBe(200);
+		expect(cleared.json().avatarUrl).toBe(gravatarUrl(credentials.email));
+	});
+
+	it('persists the change — a later /me reflects the new avatar', async () => {
+		const { token } = await signupOwner(app);
+		await app.inject({
+			method: 'PATCH',
+			url: '/v1/auth/me',
+			headers: authHeader(token),
+			payload: { avatarUrl: 'https://example.com/me.jpg' },
+		});
+
+		const me = await app.inject({
+			method: 'GET',
+			url: '/v1/auth/me',
+			headers: authHeader(token),
+		});
+
+		expect(me.json().user.avatarUrl).toBe('https://example.com/me.jpg');
+	});
+
+	it('rejects a malformed image URL (400)', async () => {
+		const { token } = await signupOwner(app);
+
+		const response = await app.inject({
+			method: 'PATCH',
+			url: '/v1/auth/me',
+			headers: authHeader(token),
+			payload: { avatarUrl: 'not a url' },
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects a missing avatarUrl field (400)', async () => {
+		const { token } = await signupOwner(app);
+
+		const response = await app.inject({
+			method: 'PATCH',
+			url: '/v1/auth/me',
+			headers: authHeader(token),
+			payload: {},
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it('rejects an unauthenticated request (401)', async () => {
+		const response = await app.inject({
+			method: 'PATCH',
+			url: '/v1/auth/me',
+			payload: { avatarUrl: 'https://example.com/me.jpg' },
+		});
+
+		expect(response.statusCode).toBe(401);
+	});
+
+	it('lets a non-owner member edit their own avatar (not owner-gated)', async () => {
+		const { token: ownerToken } = await signupOwner(app);
+		const inviteResponse = await app.inject({
+			method: 'POST',
+			url: '/v1/members/invites',
+			headers: authHeader(ownerToken),
+			payload: { email: 'teammate@example.com', name: 'Teammate', role: 'member' },
+		});
+		const inviteToken = inviteResponse.json().token as string;
+		const accepted = await app.inject({
+			method: 'POST',
+			url: '/v1/auth/accept-invite',
+			payload: { token: inviteToken },
+		});
+		const memberToken = accepted.json().token as string;
+
+		const response = await app.inject({
+			method: 'PATCH',
+			url: '/v1/auth/me',
+			headers: authHeader(memberToken),
+			payload: { avatarUrl: 'https://example.com/member.jpg' },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().avatarUrl).toBe('https://example.com/member.jpg');
 	});
 });
 

--- a/packages/api/test/members.test.ts
+++ b/packages/api/test/members.test.ts
@@ -1,4 +1,4 @@
-import type { Role } from '@rivus/core';
+import { gravatarUrl, type Role } from '@rivus/core';
 import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { authHeader, buildTestApp, RecordingMailer, signupOwner } from './helpers';
@@ -53,6 +53,39 @@ describe('members', () => {
 		expect(body.members).toHaveLength(1);
 		expect(body.members[0]).toMatchObject({ userId: owner.user.id, role: 'owner' });
 		expect(body.invites).toEqual([]);
+	});
+
+	it("defaults a member's roster avatar to their Gravatar", async () => {
+		const owner = await signupOwner(app);
+		const response = await app.inject({
+			method: 'GET',
+			url: '/v1/members',
+			headers: authHeader(owner.token),
+		});
+
+		expect(response.json().members[0].avatarUrl).toBe(gravatarUrl(owner.credentials.email));
+	});
+
+	it("reflects a member's custom avatar in the roster", async () => {
+		const owner = await signupOwner(app);
+		const teammate = await addMember(owner.token, 'member', 'teammate@example.com');
+		await app.inject({
+			method: 'PATCH',
+			url: '/v1/auth/me',
+			headers: authHeader(teammate.token),
+			payload: { avatarUrl: 'https://example.com/teammate.jpg' },
+		});
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/v1/members',
+			headers: authHeader(owner.token),
+		});
+
+		const member = response
+			.json()
+			.members.find((m: { userId: string }) => m.userId === teammate.userId);
+		expect(member.avatarUrl).toBe('https://example.com/teammate.jpg');
 	});
 
 	it('lets an owner invite a manager and shows the pending invite', async () => {

--- a/packages/app/app/_layout.tsx
+++ b/packages/app/app/_layout.tsx
@@ -285,6 +285,7 @@ function Sidebar() {
 				<Pressable style={styles.userRow} onPress={signOut}>
 					<Avatar
 						initials={userName ? initialsOf(userName) : '–'}
+						imageUrl={session?.user.avatarUrl}
 						size={30}
 						background="#2a2a3a"
 						color="#cfd0dc"
@@ -516,6 +517,7 @@ function MoreSheet({
 				>
 					<Avatar
 						initials={userName ? initialsOf(userName) : '–'}
+						imageUrl={session?.user.avatarUrl}
 						size={32}
 						background={colors.avatarBg}
 						color={colors.avatarText}

--- a/packages/app/app/settings.tsx
+++ b/packages/app/app/settings.tsx
@@ -1,3 +1,4 @@
+import { gravatarUrl } from '@rivus/core';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
 	ActivityIndicator,
@@ -10,9 +11,10 @@ import {
 import { ApiError, type Billing, type SeedSummary } from '@/src/api/client';
 import { getGoogleMapsApiKey, isDevelopment } from '@/src/api/config';
 import { deviceTimezone, listTimezones } from '@/src/api/timezones';
-import { useAuth } from '@/src/auth/AuthContext';
+import { initialsOf, useAuth } from '@/src/auth/AuthContext';
 import { AddressAutocomplete } from '@/src/components/AddressAutocomplete';
 import {
+	Avatar,
 	Card,
 	GradientButton,
 	OutlineButton,
@@ -33,6 +35,104 @@ function messageFor(error: unknown, fallback: string): string {
 		return error.message;
 	}
 	return fallback;
+}
+
+/**
+ * The signed-in user's own profile photo, with a button to set a custom image
+ * URL. Visible to every role (unlike the business settings below, which are
+ * owner-only) since it edits the user's own profile, not the account. Defaults
+ * to the Gravatar linked to their email — see {@link Avatar} and `gravatarUrl`.
+ */
+function YourProfileCard() {
+	const { session, updateProfile } = useAuth();
+	const [editing, setEditing] = useState(false);
+	const [avatarUrl, setAvatarUrl] = useState('');
+	const [saving, setSaving] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	if (!session) {
+		return null;
+	}
+	// Narrowed once here: `session` stays non-null for the rest of this render, but
+	// TS can't carry that into `startEditing` below since it's a nested function.
+	const { user } = session;
+
+	function startEditing() {
+		// Pre-fill with the existing custom image so re-saving without changes is a
+		// no-op. When the user has no override, `user.avatarUrl` is exactly the
+		// Gravatar `toPublicUser` would've computed (same email, same defaults), so
+		// that exact-match check (rather than just "looks like a Gravatar URL") is
+		// what tells "no custom override" apart from "a custom image that happens to
+		// be hosted on gravatar.com" — leaving the field blank doubles as "use my
+		// Gravatar" either way.
+		const isDefaultGravatar = user.avatarUrl === gravatarUrl(user.email);
+		setAvatarUrl(isDefaultGravatar ? '' : user.avatarUrl);
+		setError(null);
+		setEditing(true);
+	}
+
+	async function onSave() {
+		if (saving) {
+			return;
+		}
+		setError(null);
+		setSaving(true);
+		try {
+			await updateProfile({ avatarUrl: avatarUrl.trim() });
+			setEditing(false);
+		} catch (caught) {
+			setError(messageFor(caught, 'Could not update your profile image.'));
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	return (
+		<Card style={styles.card}>
+			<SectionLabel>Your profile</SectionLabel>
+			<View style={styles.profileRow}>
+				<Avatar initials={initialsOf(user.name)} imageUrl={user.avatarUrl} size={64} />
+				<View style={styles.profileMain}>
+					<Txt style={styles.profileName}>{user.name}</Txt>
+					<Txt style={styles.rowSub}>{user.email}</Txt>
+				</View>
+			</View>
+
+			{editing ? (
+				<View style={styles.form}>
+					<TextField
+						label="Image URL"
+						value={avatarUrl}
+						onChangeText={setAvatarUrl}
+						placeholder="https://example.com/photo.jpg"
+						hint="Leave blank and save to use your Gravatar — the photo linked to your email at gravatar.com."
+						autoCapitalize="none"
+						autoCorrect={false}
+						keyboardType="url"
+					/>
+					{error ? <Txt style={styles.errorTxt}>{error}</Txt> : null}
+					<View style={styles.confirmRow}>
+						<GradientButton
+							label={saving ? 'Saving…' : 'Save image'}
+							icon="check"
+							onPress={onSave}
+							style={styles.confirmBtn}
+						/>
+						<OutlineButton
+							label="Cancel"
+							onPress={() => {
+								setEditing(false);
+								setError(null);
+							}}
+							style={styles.confirmBtn}
+						/>
+					</View>
+				</View>
+			) : (
+				<OutlineButton label="Edit image" onPress={startEditing} />
+			)}
+		</Card>
+	);
 }
 
 /**
@@ -184,6 +284,7 @@ export default function SettingsScreen() {
 		return (
 			<ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
 				<Txt style={styles.h1}>Account settings</Txt>
+				<YourProfileCard />
 				<Card style={styles.card}>
 					<Txt style={styles.rowSub}>
 						Only the account Owner can change account settings or billing. Ask an Owner if you need
@@ -241,6 +342,8 @@ export default function SettingsScreen() {
 		>
 			<Txt style={styles.h1}>Account settings</Txt>
 			<Txt style={styles.subtitle}>Business details for {session.account.name}.</Txt>
+
+			<YourProfileCard />
 
 			<Card style={styles.card}>
 				<SectionLabel>Business information</SectionLabel>
@@ -386,6 +489,21 @@ const styles = StyleSheet.create({
 	},
 	form: {
 		gap: 13,
+	},
+	profileRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 14,
+	},
+	profileMain: {
+		flex: 1,
+		minWidth: 0,
+		gap: 2,
+	},
+	profileName: {
+		fontFamily: font.bold,
+		fontSize: 16,
+		color: colors.text,
 	},
 	rowSub: {
 		fontFamily: font.regular,

--- a/packages/app/app/team.tsx
+++ b/packages/app/app/team.tsx
@@ -122,7 +122,7 @@ export default function TeamScreen() {
 						const pill = rolePillColors(member.role);
 						return (
 							<View key={member.userId} style={styles.row}>
-								<Avatar initials={initialsOf(member.name)} size={38} />
+								<Avatar initials={initialsOf(member.name)} imageUrl={member.avatarUrl} size={38} />
 								<View style={styles.rowMain}>
 									<Txt style={styles.rowName}>{member.name}</Txt>
 									<Txt style={styles.rowSub}>{member.email}</Txt>

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -28,6 +28,7 @@ function makeUser() {
 		id: faker.string.uuid(),
 		email: faker.internet.email().toLowerCase(),
 		name: faker.person.fullName(),
+		avatarUrl: faker.internet.url(),
 		createdAt: now,
 		updatedAt: now,
 	};
@@ -346,6 +347,7 @@ describe('createApiClient', () => {
 						userId: faker.string.uuid(),
 						email: faker.internet.email().toLowerCase(),
 						name: faker.person.fullName(),
+						avatarUrl: faker.internet.url(),
 						role: 'owner' as const,
 						joinedAt: now,
 					},
@@ -422,6 +424,43 @@ describe('createApiClient', () => {
 		it('rejects an empty update before hitting the network', async () => {
 			const client = createApiClient(BASE, fetchMock);
 			await expect(client.updateAccount('tok', {})).rejects.toThrow();
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('updateProfile', () => {
+		it('PATCHes the current user with the bearer token and returns it', async () => {
+			const user = makeUser();
+			const updated = { ...user, avatarUrl: 'https://example.com/me.jpg' };
+			fetchMock.mockResolvedValueOnce(jsonResponse(updated));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.updateProfile('owner-token', {
+				avatarUrl: 'https://example.com/me.jpg',
+			});
+
+			expect(result.avatarUrl).toBe('https://example.com/me.jpg');
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/auth/me`);
+			expect(init.method).toBe('PATCH');
+			expect(JSON.parse(init.body as string)).toEqual({ avatarUrl: 'https://example.com/me.jpg' });
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer owner-token' });
+		});
+
+		it('accepts an empty string to clear a custom avatar', async () => {
+			const user = makeUser();
+			fetchMock.mockResolvedValueOnce(jsonResponse(user));
+
+			const client = createApiClient(BASE, fetchMock);
+			await client.updateProfile('owner-token', { avatarUrl: '' });
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(JSON.parse(init.body as string)).toEqual({ avatarUrl: '' });
+		});
+
+		it('rejects a malformed image URL before hitting the network', async () => {
+			const client = createApiClient(BASE, fetchMock);
+			await expect(client.updateProfile('tok', { avatarUrl: 'not a url' })).rejects.toThrow();
 			expect(fetchMock).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -57,6 +57,7 @@ import {
 	type UpdateCustomerInput,
 	type UpdateFaqInput,
 	type UpdateJobInput,
+	type UpdateProfileInput,
 	type User,
 	type UserId,
 	updateAccountSchema,
@@ -64,6 +65,7 @@ import {
 	updateCustomerSchema,
 	updateFaqSchema,
 	updateJobSchema,
+	updateProfileSchema,
 	type VerifyCodeInput,
 	verifyCodeSchema,
 } from '@rivus/core';
@@ -162,12 +164,13 @@ function parseInput<S extends z.ZodType>(schema: S, input: unknown): z.infer<S> 
 // --- Response schemas (mirror @rivus/api http-schemas; app depends on core only).
 
 const userResponseSchema = z.object({
-	id: z.string(),
+	id: userId(),
 	email: z.string(),
 	name: z.string(),
+	avatarUrl: z.string(),
 	createdAt: z.string(),
 	updatedAt: z.string(),
-});
+}) satisfies z.ZodType<User>;
 
 const accountResponseSchema = z.object({
 	id: accountId(),
@@ -214,6 +217,7 @@ const memberResponseSchema = z.object({
 	userId: userId(),
 	email: z.string(),
 	name: z.string(),
+	avatarUrl: z.string(),
 	role: roleSchema,
 	joinedAt: z.string(),
 });
@@ -550,6 +554,8 @@ export interface RivusApiClient {
 	logout(): Promise<void>;
 	listMembers(token: string): Promise<MemberList>;
 	inviteMember(token: string, input: InviteMemberInput): Promise<Invite>;
+	/** Update the signed-in user's own profile image (any member may edit their own). */
+	updateProfile(token: string, input: UpdateProfileInput): Promise<User>;
 	/** Update the account's business settings (owner only). */
 	updateAccount(token: string, input: UpdateAccountInput): Promise<Account>;
 	/** Cancel (soft-delete) the account (owner only). */
@@ -783,6 +789,11 @@ export function createApiClient(
 		async inviteMember(token: string, input: InviteMemberInput) {
 			const payload = parseInput(inviteMemberSchema, input);
 			return request('/v1/members/invites', inviteResponseSchema, jsonInit('POST', payload, token));
+		},
+
+		async updateProfile(token: string, input: UpdateProfileInput) {
+			const payload = parseInput(updateProfileSchema, input);
+			return request('/v1/auth/me', userResponseSchema, jsonInit('PATCH', payload, token));
 		},
 
 		async updateAccount(token: string, input: UpdateAccountInput) {

--- a/packages/app/src/auth/AuthContext.tsx
+++ b/packages/app/src/auth/AuthContext.tsx
@@ -3,6 +3,7 @@ import {
 	isRivusStaffEmail,
 	type LoginInput,
 	type UpdateAccountInput,
+	type UpdateProfileInput,
 	type VerifyCodeInput,
 } from '@rivus/core';
 import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from 'react';
@@ -46,6 +47,8 @@ export interface AuthContextValue {
 	/** Exchange a one-time code for a session. */
 	verifyCode: (input: VerifyCodeInput) => Promise<void>;
 	acceptInvite: (token: string) => Promise<void>;
+	/** Update the signed-in user's own profile image, keeping the session in sync. */
+	updateProfile: (input: UpdateProfileInput) => Promise<void>;
 	/** Update the account's business settings, keeping the session in sync (owner only). */
 	updateAccount: (input: UpdateAccountInput) => Promise<void>;
 	/** Switch the active company and adopt the new session (Rivus staff only). */
@@ -121,6 +124,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 			},
 			async acceptInvite(token) {
 				setSession(adopt(await client.acceptInvite({ token })));
+			},
+			async updateProfile(input) {
+				if (!session) {
+					return;
+				}
+				const user = await client.updateProfile(session.token, input);
+				setSession({ ...session, user });
 			},
 			async updateAccount(input) {
 				if (!session) {

--- a/packages/app/src/components/ui.tsx
+++ b/packages/app/src/components/ui.tsx
@@ -2,6 +2,7 @@ import { Feather } from '@expo/vector-icons';
 import { type ComponentProps, type ReactNode, useMemo, useState } from 'react';
 import {
 	FlatList,
+	Image,
 	Modal,
 	Pressable,
 	type StyleProp,
@@ -70,18 +71,36 @@ export function Pill({
 	);
 }
 
-/** Circular initials avatar. */
+/**
+ * Circular avatar. Shows `imageUrl` (e.g. a Gravatar or a custom upload) when
+ * given; falls back to 2-letter initials when there's no image, or the image
+ * fails to load (an unset Gravatar 404s, by design — see `gravatarUrl`).
+ */
 export function Avatar({
 	initials,
+	imageUrl,
 	size = 40,
 	background = colors.avatarBg,
 	color = colors.avatarText,
 }: {
 	initials: string;
+	imageUrl?: string;
 	size?: number;
 	background?: string;
 	color?: string;
 }) {
+	// Reset the "failed to load" flag whenever `imageUrl` itself changes (e.g. the
+	// user saves a new avatar after an old one 404'd) — without this, `imageFailed`
+	// would stick from the previous URL and the new image would never be tried.
+	const [[trackedUrl, imageFailed], setImageState] = useState<[string | undefined, boolean]>([
+		imageUrl,
+		false,
+	]);
+	if (trackedUrl !== imageUrl) {
+		setImageState([imageUrl, false]);
+	}
+	const showImage = Boolean(imageUrl) && !imageFailed;
+
 	return (
 		<View
 			style={[
@@ -89,7 +108,18 @@ export function Avatar({
 				{ width: size, height: size, borderRadius: size / 2, backgroundColor: background },
 			]}
 		>
-			<Txt style={[styles.avatarTxt, { color, fontSize: Math.round(size * 0.32) }]}>{initials}</Txt>
+			{showImage ? (
+				<Image
+					source={{ uri: imageUrl }}
+					style={{ width: size, height: size, borderRadius: size / 2 }}
+					onError={() => setImageState([imageUrl, true])}
+					accessibilityIgnoresInvertColors
+				/>
+			) : (
+				<Txt style={[styles.avatarTxt, { color, fontSize: Math.round(size * 0.32) }]}>
+					{initials}
+				</Txt>
+			)}
 		</View>
 	);
 }
@@ -376,6 +406,7 @@ export const styles = StyleSheet.create({
 	avatar: {
 		alignItems: 'center',
 		justifyContent: 'center',
+		overflow: 'hidden',
 	},
 	avatarTxt: {
 		fontFamily: font.semibold,

--- a/packages/core/src/gravatar.test.ts
+++ b/packages/core/src/gravatar.test.ts
@@ -1,0 +1,51 @@
+import { createHash } from 'node:crypto';
+import { faker } from '@faker-js/faker';
+import { describe, expect, it } from 'vitest';
+import { gravatarUrl } from './gravatar';
+
+/** Reference MD5 via Node's `crypto`, so the dependency-free implementation is cross-checked. */
+function referenceHash(email: string): string {
+	return createHash('md5').update(email.trim().toLowerCase()).digest('hex');
+}
+
+describe('gravatarUrl', () => {
+	it('builds a Gravatar URL keyed by the MD5 hash of the trimmed, lowercased email', () => {
+		const email = '  MyEmailAddress@Example.com  ';
+		expect(gravatarUrl(email)).toBe(
+			`https://www.gravatar.com/avatar/${referenceHash(email)}?s=200&d=404`,
+		);
+	});
+
+	it('matches the MD5 reference implementation across a range of emails', () => {
+		for (let i = 0; i < 25; i++) {
+			const email = faker.internet.email();
+			expect(gravatarUrl(email)).toContain(referenceHash(email));
+		}
+	});
+
+	it('hashes a message long enough to span multiple 64-byte MD5 chunks', () => {
+		const email = `${faker.string.alpha(120)}@example.com`;
+		expect(gravatarUrl(email)).toContain(referenceHash(email));
+	});
+
+	it('is case- and whitespace-insensitive, like Gravatar requires', () => {
+		expect(gravatarUrl('Foo@Bar.com')).toBe(gravatarUrl('  foo@bar.com  '));
+	});
+
+	it('defaults to a 200px image and a 404 default (so callers can fall back to initials)', () => {
+		const url = gravatarUrl('foo@bar.com');
+		expect(url).toContain('s=200');
+		expect(url).toContain('d=404');
+	});
+
+	it('accepts a custom size and default image', () => {
+		const url = gravatarUrl('foo@bar.com', { size: 64, default: 'identicon' });
+		expect(url).toContain('s=64');
+		expect(url).toContain('d=identicon');
+	});
+
+	it('is deterministic — the same email always builds the same URL', () => {
+		const email = faker.internet.email();
+		expect(gravatarUrl(email)).toBe(gravatarUrl(email));
+	});
+});

--- a/packages/core/src/gravatar.ts
+++ b/packages/core/src/gravatar.ts
@@ -1,0 +1,161 @@
+/**
+ * Gravatar shows a profile photo for an email address without any account setup
+ * on our side — it's keyed by the MD5 hash of the (trimmed, lowercased) address,
+ * per https://docs.gravatar.com/api/avatars/images/. MD5 isn't used for anything
+ * security-sensitive here, just as the public lookup key the Gravatar API
+ * expects, so a small dependency-free implementation keeps this working
+ * identically across Node, the browser, Cloudflare Workers, and the Expo app
+ * without relying on a platform crypto API that isn't uniformly available across
+ * all of them.
+ */
+
+const SHIFTS = [
+	7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14,
+	20, 5, 9, 14, 20, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 6, 10, 15, 21, 6,
+	10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+];
+
+// `floor(abs(sin(i + 1)) * 2**32)` for i in 0..63, per RFC 1321.
+const SINE_TABLE = [
+	0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee, 0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+	0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be, 0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+	0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa, 0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+	0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed, 0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+	0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c, 0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+	0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05, 0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+	0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039, 0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+	0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1, 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
+];
+
+function rotateLeft(value: number, bits: number): number {
+	return (value << bits) | (value >>> (32 - bits));
+}
+
+/**
+ * Index into one of the fixed-size lookup tables above. The indices used below
+ * are always in range (derived from a fixed round count and chunk size) — this
+ * just satisfies `noUncheckedIndexedAccess` in one place instead of scattering
+ * non-null assertions through the round function.
+ */
+function at(values: readonly number[], index: number): number {
+	// biome-ignore lint/style/noNonNullAssertion: index is always in range, see above.
+	return values[index]!;
+}
+
+/** Pad a message per the MD5 spec: a `1` bit, zero bits to 448 mod 512, then its 64-bit length. */
+function pad(message: Uint8Array): Uint8Array {
+	const bitLength = message.length * 8;
+	let paddedLength = message.length + 1;
+	while (paddedLength % 64 !== 56) {
+		paddedLength += 1;
+	}
+	const padded = new Uint8Array(paddedLength + 8);
+	padded.set(message);
+	padded[message.length] = 0x80;
+	const view = new DataView(padded.buffer);
+	// Realistic inputs here (email addresses) are far short of 2**32 bits, so the
+	// high 32 bits of the 64-bit little-endian length are always zero.
+	view.setUint32(paddedLength, bitLength >>> 0, true);
+	view.setUint32(paddedLength + 4, 0, true);
+	return padded;
+}
+
+function wordToHexLE(word: number): string {
+	let hex = '';
+	for (let i = 0; i < 4; i++) {
+		hex += ((word >>> (i * 8)) & 0xff).toString(16).padStart(2, '0');
+	}
+	return hex;
+}
+
+/** The MD5 digest of `message` as a lowercase 32-character hex string (RFC 1321). */
+function md5Hex(message: string): string {
+	const padded = pad(new TextEncoder().encode(message));
+	const view = new DataView(padded.buffer);
+
+	let a0 = 0x67452301;
+	let b0 = 0xefcdab89;
+	let c0 = 0x98badcfe;
+	let d0 = 0x10325476;
+
+	for (let chunk = 0; chunk < padded.length; chunk += 64) {
+		const words: number[] = [];
+		for (let i = 0; i < 16; i++) {
+			words.push(view.getUint32(chunk + i * 4, true));
+		}
+
+		let a = a0;
+		let b = b0;
+		let c = c0;
+		let d = d0;
+
+		for (let i = 0; i < 64; i++) {
+			let f: number;
+			let g: number;
+			if (i < 16) {
+				f = (b & c) | (~b & d);
+				g = i;
+			} else if (i < 32) {
+				f = (d & b) | (~d & c);
+				g = (5 * i + 1) % 16;
+			} else if (i < 48) {
+				f = b ^ c ^ d;
+				g = (3 * i + 5) % 16;
+			} else {
+				f = c ^ (b | ~d);
+				g = (7 * i) % 16;
+			}
+			f = (f + a + at(SINE_TABLE, i) + at(words, g)) | 0;
+			a = d;
+			d = c;
+			c = b;
+			b = (b + rotateLeft(f, at(SHIFTS, i))) | 0;
+		}
+
+		a0 = (a0 + a) | 0;
+		b0 = (b0 + b) | 0;
+		c0 = (c0 + c) | 0;
+		d0 = (d0 + d) | 0;
+	}
+
+	return [a0, b0, c0, d0].map(wordToHexLE).join('');
+}
+
+/** The image Gravatar serves when the email has no avatar set. */
+export type GravatarDefault =
+	| '404'
+	| 'mp'
+	| 'identicon'
+	| 'monsterid'
+	| 'wavatar'
+	| 'retro'
+	| 'robohash'
+	| 'blank';
+
+export interface GravatarOptions {
+	/** Image size in pixels (Gravatar serves a square image). Defaults to `200`. */
+	size?: number;
+	/**
+	 * What Gravatar serves when the email has no avatar. Defaults to `'404'` —
+	 * an actual HTTP 404 — so callers can detect "no Gravatar" (e.g. an `<Image>`
+	 * `onError`) and fall back to initials, instead of always getting Gravatar's
+	 * generic placeholder art.
+	 */
+	default?: GravatarDefault;
+}
+
+/**
+ * Build a Gravatar image URL for an email address — no API call or account
+ * setup required, since Gravatar derives the image purely from the email's MD5
+ * hash. See https://docs.gravatar.com/api/avatars/images/.
+ *
+ * @example gravatarUrl('jane@example.com') // 'https://www.gravatar.com/avatar/...?s=200&d=404'
+ */
+export function gravatarUrl(email: string, options: GravatarOptions = {}): string {
+	const hash = md5Hex(email.trim().toLowerCase());
+	const params = new URLSearchParams({
+		s: String(options.size ?? 200),
+		d: options.default ?? '404',
+	});
+	return `https://www.gravatar.com/avatar/${hash}?${params.toString()}`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './gravatar';
 export * from './pagination';
 export * from './regex';
 export * from './schemas';

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -35,6 +35,7 @@ import {
 	updateItemSchema,
 	updateJobSchema,
 	updateMemberRoleSchema,
+	updateProfileSchema,
 	verifyCodeSchema,
 } from './schemas';
 
@@ -201,6 +202,32 @@ describe('updateAccountSchema', () => {
 
 	it('rejects a malformed website', () => {
 		expect(() => updateAccountSchema.parse({ website: 'not a url' })).toThrow();
+	});
+});
+
+describe('updateProfileSchema', () => {
+	it('accepts a valid image URL', () => {
+		expect(updateProfileSchema.parse({ avatarUrl: 'https://example.com/photo.jpg' })).toEqual({
+			avatarUrl: 'https://example.com/photo.jpg',
+		});
+	});
+
+	it('accepts an empty string (reverts to Gravatar)', () => {
+		expect(updateProfileSchema.parse({ avatarUrl: '' })).toEqual({ avatarUrl: '' });
+	});
+
+	it('trims the URL', () => {
+		expect(
+			updateProfileSchema.parse({ avatarUrl: '  https://example.com/me.png  ' }).avatarUrl,
+		).toBe('https://example.com/me.png');
+	});
+
+	it('rejects a malformed URL', () => {
+		expect(() => updateProfileSchema.parse({ avatarUrl: 'not a url' })).toThrow();
+	});
+
+	it('rejects a missing avatarUrl field', () => {
+		expect(() => updateProfileSchema.parse({})).toThrow();
 	});
 });
 

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -88,6 +88,15 @@ export const websiteSchema = z
 		error: 'Enter a valid website URL, like https://example.com.',
 	});
 
+/** A custom profile-image URL, or an empty string to fall back to the user's Gravatar. */
+export const avatarUrlSchema = z
+	.string()
+	.trim()
+	.max(2048, { error: 'That image URL is too long.' })
+	.refine((value) => value === '' || z.url().safeParse(value).success, {
+		error: 'Enter a valid image URL, like https://example.com/photo.jpg.',
+	});
+
 /** The "standard business information" collected when an account is created. */
 export const accountBusinessSchema = z.object({
 	businessName: businessNameSchema,
@@ -158,6 +167,16 @@ export const updateAccountSchema = z
 		error: 'Provide at least one field to update.',
 	});
 export type UpdateAccountInput = z.infer<typeof updateAccountSchema>;
+
+/**
+ * Update the signed-in user's own profile image. Any member may edit their own
+ * profile (unlike account settings, this isn't owner-gated). An empty string
+ * clears a custom override and reverts to the Gravatar derived from the email.
+ */
+export const updateProfileSchema = z.object({
+	avatarUrl: avatarUrlSchema,
+});
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;
 
 export const itemStatusSchema = z.enum(['active', 'archived'], {
 	error: 'Status must be either active or archived.',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -23,6 +23,8 @@ export interface User {
 	id: UserId;
 	email: string;
 	name: string;
+	/** Profile image URL — a custom override if one is set, else the Gravatar derived from `email`. */
+	avatarUrl: string;
 	createdAt: IsoDateString;
 	updatedAt: IsoDateString;
 }

--- a/packages/docs/site/openapi.json
+++ b/packages/docs/site/openapi.json
@@ -360,6 +360,78 @@
             }
           }
         }
+      },
+      "patch": {
+        "summary": "Update the signed-in user's own profile image",
+        "tags": [
+          "auth"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "avatarUrl": {
+                    "type": "string",
+                    "maxLength": 2048
+                  }
+                },
+                "required": [
+                  "avatarUrl"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/auth/accept-invite": {
@@ -2367,6 +2439,1602 @@
           }
         }
       }
+    },
+    "/v1/jobs/": {
+      "get": {
+        "summary": "List your account's scheduled jobs",
+        "tags": [
+          "jobs"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            },
+            "in": "query",
+            "name": "from",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            },
+            "in": "query",
+            "name": "to",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 128
+            },
+            "in": "query",
+            "name": "assignedUserId",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "scheduled",
+                "confirmed",
+                "in_progress",
+                "completed",
+                "canceled"
+              ]
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 128
+            },
+            "in": "query",
+            "name": "customerId",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Schedule a job",
+        "tags": [
+          "jobs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "customerId": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "assignedUserId": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "startAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                  },
+                  "durationMinutes": {
+                    "default": 60,
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1440
+                  },
+                  "status": {
+                    "default": "scheduled",
+                    "type": "string",
+                    "enum": [
+                      "scheduled",
+                      "confirmed",
+                      "in_progress",
+                      "completed",
+                      "canceled"
+                    ]
+                  },
+                  "address": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 300
+                  },
+                  "notes": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "estimatedValue": {
+                    "default": 0,
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "title",
+                  "startAt"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/jobs/conflicts": {
+      "get": {
+        "summary": "List jobs that would overlap a proposed booking",
+        "tags": [
+          "jobs"
+        ],
+        "description": "Double-booking pre-check: returns the assignee’s non-canceled jobs overlapping the proposed window. Empty when the slot is free.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128
+            },
+            "in": "query",
+            "name": "assignedUserId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+            },
+            "in": "query",
+            "name": "startAt",
+            "required": true
+          },
+          {
+            "schema": {
+              "default": 60,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1440
+            },
+            "in": "query",
+            "name": "durationMinutes",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 128
+            },
+            "in": "query",
+            "name": "excludeJobId",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobConflicts"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/jobs/{id}": {
+      "get": {
+        "summary": "Fetch one of your jobs",
+        "tags": [
+          "jobs"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update or reschedule one of your jobs",
+        "tags": [
+          "jobs"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 160
+                  },
+                  "customerId": {
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "assignedUserId": {
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "startAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                  },
+                  "durationMinutes": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1440
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "scheduled",
+                      "confirmed",
+                      "in_progress",
+                      "completed",
+                      "canceled"
+                    ]
+                  },
+                  "address": {
+                    "type": "string",
+                    "maxLength": 300
+                  },
+                  "notes": {
+                    "type": "string",
+                    "maxLength": 2000
+                  },
+                  "estimatedValue": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete one of your jobs",
+        "tags": [
+          "jobs"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/notifications/": {
+      "get": {
+        "summary": "List your notifications",
+        "tags": [
+          "notifications"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "in": "query",
+            "name": "unread",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/notifications/unread-count": {
+      "get": {
+        "summary": "Count your unread notifications (for the bell badge)",
+        "tags": [
+          "notifications"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationUnreadCount"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/notifications/read-all": {
+      "post": {
+        "summary": "Mark all your notifications read",
+        "tags": [
+          "notifications"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationMarkAllRead"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/notifications/{id}/read": {
+      "post": {
+        "summary": "Mark one notification read",
+        "tags": [
+          "notifications"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Notification"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/notifications/{id}": {
+      "delete": {
+        "summary": "Dismiss (delete) one of your notifications",
+        "tags": [
+          "notifications"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/conversations/": {
+      "get": {
+        "summary": "List your account's conversations (the inbox)",
+        "tags": [
+          "conversations"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "rivus_handling",
+                "needs_attention",
+                "resolved"
+              ]
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Open a conversation",
+        "tags": [
+          "conversations"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contactName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "channel": {
+                    "type": "string",
+                    "enum": [
+                      "whatsapp",
+                      "phone",
+                      "email",
+                      "sms"
+                    ]
+                  },
+                  "customerId": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "contactPhone": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 40
+                  },
+                  "status": {
+                    "default": "rivus_handling",
+                    "type": "string",
+                    "enum": [
+                      "rivus_handling",
+                      "needs_attention",
+                      "resolved"
+                    ]
+                  },
+                  "tags": {
+                    "default": [],
+                    "maxItems": 12,
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 40
+                    }
+                  },
+                  "lastInvoice": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 120
+                  }
+                },
+                "required": [
+                  "contactName",
+                  "channel"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/conversations/needs-attention-count": {
+      "get": {
+        "summary": "Count conversations that need a human (for the Inbox badge)",
+        "tags": [
+          "conversations"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationNeedsAttentionCount"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/conversations/{id}": {
+      "get": {
+        "summary": "Fetch one conversation with its full transcript",
+        "tags": [
+          "conversations"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update a conversation (tags, status, contact, …)",
+        "tags": [
+          "conversations"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contactName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "channel": {
+                    "type": "string",
+                    "enum": [
+                      "whatsapp",
+                      "phone",
+                      "email",
+                      "sms"
+                    ]
+                  },
+                  "customerId": {
+                    "type": "string",
+                    "maxLength": 128
+                  },
+                  "contactPhone": {
+                    "type": "string",
+                    "maxLength": 40
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "rivus_handling",
+                      "needs_attention",
+                      "resolved"
+                    ]
+                  },
+                  "tags": {
+                    "maxItems": 12,
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 40
+                    }
+                  },
+                  "lastInvoice": {
+                    "type": "string",
+                    "maxLength": 120
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a conversation",
+        "tags": [
+          "conversations"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/conversations/{id}/messages": {
+      "post": {
+        "summary": "Send a reply as a team member",
+        "tags": [
+          "conversations"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 4000
+                  }
+                },
+                "required": [
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationDetail"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/conversations/{id}/reply": {
+      "post": {
+        "summary": "Let Rivus draft a reply from the knowledge base",
+        "tags": [
+          "conversations"
+        ],
+        "description": "Rivus answers the latest customer message from the account’s published FAQs. An everyday answer is sent immediately; a money/billing question (or one the knowledge base can’t answer) is held as a draft and the thread is flagged for review.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/conversations/{id}/approve": {
+      "post": {
+        "summary": "Approve and send Rivus's held draft (optionally edited)",
+        "tags": [
+          "conversations"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 4000
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationDetail"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/search/": {
+      "get": {
+        "summary": "Search your account's customers and jobs",
+        "tags": [
+          "search"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 200
+            },
+            "in": "query",
+            "name": "q",
+            "required": true
+          },
+          {
+            "schema": {
+              "default": 8,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResults"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -2387,6 +4055,10 @@
     {
       "name": "items",
       "description": "Owner-scoped item resources"
+    },
+    {
+      "name": "notifications",
+      "description": "Per-user notifications (the bell)"
     }
   ]
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage (on the new `@rivus/core` code; overall package thresholds are met).

**What kind of change does this PR introduce?**

Feature: Gravatar support for user profiles, plus a button to edit/update the profile image.

## Summary

- Adds a dependency-free, cross-runtime Gravatar URL helper (`gravatarUrl`) to `@rivus/core`, backed by a small pure-JS MD5 implementation (cross-validated against Node's `crypto` in tests) — works identically in Node, Cloudflare Workers, the browser, and the Expo app without relying on a platform crypto API.
- `User.avatarUrl` is now always a usable image URL: a custom override if the user set one, otherwise their Gravatar (derived from their email). Threaded through core types/schemas, the API (`UserRepository.update`, both in-memory and Mongo implementations, presenters, OpenAPI), and the app's API client.
- New `PATCH /v1/auth/me` route lets any signed-in user update their own profile image (not owner-gated, unlike account settings). An empty string clears a custom override back to the Gravatar default.
- The shared `Avatar` component now accepts an optional `imageUrl`, rendering the image with a graceful fallback to initials if it's unset or fails to load — documented in `DESIGN_SYSTEM.md`. Wired up in the sidebar, the mobile "more" sheet, and the team roster.
- New "Your profile" card in Settings (visible to every role) shows the user's avatar and an "Edit image" button to set a custom image URL or revert to Gravatar.

## Test plan

- [x] `pnpm lint && pnpm type-check && pnpm test` all pass across every package.
- [x] `packages/core`'s new `gravatar.ts` has 100% coverage; its tests cross-validate the hand-rolled MD5 against Node's `crypto` MD5 across randomized emails and a multi-chunk input.
- [x] New API tests cover setting/clearing a custom avatar via `PATCH /v1/auth/me`, persistence, validation, auth, and non-owner access; roster tests confirm Gravatar defaults and custom avatars show up for teammates.
- [x] Reviewed with an independent multi-angle pass (correctness, cross-file impact, language pitfalls, reuse/simplification/efficiency, architecture, conventions) and fixed the real issues it surfaced (a Mongo `update()` divergence from the in-memory repository, a stale avatar-load-failure flag not resetting when the image URL changes, and an edit-form pre-fill that could otherwise silently clear a saved custom avatar).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VdZCRwG7NXrkAHjc6eC3dE)_