### PR TITLE
fix(api): send email when replying to an email conversation from the inbox

### DIFF
--- a/packages/api/src/repositories/memory.ts
+++ b/packages/api/src/repositories/memory.ts
@@ -1241,6 +1241,16 @@ export class InMemoryAgentThreadRepository implements AgentThreadRepository {
 		return match ? structuredClone(match) : null;
 	}
 
+	async findByConversationId(
+		accountId: AccountId,
+		conversationId: ConversationId,
+	): Promise<AgentThread | null> {
+		const match = [...this.data.agentThreads.values()].find(
+			(thread) => thread.accountId === accountId && thread.conversationId === conversationId,
+		);
+		return match ? structuredClone(match) : null;
+	}
+
 	async update(
 		accountId: AccountId,
 		id: AgentThreadId,

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -1521,6 +1521,22 @@ export class MongoAgentThreadRepository implements AgentThreadRepository {
 		return doc ? mapAgentThread(doc) : null;
 	}
 
+	async findByConversationId(
+		accountId: AccountId,
+		conversationId: ConversationId,
+	): Promise<AgentThread | null> {
+		if (!Types.ObjectId.isValid(accountId) || !Types.ObjectId.isValid(conversationId)) {
+			return null;
+		}
+		// The (account, channel, address) index already scopes to this account's
+		// threads; the extra conversationId predicate filters the handful within it.
+		const doc = await AgentThreadModel.findOne({
+			accountId: new Types.ObjectId(accountId),
+			conversationId: new Types.ObjectId(conversationId),
+		}).exec();
+		return doc ? mapAgentThread(doc) : null;
+	}
+
 	async update(
 		accountId: AccountId,
 		id: AgentThreadId,

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -529,6 +529,17 @@ export interface AgentThreadRepository {
 		channel: ConversationChannel,
 		contactAddress: string,
 	): Promise<AgentThread | null>;
+	/**
+	 * The thread whose transcript is this conversation, or null when the
+	 * conversation isn't agent-driven. How an inbox reply on an email thread
+	 * finds the customer's address and the RFC 5322 id to thread under, so a
+	 * human's message actually leaves as email instead of only landing in the
+	 * transcript.
+	 */
+	findByConversationId(
+		accountId: AccountId,
+		conversationId: ConversationId,
+	): Promise<AgentThread | null>;
 	/** Apply a machine-state patch; returns the updated thread, or null when it isn't the account's. */
 	update(
 		accountId: AccountId,

--- a/packages/api/src/routes/agent-email.ts
+++ b/packages/api/src/routes/agent-email.ts
@@ -2,7 +2,6 @@ import {
 	type Account,
 	type AccountId,
 	type AgentSlot,
-	agentEmailLocalPart,
 	type JobId,
 	stripAgentEmailTag,
 	type UserId,
@@ -27,6 +26,7 @@ import {
 	parseAddress,
 	resolveAgentRecipient,
 } from '../services/agent/email/inbound';
+import { agentFromHeader } from '../services/agent/email/outbound';
 import { renderAgentEmail } from '../services/agent/email/templates';
 import { verifyWebhookSignature } from '../services/agent/email/webhook';
 import { type AgentDecision, decideScheduling } from '../services/agent/engine';
@@ -90,11 +90,6 @@ function headerValue(value: string | string[] | undefined): string {
 		return value[0] ?? '';
 	}
 	return value ?? '';
-}
-
-/** A display name safe to place before `<address>` in a From header. */
-function sanitizeDisplayName(name: string): string {
-	return name.replace(/[\r\n"<>]/g, '').trim();
 }
 
 export const agentEmailRoutes: FastifyPluginAsync = async (fastify) => {
@@ -498,14 +493,10 @@ export const agentEmailRoutes: FastifyPluginAsync = async (fastify) => {
 			});
 			// Always reply from the account's canonical tagged address, regardless of
 			// which form (tagged or legacy bare slug) the customer happened to write to.
-			const agentAddress = `${agentEmailLocalPart(account.slug, account.id)}@${config.AGENT_EMAIL_DOMAIN}`;
-			const displayName = sanitizeDisplayName(account.name);
 			try {
 				await mailer.sendAgentEmail({
 					to: sender.address,
-					// Quoted so names with commas/periods ("Cascade Plumbing, Inc.")
-					// survive RFC 5322 parsing; sanitize already stripped any quotes.
-					from: displayName === '' ? agentAddress : `"${displayName}" <${agentAddress}>`,
+					from: agentFromHeader(account, config.AGENT_EMAIL_DOMAIN),
 					subject: rendered.subject,
 					html: rendered.html,
 					text: rendered.text,

--- a/packages/api/src/routes/conversations.ts
+++ b/packages/api/src/routes/conversations.ts
@@ -2,6 +2,7 @@ import {
 	type AccountId,
 	approveReplySchema,
 	buildPaginationMeta,
+	type Conversation,
 	type ConversationDetail,
 	type ConversationId,
 	type CustomerId,
@@ -11,7 +12,7 @@ import {
 	type UserId,
 	updateConversationSchema,
 } from '@rivus/core';
-import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import type { FastifyBaseLogger, FastifyInstance, FastifyPluginAsync } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import {
@@ -22,6 +23,8 @@ import {
 	idParamsSchema,
 	needsAttentionCountResponseSchema,
 } from '../http-schemas';
+import { agentFromHeader } from '../services/agent/email/outbound';
+import { renderReplyEmail } from '../services/agent/email/templates';
 import { awaitingRivusReply, decideRivusReply, latestCustomerMessage } from '../services/inbox';
 
 // The newest page of FAQs handed to Rivus as the knowledge base when drafting a
@@ -51,7 +54,17 @@ async function assertCustomerExists(
 
 export const conversationRoutes: FastifyPluginAsync = async (fastify) => {
 	const app = fastify.withTypeProvider<ZodTypeProvider>();
-	const { conversations, faqs, faqAnswer, memberships, notifier } = app.deps;
+	const {
+		accounts,
+		agentThreads,
+		config,
+		conversations,
+		faqs,
+		faqAnswer,
+		mailer,
+		memberships,
+		notifier,
+	} = app.deps;
 
 	// Every conversation route requires a valid JWT.
 	app.addHook('onRequest', fastify.authenticate);
@@ -67,6 +80,61 @@ export const conversationRoutes: FastifyPluginAsync = async (fastify) => {
 		}
 		const messages = (await conversations.listMessages(accountId, id)) ?? [];
 		return { conversation, messages };
+	}
+
+	/**
+	 * Deliver a customer-facing reply to an email conversation as an actual email.
+	 *
+	 * The inbox transcript is only a record of the thread; on the `email` channel
+	 * a reply also has to leave the building, or the team believes they answered
+	 * while the customer heard nothing (the reported bug). The scheduling agent
+	 * opens every email conversation alongside an agent thread that holds the
+	 * customer's address and the last inbound message id, so we send from the
+	 * account's own agent address, threaded under the customer's latest message —
+	 * exactly like the agent's own replies. Conversations on other channels, or an
+	 * email conversation with no linked thread (no recipient on file), have no
+	 * transport, so this is a no-op for them.
+	 *
+	 * Sent *before* the message is recorded: a delivery failure then surfaces as
+	 * an error with nothing written — so the caller can retry — rather than
+	 * leaving a transcript line for an email that never sent.
+	 */
+	async function sendEmailReply(
+		conversation: Conversation,
+		body: string,
+		logger: FastifyBaseLogger,
+	): Promise<void> {
+		if (conversation.channel !== 'email') {
+			return;
+		}
+		const thread = await agentThreads.findByConversationId(conversation.accountId, conversation.id);
+		if (!thread || thread.contactAddress === '') {
+			logger.warn(
+				{ conversationId: conversation.id },
+				'email conversation has no linked agent thread; reply recorded but not emailed',
+			);
+			return;
+		}
+		const account = await accounts.findById(conversation.accountId);
+		if (!account) {
+			return;
+		}
+		const rendered = renderReplyEmail({
+			accountName: account.name,
+			inboundSubject: thread.subject,
+			body,
+		});
+		await mailer.sendAgentEmail({
+			to: thread.contactAddress,
+			from: agentFromHeader(account, config.AGENT_EMAIL_DOMAIN),
+			subject: rendered.subject,
+			html: rendered.html,
+			text: rendered.text,
+			// Thread under the customer's last inbound message so the reply lands in
+			// the same conversation in their mail client; empty when we never saw one.
+			inReplyTo: thread.lastExternalMessageId,
+			references: thread.lastExternalMessageId === '' ? [] : [thread.lastExternalMessageId],
+		});
 	}
 
 	app.get(
@@ -245,6 +313,10 @@ export const conversationRoutes: FastifyPluginAsync = async (fastify) => {
 			if (!before) {
 				throw app.httpErrors.notFound('Conversation not found');
 			}
+			// On the email channel the reply is emailed to the customer before it's
+			// recorded, so a send failure surfaces instead of a transcript line for
+			// an email that never left.
+			await sendEmailReply(before, request.body.body, request.log);
 			const detail = await conversations.addMessage(accountId, id, {
 				author: 'agent',
 				body: request.body.body,
@@ -320,7 +392,9 @@ export const conversationRoutes: FastifyPluginAsync = async (fastify) => {
 			const decision = decideRivusReply({ customerMessage: question, answer });
 
 			if (!decision.pause) {
-				// Confident, everyday answer: Rivus sends it and keeps handling the thread.
+				// Confident, everyday answer: Rivus sends it and keeps handling the thread —
+				// over email, that means actually mailing it to the customer.
+				await sendEmailReply(conversation, decision.draft, request.log);
 				const detail = await conversations.addMessage(accountId, id, {
 					author: 'rivus',
 					body: decision.draft,
@@ -400,6 +474,8 @@ export const conversationRoutes: FastifyPluginAsync = async (fastify) => {
 			if (finalText.trim() === '') {
 				throw app.httpErrors.badRequest('There is nothing to send — write a reply first.');
 			}
+			// "Approve & send" has to actually send on the email channel.
+			await sendEmailReply(conversation, finalText, request.log);
 			const detail = await conversations.addMessage(accountId, id, {
 				author: 'rivus',
 				body: finalText,

--- a/packages/api/src/services/agent/email/outbound.ts
+++ b/packages/api/src/services/agent/email/outbound.ts
@@ -1,0 +1,27 @@
+import { type Account, agentEmailLocalPart } from '@rivus/core';
+
+/**
+ * Addressing for outbound agent mail — the one thing every reply into an email
+ * thread shares, whether it comes from the scheduling engine (the webhook) or a
+ * human answering in the inbox. Rendering lives in `templates.ts`; this is just
+ * who the mail is *from*.
+ */
+
+/** A display name safe to place before `<address>` in a From header. */
+export function sanitizeDisplayName(name: string): string {
+	return name.replace(/[\r\n"<>]/g, '').trim();
+}
+
+/**
+ * The account's canonical agent `From` header: its tagged agent address
+ * (`<slug>-<hex>@domain`) with the business name as a quoted display name when
+ * it has one. Quoting lets names with commas or periods ("Cascade Plumbing,
+ * Inc.") survive RFC 5322 parsing — {@link sanitizeDisplayName} has already
+ * stripped any quotes. Every reply on the thread goes out from this single
+ * address, so the customer sees one consistent sender.
+ */
+export function agentFromHeader(account: Account, agentDomain: string): string {
+	const address = `${agentEmailLocalPart(account.slug, account.id)}@${agentDomain}`;
+	const displayName = sanitizeDisplayName(account.name);
+	return displayName === '' ? address : `"${displayName}" <${address}>`;
+}

--- a/packages/api/src/services/agent/email/templates.ts
+++ b/packages/api/src/services/agent/email/templates.ts
@@ -198,6 +198,31 @@ const TEXT_PRIMARY = '#16161f';
 const TEXT_SUB = '#8a8b99';
 const GRADIENT = 'linear-gradient(135deg, #1ebefa, #6e1ec8)';
 
+/** One body paragraph in the shared card style (its text is HTML-escaped). */
+function paragraph(line: string): string {
+	return `<p style="margin: 0 0 12px; font-size: 13.5px; line-height: 1.6; color: ${TEXT_PRIMARY};">${escapeHtml(line)}</p>`;
+}
+
+/**
+ * Wrap already-rendered body fragments in the shared design-system chrome — the
+ * page background, the account-headed card, and the Rivus footer — so every
+ * agent email (a scheduling decision or a plain reply) looks like one thread.
+ */
+function emailShell(accountName: string, body: string[]): string {
+	return [
+		'<!doctype html>',
+		'<html lang="en">',
+		`<body style="margin: 0; padding: 24px 12px; background: ${PAGE_BG}; font-family: ${FONT_STACK};">`,
+		`<div style="max-width: 560px; margin: 0 auto; background: ${CARD_BG}; border: 1px solid ${HAIRLINE}; border-radius: 14px; padding: 24px;">`,
+		`<p style="margin: 0 0 16px; font-size: 12px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: ${TEXT_SUB};">${escapeHtml(accountName)}</p>`,
+		...body,
+		'</div>',
+		`<p style="max-width: 560px; margin: 12px auto 0; font-size: 11.5px; font-weight: 500; color: ${TEXT_SUB}; text-align: center;">${escapeHtml(FOOTER_NOTE(accountName))}</p>`,
+		'</body>',
+		'</html>',
+	].join('\n');
+}
+
 /** Render a decision as a full email (subject + design-system HTML + text). */
 export function renderAgentEmail(
 	decision: AgentDecision,
@@ -206,9 +231,6 @@ export function renderAgentEmail(
 	const content = contentFor(decision, context);
 	const subject = replySubject(context.inboundSubject, context.accountName);
 	const text = renderAgentReplyText(decision, context);
-
-	const paragraph = (line: string) =>
-		`<p style="margin: 0 0 12px; font-size: 13.5px; line-height: 1.6; color: ${TEXT_PRIMARY};">${escapeHtml(line)}</p>`;
 
 	const body: string[] = [
 		paragraph(greeting(context.customerName)),
@@ -235,18 +257,38 @@ export function renderAgentEmail(
 	}
 	body.push(...content.trail.map(paragraph));
 
-	const html = [
-		'<!doctype html>',
-		'<html lang="en">',
-		`<body style="margin: 0; padding: 24px 12px; background: ${PAGE_BG}; font-family: ${FONT_STACK};">`,
-		`<div style="max-width: 560px; margin: 0 auto; background: ${CARD_BG}; border: 1px solid ${HAIRLINE}; border-radius: 14px; padding: 24px;">`,
-		`<p style="margin: 0 0 16px; font-size: 12px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: ${TEXT_SUB};">${escapeHtml(context.accountName)}</p>`,
-		...body,
-		'</div>',
-		`<p style="max-width: 560px; margin: 12px auto 0; font-size: 11.5px; font-weight: 500; color: ${TEXT_SUB}; text-align: center;">${escapeHtml(FOOTER_NOTE(context.accountName))}</p>`,
-		'</body>',
-		'</html>',
-	].join('\n');
+	return { subject, html: emailShell(context.accountName, body), text };
+}
 
-	return { subject, html, text };
+/**
+ * Render a free-text reply into an email thread: a human team member's message
+ * from the inbox, or an approved Rivus draft. There's no scheduling decision
+ * behind it — the body is whatever was written — so it carries no slot list or
+ * action button, but it wears the same `Re:` subject and design-system card as
+ * the agent's own replies, so the customer sees one consistent thread. The
+ * writer's paragraph and line breaks are preserved; every line is HTML-escaped.
+ */
+export function renderReplyEmail(context: {
+	accountName: string;
+	/** The email thread's subject, so the reply threads under `Re: …`. */
+	inboundSubject: string;
+	/** The reply text, exactly as the human wrote it (or the approved draft). */
+	body: string;
+}): RenderedEmail {
+	const subject = replySubject(context.inboundSubject, context.accountName);
+	// A blank line separates paragraphs; single breaks within one become <br>.
+	const paragraphs = context.body
+		.split(/\n{2,}/)
+		.map((block) =>
+			block
+				.split(/\n/)
+				.map((line) => escapeHtml(line))
+				.join('<br>'),
+		)
+		.filter((block) => block.trim() !== '')
+		.map(
+			(block) =>
+				`<p style="margin: 0 0 12px; font-size: 13.5px; line-height: 1.6; color: ${TEXT_PRIMARY};">${block}</p>`,
+		);
+	return { subject, html: emailShell(context.accountName, paragraphs), text: context.body };
 }

--- a/packages/api/test/conversations.test.ts
+++ b/packages/api/test/conversations.test.ts
@@ -1,8 +1,15 @@
-import type { AccountId, ConversationId } from '@rivus/core';
+import { type AccountId, agentEmailLocalPart, type ConversationId } from '@rivus/core';
 import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { InMemoryRepositories } from '../src/repositories/memory';
-import { addMember, authHeader, buildTestApp, buildTestAppWithRepos, signupOwner } from './helpers';
+import { createInMemoryRepositories, type InMemoryRepositories } from '../src/repositories/memory';
+import {
+	addMember,
+	authHeader,
+	buildTestApp,
+	buildTestAppWithRepos,
+	RecordingMailer,
+	signupOwner,
+} from './helpers';
 
 describe('conversation routes', () => {
 	let app: FastifyInstance;
@@ -592,5 +599,199 @@ describe('conversation list isolation', () => {
 			headers: authHeader(other.token),
 		});
 		expect(response.json().data).toHaveLength(0);
+	});
+});
+
+describe('inbox replies dispatch email on the email channel', () => {
+	let app: FastifyInstance;
+	let repos: InMemoryRepositories;
+	let token: string;
+	let accountId: AccountId;
+	let slug: string;
+
+	beforeEach(async () => {
+		({ app, repos } = await buildTestAppWithRepos());
+		const owner = await signupOwner(app);
+		token = owner.token;
+		accountId = owner.account.id as AccountId;
+		slug = owner.account.slug;
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	function outbox(instance: FastifyInstance = app): RecordingMailer {
+		return instance.deps.mailer as RecordingMailer;
+	}
+
+	/** Open an email conversation paired with an agent thread, the way the webhook does. */
+	async function seedEmailThread(
+		options: { subject?: string; lastMessageId?: string; address?: string } = {},
+	) {
+		const address = options.address ?? 'dana@example.com';
+		const conversation = await repos.conversations.create(accountId, {
+			contactName: 'Dana Fox',
+			channel: 'email',
+			customerId: '',
+			contactPhone: '',
+			status: 'rivus_handling',
+			tags: [],
+			lastInvoice: '',
+		});
+		const thread = await repos.agentThreads.create({
+			accountId,
+			channel: 'email',
+			contactAddress: address,
+			conversationId: conversation.id,
+			customerId: '',
+			subject: options.subject ?? 'Water heater',
+		});
+		if (options.lastMessageId) {
+			await repos.agentThreads.update(accountId, thread.id, {
+				lastExternalMessageId: options.lastMessageId,
+			});
+		}
+		return conversation;
+	}
+
+	it("emails a team member's reply to the customer, threaded into the conversation", async () => {
+		const conversation = await seedEmailThread({
+			subject: 'Water heater',
+			lastMessageId: '<m1@mail.example.com>',
+		});
+
+		const response = await app.inject({
+			method: 'POST',
+			url: `/v1/conversations/${conversation.id}/messages`,
+			headers: authHeader(token),
+			payload: { body: 'Hi this is Jared. We can book you then.' },
+		});
+
+		expect(response.statusCode).toBe(201);
+		// Recorded in the transcript as a human reply...
+		expect(response.json().messages.at(-1)).toMatchObject({
+			author: 'agent',
+			body: 'Hi this is Jared. We can book you then.',
+		});
+		// ...and actually sent as an email from the account's own agent address.
+		expect(outbox().agentEmails).toHaveLength(1);
+		const sent = outbox().agentEmails[0];
+		expect(sent?.to).toBe('dana@example.com');
+		expect(sent?.from).toContain(`<${agentEmailLocalPart(slug, accountId)}@riv.us>`);
+		expect(sent?.subject).toBe('Re: Water heater');
+		expect(sent?.text).toContain('We can book you then.');
+		expect(sent?.html).toContain('We can book you then.');
+		// Threaded under the customer's last inbound message.
+		expect(sent?.inReplyTo).toBe('<m1@mail.example.com>');
+		expect(sent?.references).toEqual(['<m1@mail.example.com>']);
+	});
+
+	it('emails the held draft when a flagged reply is approved', async () => {
+		const conversation = await seedEmailThread();
+		await repos.conversations.setReviewState(accountId, conversation.id as ConversationId, {
+			status: 'needs_attention',
+			pendingReply: "You're all set for Monday at 9.",
+			flagReason: 'billing',
+		});
+
+		const response = await app.inject({
+			method: 'POST',
+			url: `/v1/conversations/${conversation.id}/approve`,
+			headers: authHeader(token),
+			payload: {},
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(outbox().agentEmails).toHaveLength(1);
+		expect(outbox().agentEmails[0]?.text).toContain('all set for Monday');
+	});
+
+	it('emails a grounded answer when a human lets Rivus reply', async () => {
+		await repos.faqs.create(accountId, {
+			question: 'What are your hours?',
+			answer: 'We are open Monday to Friday, 9 AM to 6 PM.',
+			category: '',
+			status: 'published',
+		});
+		const conversation = await seedEmailThread();
+		await repos.conversations.addMessage(accountId, conversation.id as ConversationId, {
+			author: 'customer',
+			body: 'What are your hours?',
+		});
+
+		const response = await app.inject({
+			method: 'POST',
+			url: `/v1/conversations/${conversation.id}/reply`,
+			headers: authHeader(token),
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(outbox().agentEmails).toHaveLength(1);
+		expect(outbox().agentEmails[0]?.text).toContain('9 AM to 6 PM');
+	});
+
+	it('does not send email for a reply on a non-email channel', async () => {
+		const conversation = (
+			await app.inject({
+				method: 'POST',
+				url: '/v1/conversations',
+				headers: authHeader(token),
+				payload: { contactName: 'Dana Fox', channel: 'whatsapp' },
+			})
+		).json();
+
+		const response = await app.inject({
+			method: 'POST',
+			url: `/v1/conversations/${conversation.id}/messages`,
+			headers: authHeader(token),
+			payload: { body: 'Following up here.' },
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(outbox().agentEmails).toHaveLength(0);
+	});
+
+	it('surfaces a delivery failure and records nothing, so the reply can be retried', async () => {
+		class ThrowingMailer extends RecordingMailer {
+			override async sendAgentEmail(_email: Parameters<RecordingMailer['sendAgentEmail']>[0]) {
+				throw new Error('Resend rejected the email (status 500)');
+			}
+		}
+		const failingRepos = createInMemoryRepositories();
+		const failingApp = await buildTestApp({ ...failingRepos, mailer: new ThrowingMailer() });
+		const owner = await signupOwner(failingApp);
+		const failAccountId = owner.account.id as AccountId;
+		const conversation = await failingRepos.conversations.create(failAccountId, {
+			contactName: 'Dana Fox',
+			channel: 'email',
+			customerId: '',
+			contactPhone: '',
+			status: 'rivus_handling',
+			tags: [],
+			lastInvoice: '',
+		});
+		await failingRepos.agentThreads.create({
+			accountId: failAccountId,
+			channel: 'email',
+			contactAddress: 'dana@example.com',
+			conversationId: conversation.id,
+			customerId: '',
+			subject: 'Water heater',
+		});
+
+		const response = await failingApp.inject({
+			method: 'POST',
+			url: `/v1/conversations/${conversation.id}/messages`,
+			headers: authHeader(owner.token),
+			payload: { body: 'This should not be recorded if the email fails.' },
+		});
+
+		expect(response.statusCode).toBe(500);
+		// The transcript stayed empty — nothing recorded for an email that never sent.
+		const messages = await failingRepos.conversations.listMessages(failAccountId, conversation.id);
+		expect(messages).toEqual([]);
+
+		await failingApp.close();
 	});
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features). The `@rivus/api` coverage gate (90/80/90/90) passes.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

## The problem

Responding to a customer from the inbox didn't send the email. When a scheduling-agent email thread ("— Rivus, scheduling for …") lands in the inbox and a team member types a reply, the message showed up in the transcript but the customer never received anything.

The scheduling agent's inbound webhook (`routes/agent-email.ts`) was the **only** path that actually called `mailer.sendAgentEmail`. The inbox reply routes only appended to the conversation's transcript, so on the `email` channel:

- a team member's reply (`POST /:id/messages`),
- an approved held draft (`POST /:id/approve`), and
- an auto-sent "Let Rivus reply" answer (`POST /:id/reply`)

all silently went nowhere.

## The fix

Every agent-email conversation is opened alongside an `AgentThread` that already holds the customer's address, the email subject, and the RFC 5322 `Message-ID` to thread under. The reply routes now use that to actually deliver:

- **`AgentThreadRepository.findByConversationId`** (new) — resolves the thread from a conversation id, so an inbox reply can recover the recipient and threading id (implemented for both the in-memory and Mongo backends).
- **`sendEmailReply`** in `routes/conversations.ts` — for an `email` conversation with a linked thread, renders the reply and sends it from the account's own agent address, threaded under the customer's last message. It runs **before** the transcript write, so a delivery failure surfaces as an error (nothing recorded, safe to retry) instead of leaving a transcript line for an email that never sent. Other channels have no transport wired, so it's a no-op for them.
- **`renderReplyEmail`** in `services/agent/email/templates.ts` — renders a free-text reply (a human message or an approved draft) in the same design-system card and `Re:` subject as the agent's own replies, preserving the writer's line breaks and HTML-escaping every line.

Two bits of shared plumbing were factored out to avoid forking behavior: `agentFromHeader` (the account's canonical `From` header, now reused by the webhook) and the email HTML `emailShell` (shared by the scheduling templates and the new reply renderer).

## Testing

Added end-to-end route tests (`test/conversations.test.ts`) that a reply on an email conversation:

- is emailed to the customer from the account's tagged agent address, `Re:` the thread subject, threaded via `In-Reply-To`/`References`;
- is emailed on approve and on an auto-sent Rivus answer;
- is **not** emailed on non-email channels;
- surfaces a `500` and records nothing when delivery fails (so it can be retried).

`pnpm lint && pnpm type-check && pnpm test` all pass (1088 tests); the API coverage gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUTkbaiDVcbNLQM2KmfdCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUTkbaiDVcbNLQM2KmfdCZ)_