### PR TITLE
test(api): lock in agent-email domain isolation between dev and prod

### DIFF
--- a/packages/api/src/services/agent/email/inbound.ts
+++ b/packages/api/src/services/agent/email/inbound.ts
@@ -44,6 +44,10 @@ export const EMAIL_COMPLAINED_EVENT = 'email.complained';
  * event (`email.bounced`/`email.complained`) is about mail Rivus *sent*, so the
  * account is identified by the `From` (`<slug>@domain`), not the recipient.
  * Returns the local part (slug or id), or null when the address isn't ours.
+ *
+ * The domain check is exact and anchored on `@`, so it never mistakes the other
+ * deployment's alias for ours: `riv.us` (production) does not match `dev.riv.us`
+ * (development), nor the reverse.
  */
 export function agentAddressLocalPart(address: string, agentDomain: string): string | null {
 	const suffix = `@${agentDomain.toLowerCase()}`;
@@ -87,6 +91,12 @@ export function parseAddress(raw: string): ParsedAddress | null {
  * then forwarded-for) at the agent domain. Returns its local part — the
  * account's slug or id — or null when the mail wasn't addressed to the agent
  * domain at all.
+ *
+ * The domain match is exact and anchored on `@` (not a loose suffix), so a
+ * deployment configured for `riv.us` throws away mail to the `dev.riv.us` alias
+ * — and one configured for `dev.riv.us` throws away mail to `riv.us`. That keeps
+ * the production and development agent inboxes isolated even though one domain is
+ * a subdomain of the other.
  */
 export function resolveAgentRecipient(
 	event: InboundEmailEvent,

--- a/packages/api/test/agent-email-channel.test.ts
+++ b/packages/api/test/agent-email-channel.test.ts
@@ -161,6 +161,19 @@ describe('resolveAgentRecipient', () => {
 		expect(resolveAgentRecipient(event(['someone@example.com']), 'riv.us')).toBeNull();
 		expect(resolveAgentRecipient(event([]), 'riv.us')).toBeNull();
 	});
+
+	it('throws away the other environment’s domain alias (keeps dev/prod isolated)', () => {
+		// Production runs AGENT_EMAIL_DOMAIN=riv.us and must ignore mail to the
+		// development alias — the `@`-anchored match means `@dev.riv.us` is not a
+		// match for `@riv.us`, even though `dev.riv.us` is a subdomain of `riv.us`.
+		expect(resolveAgentRecipient(event(['cascade-1a2b3c4d@dev.riv.us']), 'riv.us')).toBeNull();
+		// Development runs AGENT_EMAIL_DOMAIN=dev.riv.us: it serves its own subdomain
+		// and rejects the bare production domain.
+		expect(resolveAgentRecipient(event(['cascade-1a2b3c4d@dev.riv.us']), 'dev.riv.us')).toBe(
+			'cascade-1a2b3c4d',
+		);
+		expect(resolveAgentRecipient(event(['cascade-1a2b3c4d@riv.us']), 'dev.riv.us')).toBeNull();
+	});
 });
 
 describe('agentAddressLocalPart', () => {
@@ -171,6 +184,15 @@ describe('agentAddressLocalPart', () => {
 	it('returns null for an address at another domain, or with an empty local part', () => {
 		expect(agentAddressLocalPart('hello@rivus.ai', 'riv.us')).toBeNull();
 		expect(agentAddressLocalPart('@riv.us', 'riv.us')).toBeNull();
+	});
+
+	it('does not treat the other environment’s domain alias as ours', () => {
+		// The bounce/complaint path identifies the account from our own From address;
+		// a prod deployment must not read a `dev.riv.us` sender as one of its agent
+		// addresses (nor the reverse), so the two inboxes never cross over.
+		expect(agentAddressLocalPart('acme-1a2b3c4d@dev.riv.us', 'riv.us')).toBeNull();
+		expect(agentAddressLocalPart('acme-1a2b3c4d@dev.riv.us', 'dev.riv.us')).toBe('acme-1a2b3c4d');
+		expect(agentAddressLocalPart('acme-1a2b3c4d@riv.us', 'dev.riv.us')).toBeNull();
 	});
 });
 

--- a/packages/api/test/agent-email-route.test.ts
+++ b/packages/api/test/agent-email-route.test.ts
@@ -410,6 +410,55 @@ describe('POST /v1/channels/email/inbound — address resolution', () => {
 		expect(agentMailbox(app).agentEmails).toHaveLength(0);
 		await app.close();
 	});
+
+	it('throws away mail to the other environment’s domain alias', async () => {
+		// A production-configured API (AGENT_EMAIL_DOMAIN defaults to riv.us) must
+		// ignore mail to the development alias `@dev.riv.us` — even for a real
+		// account — so the two deployments never share an inbox.
+		const app = await buildTestApp();
+		const owner = await signupOwner(app);
+		const tagged = agentEmailLocalPart(owner.account.slug, owner.account.id as AccountId);
+
+		const response = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inboundPayload(owner.account.slug, { to: [`${tagged}@dev.riv.us`] }),
+		});
+		expect(response.json()).toEqual({ handled: false, outcome: 'no_agent_recipient' });
+		expect(agentMailbox(app).agentEmails).toHaveLength(0);
+		await app.close();
+	});
+
+	it('serves its own domain and rejects the production alias when configured for development', async () => {
+		// The development deployment runs AGENT_EMAIL_DOMAIN=dev.riv.us: it answers
+		// mail to `@dev.riv.us` and throws away mail to the bare production `@riv.us`.
+		const app = await buildTestApp({
+			config: loadConfig({
+				NODE_ENV: 'test',
+				JWT_SECRET: 'test-secret-value-1234',
+				AGENT_EMAIL_DOMAIN: 'dev.riv.us',
+			} as NodeJS.ProcessEnv),
+		});
+		const owner = await signupOwner(app);
+		const tagged = agentEmailLocalPart(owner.account.slug, owner.account.id as AccountId);
+
+		const served = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inboundPayload(owner.account.slug, { to: [`${tagged}@dev.riv.us`] }),
+		});
+		expect(served.json()).toEqual({ handled: true, outcome: 'send_signup_link' });
+		// The reply goes back out from that same dev-domain address.
+		expect(agentMailbox(app).agentEmails.at(-1)?.from).toContain(`<${tagged}@dev.riv.us>`);
+
+		const prodAlias = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inboundPayload(owner.account.slug, { to: [`${tagged}@riv.us`] }),
+		});
+		expect(prodAlias.json()).toEqual({ handled: false, outcome: 'no_agent_recipient' });
+		await app.close();
+	});
 });
 
 describe('POST /v1/channels/email/inbound — signatures', () => {


### PR DESCRIPTION
Follow-up to #102 (which set `AGENT_EMAIL_DOMAIN` per environment — `dev.riv.us` for development, `riv.us` for production). This makes sure the `/v1/channels/email/inbound` endpoint filters by the configured domain and throws away mail addressed to the *other* environment's alias.

### What I verified

The endpoint resolves the recipient with `resolveAgentRecipient(event, config.AGENT_EMAIL_DOMAIN)` and returns `{ handled: false, outcome: 'no_agent_recipient' }` (sending no reply) when it doesn't match. Because the domain match is anchored on `@` (`.endsWith('@' + domain)`), the environment separation already holds:

- **production** (`riv.us`) accepts `@riv.us` and **rejects `@dev.riv.us`**
- **development** (`dev.riv.us`) accepts `@dev.riv.us` and **rejects `@riv.us`**

This works even though `dev.riv.us` is a subdomain of `riv.us`, because the `@` anchor means the subdomain's `.` never lines up with the parent domain's suffix. It also rejects lookalikes like `@notriv.us`.

### What changed

The behavior was correct but **untested** — nothing stopped a future refactor (e.g. loosening the match to a bare suffix) from silently letting dev and prod share an inbox. So this PR adds regression coverage and documents the guarantee:

- **`resolveAgentRecipient` / `agentAddressLocalPart`** (`inbound.ts`): docstrings now state the `@`-anchored exact-domain match keeps the two deployments isolated.
- **Unit tests** (`agent-email-channel.test.ts`): cross-environment alias rejection for both matchers, in both directions.
- **End-to-end test** (`agent-email-route.test.ts`): the endpoint ignores mail to the wrong-environment domain (`no_agent_recipient`, no reply sent) and serves its own domain when configured for development.

No production code behavior changes — matcher logic is untouched.

**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — Adds 3 unit assertions groups + 2 end-to-end cases covering the cross-environment rejection; `pnpm lint && pnpm type-check` pass and the API suite is green (661 tests).

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Test hardening + docs — locks in the dev/prod agent-email domain isolation at the inbound webhook (no runtime behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6vnhkb2bLjE6d6HRfJ7SQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6vnhkb2bLjE6d6HRfJ7SQ)_