### PR TITLE
fix(app): stop the customers list from running off the bottom edge

### DIFF
--- a/packages/app/app/customers.tsx
+++ b/packages/app/app/customers.tsx
@@ -270,7 +270,10 @@ export default function CustomersScreen() {
 
 	return (
 		<View style={styles.row}>
-			<ScrollView style={{ flex: 1 }} contentContainerStyle={styles.leftPad}>
+			<View style={styles.leftPane}>
+				{/* The header stays fixed above the list so the table scrolls within the
+				    viewport instead of the whole page running off the bottom edge —
+				    matching the schedule and inbox screens. */}
 				<View style={styles.head}>
 					<View>
 						<Txt style={styles.title}>Customers</Txt>
@@ -279,158 +282,160 @@ export default function CustomersScreen() {
 					<GradientButton label="Add customer" icon="plus" onPress={openCreate} />
 				</View>
 
-				{formOpen ? (
-					<Card style={styles.form}>
-						<View style={styles.formHead}>
-							<Txt style={styles.formTitle}>{editing ? 'Edit customer' : 'New customer'}</Txt>
-							<Pressable
-								onPress={closeForm}
-								accessibilityRole="button"
-								accessibilityLabel="Close"
-								hitSlop={CLOSE_HIT_SLOP}
-							>
-								<Icon name="x" size={18} color={colors.textMuted} />
-							</Pressable>
-						</View>
-						<TextField
-							label="Name"
-							value={name}
-							onChangeText={setName}
-							placeholder="Grace Kim"
-							autoCapitalize="words"
-						/>
-						<View style={styles.formRow}>
-							<View style={styles.formCol}>
-								<TextField
-									label="Email"
-									value={email}
-									onChangeText={setEmail}
-									placeholder="grace@example.com"
-									autoCapitalize="none"
-									keyboardType="email-address"
-								/>
+				<ScrollView style={styles.body} contentContainerStyle={styles.bodyPad}>
+					{formOpen ? (
+						<Card style={styles.form}>
+							<View style={styles.formHead}>
+								<Txt style={styles.formTitle}>{editing ? 'Edit customer' : 'New customer'}</Txt>
+								<Pressable
+									onPress={closeForm}
+									accessibilityRole="button"
+									accessibilityLabel="Close"
+									hitSlop={CLOSE_HIT_SLOP}
+								>
+									<Icon name="x" size={18} color={colors.textMuted} />
+								</Pressable>
 							</View>
-							<View style={styles.formCol}>
-								<TextField
-									label="Phone"
-									value={phone}
-									onChangeText={setPhone}
-									placeholder="(206) 555-0155"
-									keyboardType="phone-pad"
-								/>
-							</View>
-						</View>
-						<AddressAutocomplete
-							label="Address"
-							value={address}
-							onChangeText={setAddress}
-							placeholder="1 Main St, Seattle, WA"
-							apiKey={mapsApiKey}
-						/>
-						<View style={styles.formRow}>
-							<View style={styles.formCol}>
-								<TextField
-									label="Lifetime value ($)"
-									value={lifetime}
-									onChangeText={setLifetime}
-									placeholder="0.00"
-									keyboardType="decimal-pad"
-								/>
-							</View>
-							<View style={styles.formCol}>
-								<TextField
-									label="Balance ($)"
-									value={balance}
-									onChangeText={setBalance}
-									placeholder="0.00"
-									keyboardType="decimal-pad"
-								/>
-							</View>
-						</View>
-						<TextField
-							label="Notes"
-							value={notes}
-							onChangeText={setNotes}
-							placeholder="Repeat client · membership"
-							multiline
-							style={styles.notesInput}
-						/>
-
-						{formError ? <Txt style={styles.errorTxt}>{formError}</Txt> : null}
-
-						<View style={styles.btnRow}>
-							<GradientButton
-								label={saving ? 'Saving…' : editing ? 'Save changes' : 'Add customer'}
-								icon="check"
-								onPress={onSave}
-								style={styles.btnGrow}
+							<TextField
+								label="Name"
+								value={name}
+								onChangeText={setName}
+								placeholder="Grace Kim"
+								autoCapitalize="words"
 							/>
-							<OutlineButton label="Cancel" onPress={closeForm} style={styles.btnGrow} />
-						</View>
-						{editing ? (
-							<OutlineButton
-								label={deleting ? 'Deleting…' : 'Delete customer'}
-								onPress={onDelete}
-								style={styles.deleteBtn}
-							/>
-						) : null}
-					</Card>
-				) : null}
-
-				{loading ? (
-					<ActivityIndicator color={colors.brandPurple} style={styles.loading} />
-				) : error ? (
-					<Txt style={styles.errorTxt}>{error}</Txt>
-				) : list.length === 0 ? (
-					<Txt style={styles.empty}>
-						No customers yet. Add your first contact to start tracking jobs and balances.
-					</Txt>
-				) : (
-					<ScrollView horizontal showsHorizontalScrollIndicator={false}>
-						<View style={[styles.table, { width: tableWidth }]}>
-							<View style={styles.tableHead}>
-								<Txt style={[styles.th, { flex: COLS.customer }]}>Customer</Txt>
-								<Txt style={[styles.th, { flex: COLS.address }]}>Address</Txt>
-								<Txt style={[styles.th, styles.right, { flex: COLS.lifetime }]}>Lifetime</Txt>
-								<Txt style={[styles.th, styles.right, { flex: COLS.balance }]}>Balance</Txt>
+							<View style={styles.formRow}>
+								<View style={styles.formCol}>
+									<TextField
+										label="Email"
+										value={email}
+										onChangeText={setEmail}
+										placeholder="grace@example.com"
+										autoCapitalize="none"
+										keyboardType="email-address"
+									/>
+								</View>
+								<View style={styles.formCol}>
+									<TextField
+										label="Phone"
+										value={phone}
+										onChangeText={setPhone}
+										placeholder="(206) 555-0155"
+										keyboardType="phone-pad"
+									/>
+								</View>
 							</View>
-							{list.map((customer, index) => {
-								const isSelected = customer.id === selected?.id;
-								return (
-									<Pressable
-										key={customer.id}
-										onPress={() => {
-											setSelectedId(customer.id);
-											setPanelOpen(true);
-										}}
-										style={[
-											styles.tr,
-											index === list.length - 1 && styles.trLast,
-											isSelected && styles.trSelected,
-										]}
-									>
-										<View style={[styles.cell, styles.customerCell, { flex: COLS.customer }]}>
-											<Avatar initials={initialsOf(customer.name)} size={36} />
-											<Txt style={styles.customerName} numberOfLines={1}>
-												{customer.name}
+							<AddressAutocomplete
+								label="Address"
+								value={address}
+								onChangeText={setAddress}
+								placeholder="1 Main St, Seattle, WA"
+								apiKey={mapsApiKey}
+							/>
+							<View style={styles.formRow}>
+								<View style={styles.formCol}>
+									<TextField
+										label="Lifetime value ($)"
+										value={lifetime}
+										onChangeText={setLifetime}
+										placeholder="0.00"
+										keyboardType="decimal-pad"
+									/>
+								</View>
+								<View style={styles.formCol}>
+									<TextField
+										label="Balance ($)"
+										value={balance}
+										onChangeText={setBalance}
+										placeholder="0.00"
+										keyboardType="decimal-pad"
+									/>
+								</View>
+							</View>
+							<TextField
+								label="Notes"
+								value={notes}
+								onChangeText={setNotes}
+								placeholder="Repeat client · membership"
+								multiline
+								style={styles.notesInput}
+							/>
+
+							{formError ? <Txt style={styles.errorTxt}>{formError}</Txt> : null}
+
+							<View style={styles.btnRow}>
+								<GradientButton
+									label={saving ? 'Saving…' : editing ? 'Save changes' : 'Add customer'}
+									icon="check"
+									onPress={onSave}
+									style={styles.btnGrow}
+								/>
+								<OutlineButton label="Cancel" onPress={closeForm} style={styles.btnGrow} />
+							</View>
+							{editing ? (
+								<OutlineButton
+									label={deleting ? 'Deleting…' : 'Delete customer'}
+									onPress={onDelete}
+									style={styles.deleteBtn}
+								/>
+							) : null}
+						</Card>
+					) : null}
+
+					{loading ? (
+						<ActivityIndicator color={colors.brandPurple} style={styles.loading} />
+					) : error ? (
+						<Txt style={styles.errorTxt}>{error}</Txt>
+					) : list.length === 0 ? (
+						<Txt style={styles.empty}>
+							No customers yet. Add your first contact to start tracking jobs and balances.
+						</Txt>
+					) : (
+						<ScrollView horizontal showsHorizontalScrollIndicator={false}>
+							<View style={[styles.table, { width: tableWidth }]}>
+								<View style={styles.tableHead}>
+									<Txt style={[styles.th, { flex: COLS.customer }]}>Customer</Txt>
+									<Txt style={[styles.th, { flex: COLS.address }]}>Address</Txt>
+									<Txt style={[styles.th, styles.right, { flex: COLS.lifetime }]}>Lifetime</Txt>
+									<Txt style={[styles.th, styles.right, { flex: COLS.balance }]}>Balance</Txt>
+								</View>
+								{list.map((customer, index) => {
+									const isSelected = customer.id === selected?.id;
+									return (
+										<Pressable
+											key={customer.id}
+											onPress={() => {
+												setSelectedId(customer.id);
+												setPanelOpen(true);
+											}}
+											style={[
+												styles.tr,
+												index === list.length - 1 && styles.trLast,
+												isSelected && styles.trSelected,
+											]}
+										>
+											<View style={[styles.cell, styles.customerCell, { flex: COLS.customer }]}>
+												<Avatar initials={initialsOf(customer.name)} size={36} />
+												<Txt style={styles.customerName} numberOfLines={1}>
+													{customer.name}
+												</Txt>
+											</View>
+											<Txt style={[styles.td, { flex: COLS.address }]} numberOfLines={1}>
+												{customer.address || '—'}
 											</Txt>
-										</View>
-										<Txt style={[styles.td, { flex: COLS.address }]} numberOfLines={1}>
-											{customer.address || '—'}
-										</Txt>
-										<Txt style={[styles.td, styles.right, styles.tdMed, { flex: COLS.lifetime }]}>
-											{formatMoney(customer.lifetimeValue)}
-										</Txt>
-										<Txt style={[styles.td, styles.right, styles.tdBold, { flex: COLS.balance }]}>
-											{formatMoney(customer.balance)}
-										</Txt>
-									</Pressable>
-								);
-							})}
-						</View>
-					</ScrollView>
-				)}
-			</ScrollView>
+											<Txt style={[styles.td, styles.right, styles.tdMed, { flex: COLS.lifetime }]}>
+												{formatMoney(customer.lifetimeValue)}
+											</Txt>
+											<Txt style={[styles.td, styles.right, styles.tdBold, { flex: COLS.balance }]}>
+												{formatMoney(customer.balance)}
+											</Txt>
+										</Pressable>
+									);
+								})}
+							</View>
+						</ScrollView>
+					)}
+				</ScrollView>
+			</View>
 
 			{panelVisible ? (
 				<AccountPanel
@@ -534,14 +539,23 @@ function AccountPanel({
 
 const styles = StyleSheet.create({
 	row: { flex: 1, flexDirection: 'row' },
-	leftPad: { padding: 24, paddingBottom: 40 },
+	// The left pane stacks a fixed header over a scrollable body; `minWidth: 0`
+	// lets it shrink beside the detail panel instead of overflowing the row.
+	leftPane: { flex: 1, minWidth: 0 },
+	// `flex: 1` bounds the list to the space below the header so it scrolls
+	// internally; the padding that used to wrap the whole page now lives here
+	// (top spacing comes from the header) and on the header itself.
+	body: { flex: 1 },
+	bodyPad: { paddingHorizontal: 24, paddingBottom: 40 },
 	head: {
 		flexDirection: 'row',
 		alignItems: 'center',
 		justifyContent: 'space-between',
 		gap: 16,
 		flexWrap: 'wrap',
-		marginBottom: 20,
+		paddingHorizontal: 24,
+		paddingTop: 24,
+		paddingBottom: 20,
 	},
 	title: { fontFamily: font.semibold, fontSize: 20 },
 	subtitle: { fontFamily: font.regular, fontSize: 13, color: colors.textMuted, marginTop: 3 },

--- a/packages/app/app/customers.tsx
+++ b/packages/app/app/customers.tsx
@@ -282,7 +282,11 @@ export default function CustomersScreen() {
 					<GradientButton label="Add customer" icon="plus" onPress={openCreate} />
 				</View>
 
-				<ScrollView style={styles.body} contentContainerStyle={styles.bodyPad}>
+				<ScrollView
+					style={styles.body}
+					contentContainerStyle={styles.bodyPad}
+					keyboardShouldPersistTaps="handled"
+				>
 					{formOpen ? (
 						<Card style={styles.form}>
 							<View style={styles.formHead}>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

This is a layout-only change to a screen. The app's test suite is deliberately React Native–free (it unit-tests the pure API clients and helpers, not screen geometry), so there is no unit test that exercises `ScrollView` nesting. I verified the behavior in a browser instead — see **How it was verified** below. `pnpm lint && pnpm type-check && pnpm test` all pass.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

---

### The problem

The Customers screen was always cut off at the bottom: the list ran past the edge of the viewport with no bounded frame.

The screen wrapped its header, the add/edit form, **and** the table in a single page-level vertical `ScrollView`. That is the odd one out among the data screens — `schedule.tsx` and `inbox.tsx` both keep a **fixed header** above a `flex: 1` scroll region that scrolls internally. Because the customers header lived inside the scroll, it scrolled away with the list and there was no anchored list area, so the table bled off the bottom.

### The fix

Restructure the left side into the same pattern the rest of the app uses:

- A `leftPane` column (`flex: 1`, `minWidth: 0`) that holds a **fixed header** over a **bounded scroll region**.
- The header (title, contact count, "Add customer") is now a fixed sibling — it stays anchored.
- The form and table move into a `flex: 1` `ScrollView` (`body`) that is bounded to the space below the header, so the list scrolls **within** the viewport and the last row is fully reachable.
- The inner horizontal `ScrollView` (which lets the 4-column table scroll sideways on narrow widths / when the detail panel is open) is unchanged — this is the same vertical-over-horizontal nesting already proven in the schedule grid.

The page-level padding that used to wrap everything (`leftPad`) now lives on the header and the scroll body (`bodyPad`); no design tokens or colors changed.

### How it was verified

Because the bug is a pure `react-native-web` flexbox/scroll issue, I reproduced the exact CSS the RN primitives emit and drove it in a headless browser:

- **Before:** the whole page scrolled as one unit — the header scrolled away and the table extended past the viewport bottom.
- **After:** the header stays fixed (`getBoundingClientRect().top` unchanged after scrolling), the body scrolls internally (`scrollHeight > clientHeight`), and a real mouse-wheel over the table (i.e. over the nested horizontal scroller) scrolls the body all the way to the last row (`scrollTop` reaches `maxScroll`).

Gates: `pnpm lint`, `pnpm type-check`, and `pnpm test` (app 187, api 475, core 171, agent 176, website 43) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRYqUAiBptZhTnAfSMe5d3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRYqUAiBptZhTnAfSMe5d3)_