### PR TITLE
feat(app): set browser tab titles on every web view

### DIFF
--- a/packages/app/app/+html.tsx
+++ b/packages/app/app/+html.tsx
@@ -22,6 +22,10 @@ export default function Root({ children }: PropsWithChildren) {
 					content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
 				/>
 
+				{/* Default tab title — overridden per screen by useDocumentTitle once it
+				    mounts, but this covers the initial paint and any screen that doesn't. */}
+				<title>Rivus</title>
+
 				{/* Browser tab + address-bar theming. */}
 				<meta name="theme-color" content="#6e1ec8" />
 				<meta name="application-name" content="Rivus" />

--- a/packages/app/app/customers.tsx
+++ b/packages/app/app/customers.tsx
@@ -24,6 +24,7 @@ import {
 	Txt,
 } from '@/src/components/ui';
 import { colors, font, radii, SIDEBAR_BREAKPOINT, SIDEBAR_WIDTH } from '@/src/theme/tokens';
+import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 
 const COLS = {
 	customer: 2.2,
@@ -65,6 +66,7 @@ function centsToInput(cents: number): string {
 }
 
 export default function CustomersScreen() {
+	useDocumentTitle('Customers');
 	const { session, client } = useAuth();
 	const { width } = useWindowDimensions();
 	const sidebar = width >= SIDEBAR_BREAKPOINT ? SIDEBAR_WIDTH : 0;

--- a/packages/app/app/inbox.tsx
+++ b/packages/app/app/inbox.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/src/components/ui';
 import { useInbox } from '@/src/inbox/InboxContext';
 import { colors, font, radii } from '@/src/theme/tokens';
+import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 
 type ConversationChannel = Conversation['channel'];
 
@@ -102,6 +103,7 @@ function byActivity(a: Conversation, b: Conversation): number {
 }
 
 export default function InboxScreen() {
+	useDocumentTitle('Inbox');
 	const { session, client } = useAuth();
 	const inbox = useInbox();
 	const { width } = useWindowDimensions();

--- a/packages/app/app/index.tsx
+++ b/packages/app/app/index.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/src/components/ui';
 import { dayRange, formatClock, formatDayLabel } from '@/src/schedule/datetime';
 import { colors, font, radii, SIDEBAR_BREAKPOINT } from '@/src/theme/tokens';
+import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 
 // Categorical dot colors per assignee (cycled by member order).
 const TECH_DOTS = ['#1ebefa', '#6e1ec8', '#1fb573', '#f0a020', '#f0584b', '#3b6ef0'] as const;
@@ -51,6 +52,7 @@ const bars = [
 ];
 
 export default function HomeScreen() {
+	useDocumentTitle('Home');
 	const router = useRouter();
 	const { session, client } = useAuth();
 	// Below the sidebar breakpoint the dashboard renders on a phone-width column,

--- a/packages/app/app/knowledge.tsx
+++ b/packages/app/app/knowledge.tsx
@@ -17,6 +17,7 @@ import {
 	Txt,
 } from '@/src/components/ui';
 import { colors, font, radii } from '@/src/theme/tokens';
+import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 
 const STATUS_OPTIONS: { label: string; value: FaqStatus }[] = [
 	{ label: 'Published', value: 'published' },
@@ -24,6 +25,7 @@ const STATUS_OPTIONS: { label: string; value: FaqStatus }[] = [
 ];
 
 export default function KnowledgeScreen() {
+	useDocumentTitle('Knowledge');
 	const { session, client } = useAuth();
 
 	const [list, setList] = useState<Faq[]>([]);

--- a/packages/app/app/marketing.tsx
+++ b/packages/app/app/marketing.tsx
@@ -2,6 +2,7 @@ import { Pressable, ScrollView, StyleSheet, useWindowDimensions, View } from 're
 import { BrandGradient } from '@/src/components/Gradient';
 import { Card, Icon, RivusStatusChip, Txt } from '@/src/components/ui';
 import { colors, font, radii, SIDEBAR_BREAKPOINT } from '@/src/theme/tokens';
+import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 
 // Height of the mini bar charts. Bars use absolute px (not %) so they render
 // reliably on native, matching the pattern on the Home screen.
@@ -48,6 +49,7 @@ const ads: Ad[] = [
 ];
 
 export default function MarketingScreen() {
+	useDocumentTitle('Marketing');
 	// Below the sidebar breakpoint the cards stack full-width so their minWidths
 	// can't force the page past a phone viewport.
 	const { width } = useWindowDimensions();

--- a/packages/app/app/notifications.tsx
+++ b/packages/app/app/notifications.tsx
@@ -4,8 +4,10 @@ import { useAuth } from '@/src/auth/AuthContext';
 import { Card, Txt } from '@/src/components/ui';
 import { NotificationsView } from '@/src/notifications/NotificationsView';
 import { colors, font } from '@/src/theme/tokens';
+import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 
 export default function NotificationsScreen() {
+	useDocumentTitle('Notifications');
 	const router = useRouter();
 	const { session } = useAuth();
 

--- a/packages/app/app/profile.tsx
+++ b/packages/app/app/profile.tsx
@@ -14,6 +14,7 @@ import {
 	Txt,
 } from '@/src/components/ui';
 import { colors, font } from '@/src/theme/tokens';
+import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 
 function messageFor(error: unknown, fallback: string): string {
 	if (error instanceof ApiError || error instanceof Error) {
@@ -32,6 +33,7 @@ function messageFor(error: unknown, fallback: string): string {
  * pending, a second card collects the code (with a resend).
  */
 export default function ProfileScreen() {
+	useDocumentTitle('Profile');
 	const { session, updateProfile, verifyEmailChange } = useAuth();
 	const user = session?.user;
 

--- a/packages/app/app/schedule.tsx
+++ b/packages/app/app/schedule.tsx
@@ -54,6 +54,7 @@ import {
 } from '@/src/schedule/datetime';
 import { defaultScheduleView, type ScheduleView } from '@/src/schedule/view';
 import { colors, font, radii, SIDEBAR_BREAKPOINT, SIDEBAR_WIDTH } from '@/src/theme/tokens';
+import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 
 const GUTTER = 58;
 const MIN_DAY_WIDTH = 132;
@@ -116,6 +117,7 @@ function centsToInput(cents: number): string {
 }
 
 export default function ScheduleScreen() {
+	useDocumentTitle('Schedule');
 	const { session, client } = useAuth();
 	const { width, height } = useWindowDimensions();
 	const sidebar = width >= SIDEBAR_BREAKPOINT ? SIDEBAR_WIDTH : 0;

--- a/packages/app/app/settings.tsx
+++ b/packages/app/app/settings.tsx
@@ -23,6 +23,7 @@ import {
 	Txt,
 } from '@/src/components/ui';
 import { colors, font } from '@/src/theme/tokens';
+import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 
 const PLAN_LABELS: Record<Billing['plan'], string> = {
 	free: 'Free',
@@ -101,6 +102,7 @@ function DevSeedCard() {
 }
 
 export default function SettingsScreen() {
+	useDocumentTitle('Settings');
 	const { session, client, updateAccount, cancelAccount } = useAuth();
 	const account = session?.account;
 	const isOwner = session?.role === 'owner';

--- a/packages/app/app/team.tsx
+++ b/packages/app/app/team.tsx
@@ -20,6 +20,7 @@ import {
 	Txt,
 } from '@/src/components/ui';
 import { colors, font } from '@/src/theme/tokens';
+import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 
 function rolePillColors(role: Role): { color: string; background: string } {
 	if (role === 'owner') {
@@ -32,6 +33,7 @@ function rolePillColors(role: Role): { color: string; background: string } {
 }
 
 export default function TeamScreen() {
+	useDocumentTitle('Team');
 	const { session, client } = useAuth();
 	const canInvite = session?.role === 'owner' || session?.role === 'manager';
 	// Owners may grant any role; managers may only add Members.

--- a/packages/app/src/auth/AuthScreen.tsx
+++ b/packages/app/src/auth/AuthScreen.tsx
@@ -7,26 +7,30 @@ import { deviceTimezone, listTimezones } from '@/src/api/timezones';
 import { AddressAutocomplete } from '@/src/components/AddressAutocomplete';
 import { GradientButton, RivusBadge, Select, TextField, Txt } from '@/src/components/ui';
 import { colors, font, radii } from '@/src/theme/tokens';
+import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 import { useAuth } from './AuthContext';
 
 type Mode = 'signup' | 'signin' | 'invite';
 type Step = 'form' | 'code';
 
-const COPY: Record<Mode, { title: string; subtitle: string; submit: string }> = {
+const COPY: Record<Mode, { title: string; subtitle: string; submit: string; tabTitle: string }> = {
 	signup: {
 		title: 'Create your business account',
 		subtitle: 'Set up Rivus for your business in under a minute.',
 		submit: 'Create account',
+		tabTitle: 'Sign up',
 	},
 	signin: {
 		title: 'Welcome back',
 		subtitle: 'Enter your email and we’ll send you a sign-in code.',
 		submit: 'Send code',
+		tabTitle: 'Sign in',
 	},
 	invite: {
 		title: 'Join your team',
 		subtitle: 'Use the invite code you were sent to join your team.',
 		submit: 'Join the team',
+		tabTitle: 'Join your team',
 	},
 };
 
@@ -148,6 +152,7 @@ export function AuthScreen({
 	}
 
 	const copy = COPY[mode];
+	useDocumentTitle(copy.tabTitle);
 
 	return (
 		<View style={styles.screen}>

--- a/packages/app/src/theme/useDocumentTitle.ts
+++ b/packages/app/src/theme/useDocumentTitle.ts
@@ -13,6 +13,10 @@ export function useDocumentTitle(title: string): void {
 		if (Platform.OS !== 'web' || typeof document === 'undefined') {
 			return;
 		}
+		const previousTitle = document.title;
 		document.title = `${BRAND} · ${title}`;
+		return () => {
+			document.title = previousTitle;
+		};
 	}, [title]);
 }

--- a/packages/app/src/theme/useDocumentTitle.ts
+++ b/packages/app/src/theme/useDocumentTitle.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+
+const BRAND = 'Rivus';
+
+/**
+ * Sets the browser tab title to "Rivus · <title>" on web, so the tab reflects
+ * the active screen instead of the bare URL. No-op on native and during static
+ * rendering, where there's no `document`.
+ */
+export function useDocumentTitle(title: string): void {
+	useEffect(() => {
+		if (Platform.OS !== 'web' || typeof document === 'undefined') {
+			return;
+		}
+		document.title = `${BRAND} · ${title}`;
+	}, [title]);
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?**

Feature. Every web view in `@rivus/app` was showing the bare URL in the browser tab instead of a page title.

**Why**

The root layout (`app/_layout.tsx`) renders routes through `Slot`, not `Stack`, so Expo Router's built-in title wiring (which hooks into `@react-navigation`'s `Stack.Screen options.title`) never applied. On top of that, `app/+html.tsx` — the root HTML document for the web build (`web.output: "static"`) — shipped with no `<title>` element at all, so the tab had nothing to fall back to.

**What changed**

- Added `src/theme/useDocumentTitle.ts`, a small hook that sets `document.title` to `Rivus · <Screen>` on web and no-ops on native / during static rendering (same `Platform.OS` / `typeof document` guard already used by `src/theme/focusRing.ts`).
- Called it from every dashboard screen (Home, Inbox, Schedule, Customers, Marketing, Knowledge, Team, Profile, Settings, Notifications).
- Called it once from the shared `AuthScreen` component (keyed off its internal `mode`), which covers `/login`, `/signup`, `/accept-invite`, and the signed-out fallback screen, including in-place mode switches (e.g. "Have an invite code?") that don't change the URL.
- Added a static `<title>Rivus</title>` to `+html.tsx` as the fallback for the initial paint, before any screen has mounted.
- `billing.tsx` is left alone — it's a redirect-only stub with no view of its own.

**Testing**

- `pnpm lint && pnpm type-check && pnpm test` all pass repo-wide.
- No new test file: this package's coverage gate is scoped to `src/api/**` and `src/agent/**` (see `vitest.config.ts`), and the existing analogous web-only DOM utility (`focusRing.ts`) is likewise untested under this package's Node test environment (no DOM available without `document`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ht2ZxSm1HrTbVPUSLfnsn7)_