### PR TITLE
fix(api): handle CRLF line endings when rendering an inbox reply email

### DIFF
--- a/packages/api/src/services/agent/email/templates.ts
+++ b/packages/api/src/services/agent/email/templates.ts
@@ -278,9 +278,11 @@ export function renderReplyEmail(context: {
 	const subject = replySubject(context.inboundSubject, context.accountName);
 	// A blank line separates paragraphs; single breaks within one become <br>.
 	// Newlines are matched as `\r?\n` (like the inbound reply parser) so CRLF
-	// bodies from Windows/native mail clients split the same as LF ones.
+	// bodies from Windows/native mail clients split the same as LF ones. The
+	// separator tolerates spaces/tabs left on an otherwise-blank line
+	// (`\r\n \r\n`) while preserving the next paragraph's own leading indent.
 	const paragraphs = context.body
-		.split(/(?:\r?\n){2,}/)
+		.split(/\r?\n(?:[ \t]*\r?\n)+/)
 		.map((block) =>
 			block
 				.split(/\r?\n/)

--- a/packages/api/src/services/agent/email/templates.ts
+++ b/packages/api/src/services/agent/email/templates.ts
@@ -277,11 +277,13 @@ export function renderReplyEmail(context: {
 }): RenderedEmail {
 	const subject = replySubject(context.inboundSubject, context.accountName);
 	// A blank line separates paragraphs; single breaks within one become <br>.
+	// Newlines are matched as `\r?\n` (like the inbound reply parser) so CRLF
+	// bodies from Windows/native mail clients split the same as LF ones.
 	const paragraphs = context.body
-		.split(/\n{2,}/)
+		.split(/(?:\r?\n){2,}/)
 		.map((block) =>
 			block
-				.split(/\n/)
+				.split(/\r?\n/)
 				.map((line) => escapeHtml(line))
 				.join('<br>'),
 		)

--- a/packages/api/test/conversations.test.ts
+++ b/packages/api/test/conversations.test.ts
@@ -687,6 +687,26 @@ describe('inbox replies dispatch email on the email channel', () => {
 		expect(sent?.references).toEqual(['<m1@mail.example.com>']);
 	});
 
+	it('renders CRLF replies as separate paragraphs without stray carriage returns', async () => {
+		const conversation = await seedEmailThread();
+		// A reply typed in a Windows/native mail client arrives with CRLF endings:
+		// a blank line between paragraphs, a single break within one.
+		const response = await app.inject({
+			method: 'POST',
+			url: `/v1/conversations/${conversation.id}/messages`,
+			headers: authHeader(token),
+			payload: { body: 'Line one.\r\n\r\nLine two.\r\nStill line two.' },
+		});
+
+		expect(response.statusCode).toBe(201);
+		const sent = outbox().agentEmails[0];
+		// The blank line splits paragraphs; the single break becomes a <br> — and no
+		// literal carriage return leaks into the HTML.
+		expect(sent?.html).toContain('>Line one.</p>');
+		expect(sent?.html).toContain('>Line two.<br>Still line two.</p>');
+		expect(sent?.html).not.toContain('\r');
+	});
+
 	it('emails the held draft when a flagged reply is approved', async () => {
 		const conversation = await seedEmailThread();
 		await repos.conversations.setReviewState(accountId, conversation.id as ConversationId, {

--- a/packages/api/test/conversations.test.ts
+++ b/packages/api/test/conversations.test.ts
@@ -707,6 +707,23 @@ describe('inbox replies dispatch email on the email channel', () => {
 		expect(sent?.html).not.toContain('\r');
 	});
 
+	it('splits paragraphs even when the blank line carries trailing whitespace', async () => {
+		const conversation = await seedEmailThread();
+		// Some clients leave spaces/tabs on the "blank" separator line.
+		const response = await app.inject({
+			method: 'POST',
+			url: `/v1/conversations/${conversation.id}/messages`,
+			headers: authHeader(token),
+			payload: { body: 'First.\r\n \r\nSecond.' },
+		});
+
+		expect(response.statusCode).toBe(201);
+		const sent = outbox().agentEmails[0];
+		// Rendered as two separate paragraphs, not one run-on block.
+		expect(sent?.html).toContain('>First.</p>');
+		expect(sent?.html).toContain('>Second.</p>');
+	});
+
 	it('emails the held draft when a flagged reply is approved', async () => {
 		const conversation = await seedEmailThread();
 		await repos.conversations.setReviewState(accountId, conversation.id as ConversationId, {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features). The `@rivus/api` coverage gate (90/80/90/90) passes.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix — a small follow-up to #105.

## Background

The [Gemini review bot flagged this on #105](https://github.com/jaredwray/rivus/pull/105) (high priority), but the comment landed as that PR merged, so the fix isn't in `main`.

## The problem

`renderReplyEmail` split paragraphs on `\n{2,}` and lines on `\n`. A reply that arrives with **CRLF** (`\r\n`) endings — common from Windows and native mail clients — has a `\r` between the two `\n`s, so `\n{2,}` never matches the blank line: the whole body collapses into one run-on paragraph, and each `\n`-split line keeps a trailing `\r`.

## The fix

Match newlines as `\r?\n` for both the paragraph split and the intra-paragraph line split — the same convention `extractReplyText` already uses on the inbound side. CRLF bodies now split into paragraphs and `<br>`s exactly like LF ones, with no stray carriage returns in the HTML.

```
-		.split(/\n{2,}/)
+		.split(/(?:\r?\n){2,}/)
 		.map((block) =>
 			block
-				.split(/\n/)
+				.split(/\r?\n/)
```

## Testing

Added a route test asserting that a reply body with CRLF paragraph and line breaks renders as separate `<p>` blocks with a `<br>` for the single break, and contains no literal `\r`. `pnpm lint && pnpm type-check && pnpm test` pass; the API coverage gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUTkbaiDVcbNLQM2KmfdCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUTkbaiDVcbNLQM2KmfdCZ)_