### PR TITLE
feat(api): set agent email domain per environment for Resend

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -138,11 +138,14 @@ created normally) and question-answering degrades to a deterministic keyword mat
 `RESEND_WEBHOOK_SECRET` is likewise pushed only when set. It's the signing secret
 of the Resend `email.received` webhook (Resend → Webhooks); without it the agent
 email scheduling channel stays off — the webhook route answers `503` in production
-while the rest of the API runs normally. Configure the receiving domain (default
-`riv.us`, overridable via the `AGENT_EMAIL_DOMAIN` var) and the webhook in Resend
-first, then add this secret so `/v1/channels/email/inbound` goes live on the next
-deploy. The self-signup link domain (`WEBSITE_URL`) is a non-sensitive `vars` entry
-in `packages/api/wrangler.jsonc` (dev → `dev.rivus.ai`, prod → `rivus.ai`).
+while the rest of the API runs normally. Configure the receiving domain and the
+webhook in Resend first, then add this secret so `/v1/channels/email/inbound` goes
+live on the next deploy. The receiving domain is set per environment via the
+`AGENT_EMAIL_DOMAIN` `vars` entry in `packages/api/wrangler.jsonc`
+(dev → `dev.riv.us`, prod → `riv.us`) so dev traffic never lands in the production
+inbox — each must be a receiving (MX) and verified sending domain in Resend. The
+self-signup link domain (`WEBSITE_URL`) is likewise a non-sensitive `vars` entry
+(dev → `dev.rivus.ai`, prod → `rivus.ai`).
 The chat model defaults to `gpt-5.4-mini` and the embedding model (used to rank FAQs
 by relevance once a knowledge base outgrows the answerer's candidate cap) to
 `text-embedding-3-small`; since model ids aren't sensitive, override them — if needed —

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -177,8 +177,10 @@ already handled inline: the booking is rolled back and the delivery retried.)
 
 Wiring it up:
 
-1. In Resend, add `riv.us` (or your `AGENT_EMAIL_DOMAIN`) as a **receiving**
-   domain (MX records) and as a verified sending domain.
+1. In Resend, add your `AGENT_EMAIL_DOMAIN` as a **receiving** domain (MX records)
+   and as a verified sending domain. The deployed environments use separate domains
+   so dev traffic never lands in the production inbox — `dev.riv.us` for development
+   and `riv.us` for production (set per environment in `packages/api/wrangler.jsonc`).
 2. Create a webhook pointing at `POST /v1/channels/email/inbound`, subscribed to
    `email.received` **and** the delivery events `email.bounced` and
    `email.complained`, and set its signing secret as `RESEND_WEBHOOK_SECRET`.
@@ -186,7 +188,7 @@ Wiring it up:
 
 | Variable                | Default                 | Notes                                                                    |
 | ----------------------- | ----------------------- | ------------------------------------------------------------------------ |
-| `AGENT_EMAIL_DOMAIN`    | `riv.us`                | Domain of the per-account agent addresses.                                |
+| `AGENT_EMAIL_DOMAIN`    | `riv.us`                | Domain of the per-account agent addresses. Deployed: `dev.riv.us` (dev), `riv.us` (prod). |
 | `RESEND_WEBHOOK_SECRET` | _(unset)_               | Svix signing secret (`whsec_…`). Unset: dev/test accept unsigned deliveries; **production refuses the route (503)**. |
 | `WEBSITE_URL`           | `https://rivus.ai`      | Base URL for the customer self-signup link (`/customers/join/<slug>`).    |
 

--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -53,7 +53,12 @@
 				// Base URL for the accept-invite / sign-in-code links in emails.
 				"APP_URL": "https://dev-app.rivus.ai",
 				// Base URL for the agent's customer self-signup links (/customers/join).
-				"WEBSITE_URL": "https://dev.rivus.ai"
+				"WEBSITE_URL": "https://dev.rivus.ai",
+				// Inbound/outbound domain for the scheduling agent's email channel
+				// (Resend). Dev uses the `dev.riv.us` subdomain so test traffic never
+				// lands in the production `riv.us` inbox; it's configured as a receiving
+				// (MX) and verified sending domain in Resend, separate from prod's.
+				"AGENT_EMAIL_DOMAIN": "dev.riv.us"
 			},
 			"containers": [
 				{
@@ -87,7 +92,10 @@
 				// Base URL for the accept-invite / sign-in-code links in emails.
 				"APP_URL": "https://app.rivus.ai",
 				// Base URL for the agent's customer self-signup links (/customers/join).
-				"WEBSITE_URL": "https://rivus.ai"
+				"WEBSITE_URL": "https://rivus.ai",
+				// Inbound/outbound domain for the scheduling agent's email channel
+				// (Resend). Production customers email `<account-slug>@riv.us`.
+				"AGENT_EMAIL_DOMAIN": "riv.us"
 			},
 			"containers": [
 				{


### PR DESCRIPTION
Configures the scheduling agent's Resend email channel to use a dedicated domain per deployed environment, so dev email traffic never lands in the production inbox.

- **development** (`dev-api.rivus.ai`) → `dev.riv.us`
- **production** (`api.rivus.ai`) → `riv.us`

Previously neither deployed environment set `AGENT_EMAIL_DOMAIN`, so both fell back to the code default (`riv.us`) and shared the same Resend receiving/sending domain. This adds an explicit `vars` entry to each environment in `packages/api/wrangler.jsonc` (mirroring how `CORS_ORIGIN`, `COOKIE_DOMAIN`, `APP_URL`, and `WEBSITE_URL` are already split per environment). The value flows through `config.AGENT_EMAIL_DOMAIN` into the agent's `from` address, inbound recipient resolution, and the client session, so no code changes were needed.

Documentation in `DEPLOYMENT.md` and `packages/api/README.md` is updated to describe the per-environment split.

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: deployment-config (`wrangler.jsonc` `vars`) and docs only; no new runtime code path. The existing `AGENT_EMAIL_DOMAIN` plumbing is already covered, and `pnpm lint && pnpm type-check && pnpm test` all pass (1,256 tests green).

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Configuration change + docs update — sets the Resend agent email domain per deployed environment (`dev.riv.us` for dev, `riv.us` for prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6vnhkb2bLjE6d6HRfJ7SQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6vnhkb2bLjE6d6HRfJ7SQ)_