### PR TITLE
feat: unified multi-channel agent + WhatsApp Business (zernio)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,22 @@ AGENT_EMAIL_DOMAIN=riv.us
 # Base URL of the marketing website; used to build the customer self-signup link
 # (/customers/join/<slug>) the agent emails to unrecognized senders.
 WEBSITE_URL=https://rivus.ai
+# --- WhatsApp channel (zernio) ------------------------------------------------
+# Rivus assigns a WhatsApp Business number (via zernio) when an owner enables the
+# channel in settings, then answers over WhatsApp with the same scheduling agent
+# as email. zernio posts inbound messages to POST /v1/channels/whatsapp/inbound.
+# Base URL of the zernio API.
+ZERNIO_API_URL=https://api.zernio.com
+# zernio API key. When unset, WhatsApp degrades to a no-op sender + provisioner
+# (a deterministic fake number in development) so the API runs without credentials.
+# ZERNIO_API_KEY=zk_xxxxxxxx
+# Signing secret for zernio's inbound webhook. When unset, dev/test accept unsigned
+# deliveries so you can drive the flow with curl; production refuses the webhook
+# route (503) until it's set.
+# ZERNIO_WEBHOOK_SECRET=whsec_xxxxxxxx
+# Verify token for the GET webhook-registration handshake. When unset, that
+# handshake endpoint 404s.
+# ZERNIO_VERIFY_TOKEN=
 # AI knowledge-base features: the duplicate-FAQ check (run before "Add FAQ") and
 # answering visitors' questions from the FAQs (the agent's catch-all). Both run
 # through the AI SDK, so any provider whose key is set can serve them — OpenAI is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,12 +92,34 @@ Tests are an inventory of failure modes, not a coverage ritual.
 - **api** — Routes depend on repository interfaces (`repositories/types.ts`).
   Add a feature by extending the interface, both implementations
   (`memory.ts`, `mongo.ts`), and the route. Regenerate the OpenAPI doc with
-  `pnpm --filter @rivus/api openapi`. The customer-facing scheduling agent
-  lives in `src/services/agent/`: the policy (`engine.ts`), availability
-  (`slots.ts`), and reply parsing (`parse.ts`) are pure and channel-agnostic;
-  each messaging channel (email today, under `services/agent/email/` +
-  `routes/agent-email.ts`) supplies only transport, parsing-in, and rendering-
-  out. Add a new channel by reusing the engine, never by forking it.
+  `pnpm --filter @rivus/api openapi`.
+
+  The customer-facing agent is **unified across channels** (email, WhatsApp,
+  and — later — SMS/voice), and the layering is what keeps it that way:
+  - **Core (`src/services/agent/`) owns all behavior** — the pure policy
+    (`engine.ts`), availability (`slots.ts`), reply parsing (`parse.ts`), the
+    capability registry (`capabilities.ts`), the `AgentDecision → AgentResponse`
+    composer (`response.ts`), and the one shared orchestrator
+    (`orchestrator.ts`) every channel's inbound route calls.
+  - **Channels (`services/agent/<channel>/` + `routes/agent-<channel>.ts`) are
+    dumb adapters** — a `ChannelAdapter` (`channel.ts`) does only three
+    feature-blind things: normalize an inbound provider payload, generically
+    render an `AgentResponse`, and transport. A channel module must **never**
+    import `engine.ts`, `capabilities.ts`, or `AgentDecision`; if it needs to,
+    the seam is wrong.
+  - **Adding a core feature** = a new `AgentCapability` (or a new
+    `AgentDecision→AgentResponse` case) composed from the existing
+    `AgentResponseBlock` kinds, registered in `defaultCapabilities()`. It ships
+    on **every** channel with zero channel edits. Only a genuinely new *block*
+    kind touches renderers — and then the compiler (exhaustive switches) and
+    `test/agent-response-matrix.test.ts` (channels × decisions) flag every one.
+  - **Adding a channel** = a provider seam (sender/inbound-parse/webhook, all
+    Noop-able), a `ChannelCapabilities` + one generic renderer, a
+    `createXChannelAdapter`, and a thin `routes/agent-x.ts` that resolves the
+    account and hands an `InboundAgentMessage` to `handleInboundAgentMessage`.
+    Register its adapter in `services/agent/channels.ts` and it inherits inbox
+    reply-out automatically. Provider wire details stay behind config +
+    `TODO(<provider>)` markers (see `services/zernio-whatsapp.ts`).
 - **website** — `type-check` runs `next typegen` first; `next-env.d.ts` is
   generated, not committed. All UI follows [`DESIGN_SYSTEM.md`](./DESIGN_SYSTEM.md).
 - **docs** — `scripts/sync-openapi.mjs` copies the API spec into the site on

--- a/packages/agent/src/api.test.ts
+++ b/packages/agent/src/api.test.ts
@@ -32,6 +32,11 @@ const account = {
 	address: '1 Main St',
 	website: 'https://acme.example',
 	timezone: 'America/Los_Angeles',
+	channels: {
+		whatsapp: { enabled: false, address: '', providerRef: '' },
+		sms: { enabled: false, address: '', providerRef: '' },
+		voice: { enabled: false, address: '', providerRef: '' },
+	},
 	status: 'active' as const,
 	canceledAt: null,
 	createdAt: '2026-01-01T00:00:00.000Z',

--- a/packages/agent/src/api.ts
+++ b/packages/agent/src/api.ts
@@ -54,6 +54,15 @@ const userSchema = z.object({
 	updatedAt: z.string(),
 }) satisfies z.ZodType<User>;
 
+// The API serializes channel configs without `providerRef` (a server-only
+// handle), so it defaults to '' here — keeping the parsed shape assignable to the
+// full `Account` type without leaking a provider internal onto the wire.
+const channelConfigSchema = z.object({
+	enabled: z.boolean(),
+	address: z.string(),
+	providerRef: z.string().default(''),
+});
+
 const accountSchema = z.object({
 	id: branded<AccountId>(),
 	name: z.string(),
@@ -62,6 +71,18 @@ const accountSchema = z.object({
 	address: z.string(),
 	website: z.string(),
 	timezone: z.string(),
+	// Default the whole map so a session from an API that predates channels still parses.
+	channels: z
+		.object({
+			whatsapp: channelConfigSchema,
+			sms: channelConfigSchema,
+			voice: channelConfigSchema,
+		})
+		.default({
+			whatsapp: { enabled: false, address: '', providerRef: '' },
+			sms: { enabled: false, address: '', providerRef: '' },
+			voice: { enabled: false, address: '', providerRef: '' },
+		}),
 	// Reuse the core enums so the agent never drifts from the API's source of truth.
 	status: accountStatusSchema,
 	canceledAt: z.string().nullable(),

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1150,6 +1150,186 @@
         }
       }
     },
+    "/v1/account/channels/{channel}/enable": {
+      "post": {
+        "summary": "Enable a messaging channel — provisions a number (owner only)",
+        "tags": [
+          "account"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "whatsapp",
+                "sms",
+                "voice"
+              ]
+            },
+            "in": "path",
+            "name": "channel",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/account/channels/{channel}/disable": {
+      "post": {
+        "summary": "Disable a messaging channel — retains the number (owner only)",
+        "tags": [
+          "account"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "whatsapp",
+                "sms",
+                "voice"
+              ]
+            },
+            "in": "path",
+            "name": "channel",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/admin/companies": {
       "get": {
         "summary": "List/search every company (Rivus staff only)",
@@ -4287,6 +4467,109 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AgentEmailWebhookResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/whatsapp/inbound": {
+      "get": {
+        "summary": "zernio WhatsApp webhook verification handshake",
+        "tags": [
+          "channels"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "hub.mode",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "hub.verify_token",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "hub.challenge",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "zernio WhatsApp webhook (inbound customer messages + delivery status)",
+        "tags": [
+          "channels"
+        ],
+        "description": "zernio delivers WhatsApp events for the account’s provisioned business number here. On an inbound message Rivus validates the sender against the account’s customers (by phone), keeps the multi-turn scheduling state on the thread, and replies over WhatsApp. On a delivery failure it flags the conversation for a human. Deliveries are authenticated with the signature header when ZERNIO_WEBHOOK_SECRET is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWhatsappWebhookResult"
                 }
               }
             }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -14,6 +14,7 @@ import { ConflictError, InviteNotPendingError, LastOwnerError } from './reposito
 import { accountRoutes } from './routes/account';
 import { adminRoutes } from './routes/admin';
 import { agentEmailRoutes } from './routes/agent-email';
+import { agentWhatsappRoutes } from './routes/agent-whatsapp';
 import { authRoutes } from './routes/auth';
 import { billingRoutes } from './routes/billing';
 import { conversationRoutes } from './routes/conversations';
@@ -194,6 +195,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	// webhook feeding the agent's email channel.
 	app.register(publicRoutes, { prefix: '/v1/public' });
 	app.register(agentEmailRoutes, { prefix: '/v1/channels' });
+	app.register(agentWhatsappRoutes, { prefix: '/v1/channels' });
 
 	return app;
 }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -12,6 +12,7 @@ import authPlugin, { SESSION_COOKIE } from './plugins/auth';
 import swaggerPlugin from './plugins/swagger';
 import { ConflictError, InviteNotPendingError, LastOwnerError } from './repositories/errors';
 import { accountRoutes } from './routes/account';
+import { accountChannelRoutes } from './routes/account-channels';
 import { adminRoutes } from './routes/admin';
 import { agentEmailRoutes } from './routes/agent-email';
 import { agentWhatsappRoutes } from './routes/agent-whatsapp';
@@ -182,6 +183,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	app.register(authRoutes, { prefix: '/v1/auth' });
 	app.register(memberRoutes, { prefix: '/v1/members' });
 	app.register(accountRoutes, { prefix: '/v1/account' });
+	app.register(accountChannelRoutes, { prefix: '/v1/account' });
 	app.register(adminRoutes, { prefix: '/v1/admin' });
 	app.register(billingRoutes, { prefix: '/v1/billing' });
 	app.register(itemRoutes, { prefix: '/v1/items' });

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -55,6 +55,22 @@ const envSchema = z
 		// serve at all in production — never unauthenticated in prod, and never a
 		// hard boot failure for deployments that don't use the email channel.
 		RESEND_WEBHOOK_SECRET: z.string().min(1).optional(),
+		// --- WhatsApp channel (zernio) ---
+		// Base URL of the zernio API (WhatsApp Business provider). Overridable so a
+		// self-hosted/staging zernio can be targeted; the send + provision endpoints
+		// hang off it.
+		ZERNIO_API_URL: z.url().default('https://api.zernio.com'),
+		// API key for zernio. When unset, WhatsApp degrades to a no-op sender +
+		// provisioner (a deterministic fake number in development) so the API still
+		// runs and tests without zernio credentials — mirroring the Resend gate.
+		ZERNIO_API_KEY: z.string().min(1).optional(),
+		// Signing secret for zernio's inbound webhook. When set, every delivery must
+		// carry a valid signature; when unset, dev/test accept unsigned payloads but
+		// production refuses the webhook route (503) until it's configured.
+		ZERNIO_WEBHOOK_SECRET: z.string().min(1).optional(),
+		// Verify token for the GET webhook handshake some WhatsApp providers require
+		// to register a webhook URL. When unset, the handshake endpoint 404s.
+		ZERNIO_VERIFY_TOKEN: z.string().min(1).optional(),
 		// --- AI (duplicate-FAQ detection) ---
 		// The knowledge base's "is this a duplicate?" check runs through the AI SDK,
 		// so any provider whose key is set can serve it. OpenAI is the primary; the

--- a/packages/api/src/db/models/account.model.ts
+++ b/packages/api/src/db/models/account.model.ts
@@ -1,5 +1,14 @@
 import { model, Schema } from 'mongoose';
 
+/** One provisioned channel's config, embedded on the account (no identity of its own). */
+export interface AccountChannelConfigSubdocument {
+	enabled: boolean;
+	/** The provisioned E.164 identifier, stored normalized; '' until provisioned. */
+	address: string;
+	/** The provider's opaque handle for the resource; '' when none. */
+	providerRef: string;
+}
+
 export interface AccountDocument {
 	name: string;
 	slug: string;
@@ -7,6 +16,16 @@ export interface AccountDocument {
 	address: string;
 	website: string;
 	timezone: string;
+	/**
+	 * Provisioned messaging channels. Email is derived from `slug`+`id` and never
+	 * stored here; only externally-assigned identifiers (WhatsApp today; SMS and
+	 * voice reserved) live on the account.
+	 */
+	channels: {
+		whatsapp: AccountChannelConfigSubdocument;
+		sms: AccountChannelConfigSubdocument;
+		voice: AccountChannelConfigSubdocument;
+	};
 	status: 'active' | 'canceled';
 	canceledAt: Date | null;
 	/**
@@ -20,6 +39,17 @@ export interface AccountDocument {
 	updatedAt: Date;
 }
 
+// Embedded per-channel config. No `_id` — it's a value object rewritten wholesale
+// when a channel is provisioned/enabled/disabled.
+const accountChannelConfigSchema = new Schema<AccountChannelConfigSubdocument>(
+	{
+		enabled: { type: Boolean, default: false },
+		address: { type: String, default: '', trim: true },
+		providerRef: { type: String, default: '', trim: true },
+	},
+	{ _id: false },
+);
+
 const accountSchema = new Schema<AccountDocument>(
 	{
 		name: { type: String, required: true, trim: true },
@@ -28,6 +58,12 @@ const accountSchema = new Schema<AccountDocument>(
 		address: { type: String, default: '' },
 		website: { type: String, default: '' },
 		timezone: { type: String, default: 'UTC' },
+		// Each channel defaults to its own fresh off/empty subdoc.
+		channels: {
+			whatsapp: { type: accountChannelConfigSchema, default: () => ({}) },
+			sms: { type: accountChannelConfigSchema, default: () => ({}) },
+			voice: { type: accountChannelConfigSchema, default: () => ({}) },
+		},
 		// Soft delete: `canceled` keeps the row (and its data) but locks the account
 		// out at authentication time. Defaults keep existing/active accounts unchanged.
 		status: { type: String, enum: ['active', 'canceled'], default: 'active', index: true },
@@ -36,5 +72,18 @@ const accountSchema = new Schema<AccountDocument>(
 	},
 	{ timestamps: true },
 );
+
+// A provisioned channel identifier is the multi-tenant key an inbound webhook
+// resolves to its account, so it must be unique across accounts — but only when
+// actually assigned. A *partial* (not sparse) index is required: every account
+// stores the field, defaulting to `''`, so a sparse index wouldn't skip the
+// unprovisioned rows and their shared `''` would collide. The partial filter
+// indexes only rows whose address is non-empty.
+for (const channel of ['whatsapp', 'sms', 'voice'] as const) {
+	accountSchema.index(
+		{ [`channels.${channel}.address`]: 1 },
+		{ unique: true, partialFilterExpression: { [`channels.${channel}.address`]: { $gt: '' } } },
+	);
+}
 
 export const AccountModel = model<AccountDocument>('Account', accountSchema);

--- a/packages/api/src/http-schemas.ts
+++ b/packages/api/src/http-schemas.ts
@@ -50,6 +50,16 @@ export const userResponseSchema = z
 	})
 	.meta({ id: 'User' });
 
+/** A provisioned channel's public config — the provider reference stays server-side. */
+export const channelConfigResponseSchema = z
+	.object({
+		/** Whether the channel is turned on. */
+		enabled: z.boolean(),
+		/** The provisioned E.164 identifier customers reach; '' until provisioned. */
+		address: z.string(),
+	})
+	.meta({ id: 'ChannelConfig' });
+
 /** A business account. */
 export const accountResponseSchema = z
 	.object({
@@ -60,6 +70,16 @@ export const accountResponseSchema = z
 		address: z.string(),
 		website: z.string(),
 		timezone: z.string(),
+		/**
+		 * Provisioned messaging channels (WhatsApp today; SMS and voice reserved).
+		 * Email isn't here — its address is derived from `slug`+`id` (joined to
+		 * `agentEmailDomain`), always on, and never provisioned.
+		 */
+		channels: z.object({
+			whatsapp: channelConfigResponseSchema,
+			sms: channelConfigResponseSchema,
+			voice: channelConfigResponseSchema,
+		}),
 		status: accountStatusSchema,
 		canceledAt: z.string().nullable(),
 		createdAt: z.string(),

--- a/packages/api/src/openapi.ts
+++ b/packages/api/src/openapi.ts
@@ -4,10 +4,12 @@ import { buildApp } from './app';
 import { loadConfig } from './config';
 import { createInMemoryRepositories } from './repositories/memory';
 import { NoopReceivedEmailReader } from './services/agent/email/received';
+import { NoopChannelProvisioner } from './services/channel-provisioning';
 import { NoopMailer } from './services/email';
 import { NoopFaqAnswerService } from './services/faq-answer';
 import { NoopFaqSimilarityService } from './services/faq-similarity';
 import { createNotificationService } from './services/notifications';
+import { NoopWhatsappSender } from './services/whatsapp';
 
 /**
  * Boot the app with in-memory repositories (no database needed) purely to read
@@ -48,6 +50,8 @@ async function main(): Promise<void> {
 		verificationCodes,
 		mailer: new NoopMailer(),
 		receivedEmails: new NoopReceivedEmailReader(),
+		whatsappSender: new NoopWhatsappSender(),
+		whatsappProvisioner: new NoopChannelProvisioner(),
 		notifier: createNotificationService({ notifications }),
 		faqSimilarity: new NoopFaqSimilarityService(),
 		faqAnswer: new NoopFaqAnswerService(),

--- a/packages/api/src/presenters.ts
+++ b/packages/api/src/presenters.ts
@@ -1,5 +1,26 @@
-import { type Account, gravatarUrl, type Invite, type Membership, type User } from '@rivus/core';
+import {
+	type Account,
+	gravatarUrl,
+	type Invite,
+	type Membership,
+	type ProvisionedChannel,
+	type User,
+} from '@rivus/core';
 import type { StoredUser } from './repositories/types';
+
+/** A provisioned channel's config as exposed to clients — the provider reference stays server-side. */
+export interface PublicAccountChannelConfig {
+	enabled: boolean;
+	address: string;
+}
+
+/**
+ * An account as returned by the API: like {@link Account}, but each channel
+ * config drops `providerRef` (a provider-internal handle clients never need).
+ */
+export type PublicAccount = Omit<Account, 'channels'> & {
+	channels: Record<ProvisionedChannel, PublicAccountChannelConfig>;
+};
 
 /** The user's custom avatar override, or their Gravatar if none is set. */
 function resolveAvatarUrl(user: StoredUser): string {
@@ -20,8 +41,13 @@ export function toPublicUser(user: StoredUser): User {
 	};
 }
 
-/** Accounts carry no secrets; this just pins the serialized shape. */
-export function toPublicAccount(account: Account): Account {
+/** One stored channel config → its public shape (drops `providerRef`). */
+function toPublicChannel(config: Account['channels']['whatsapp']): PublicAccountChannelConfig {
+	return { enabled: config.enabled, address: config.address };
+}
+
+/** Pins the serialized account shape; channel configs expose only `enabled`/`address`. */
+export function toPublicAccount(account: Account): PublicAccount {
 	return {
 		id: account.id,
 		name: account.name,
@@ -30,6 +56,11 @@ export function toPublicAccount(account: Account): Account {
 		address: account.address,
 		website: account.website,
 		timezone: account.timezone,
+		channels: {
+			whatsapp: toPublicChannel(account.channels.whatsapp),
+			sms: toPublicChannel(account.channels.sms),
+			voice: toPublicChannel(account.channels.voice),
+		},
 		status: account.status,
 		canceledAt: account.canceledAt,
 		createdAt: account.createdAt,

--- a/packages/api/src/repositories/memory.ts
+++ b/packages/api/src/repositories/memory.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import {
 	type Account,
+	type AccountChannelConfig,
+	type AccountChannels,
 	type AccountId,
 	type AgentThread,
 	type AgentThreadId,
@@ -17,6 +19,7 @@ import {
 	type CreateNotificationInput,
 	type Customer,
 	type CustomerId,
+	emptyAccountChannels,
 	type Faq,
 	type FaqId,
 	type Invite,
@@ -32,6 +35,8 @@ import {
 	type Notification,
 	type NotificationId,
 	normalizePagination,
+	normalizePhone,
+	type ProvisionedChannel,
 	pageToSkip,
 	type Role,
 	type UpdateConversationInput,
@@ -233,6 +238,7 @@ export class InMemoryAccountRepository implements AccountRepository {
 			address: input.address,
 			website: input.website,
 			timezone: input.timezone,
+			channels: emptyAccountChannels(),
 			status: 'active',
 			canceledAt: null,
 			createdAt: timestamp,
@@ -294,6 +300,45 @@ export class InMemoryAccountRepository implements AccountRepository {
 			}
 		}
 		const updated: Account = { ...account, ...patch, updatedAt: now() };
+		this.data.accounts.set(id, updated);
+		return structuredClone(updated);
+	}
+
+	async findByChannelAddress(
+		channel: ProvisionedChannel,
+		address: string,
+	): Promise<Account | null> {
+		if (address === '') {
+			return null;
+		}
+		for (const account of this.data.accounts.values()) {
+			if (account.channels[channel].address === address) {
+				return structuredClone(account);
+			}
+		}
+		return null;
+	}
+
+	async setChannelConfig(
+		id: AccountId,
+		channel: ProvisionedChannel,
+		config: AccountChannelConfig,
+	): Promise<Account | null> {
+		const account = this.data.accounts.get(id);
+		if (!account) {
+			return null;
+		}
+		// Enforce the same cross-account uniqueness the Mongo partial index does, so
+		// a provider double-assigning a number fails identically under test.
+		if (config.address !== '') {
+			for (const other of this.data.accounts.values()) {
+				if (other.id !== id && other.channels[channel].address === config.address) {
+					throw new ConflictError('address', 'That channel number is already in use');
+				}
+			}
+		}
+		const channels: AccountChannels = { ...account.channels, [channel]: { ...config } };
+		const updated: Account = { ...account, channels, updatedAt: now() };
 		this.data.accounts.set(id, updated);
 		return structuredClone(updated);
 	}
@@ -738,6 +783,22 @@ export class InMemoryCustomerRepository implements CustomerRepository {
 			.reverse()
 			.find(
 				(customer) => customer.accountId === accountId && customer.email.toLowerCase() === needle,
+			);
+		return match ? structuredClone(match) : null;
+	}
+
+	async findByPhone(accountId: AccountId, phoneE164: string): Promise<Customer | null> {
+		if (phoneE164 === '') {
+			return null;
+		}
+		// Newest-first (reverse insertion order), so the most recent record wins;
+		// stored phones are free text, so both sides normalize before comparison and
+		// an unnormalizable stored phone simply never matches.
+		const match = [...this.data.customers.values()]
+			.reverse()
+			.find(
+				(customer) =>
+					customer.accountId === accountId && normalizePhone(customer.phone) === phoneE164,
 			);
 		return match ? structuredClone(match) : null;
 	}

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -1,5 +1,7 @@
 import {
 	type Account,
+	type AccountChannelConfig,
+	type AccountChannels,
 	type AccountId,
 	type AgentThread,
 	type AgentThreadId,
@@ -32,6 +34,8 @@ import {
 	type Notification,
 	type NotificationId,
 	normalizePagination,
+	normalizePhone,
+	type ProvisionedChannel,
 	pageToSkip,
 	type Role,
 	type UpdateConversationInput,
@@ -42,7 +46,11 @@ import {
 	type UserId,
 } from '@rivus/core';
 import mongoose, { type ClientSession, type HydratedDocument, Types } from 'mongoose';
-import { type AccountDocument, AccountModel } from '../db/models/account.model';
+import {
+	type AccountChannelConfigSubdocument,
+	type AccountDocument,
+	AccountModel,
+} from '../db/models/account.model';
 import { type AgentThreadDocument, AgentThreadModel } from '../db/models/agent-thread.model';
 import {
 	type ConversationDocument,
@@ -141,6 +149,24 @@ function mapVerificationCode(
 	};
 }
 
+/** One channel subdoc → the public config shape, defaulting a missing legacy field. */
+function mapChannelConfig(config?: AccountChannelConfigSubdocument): AccountChannelConfig {
+	return {
+		enabled: config?.enabled ?? false,
+		address: config?.address ?? '',
+		providerRef: config?.providerRef ?? '',
+	};
+}
+
+/** The account's channel map, defaulting the whole subtree for pre-`channels` documents. */
+function mapAccountChannels(channels: AccountDocument['channels'] | undefined): AccountChannels {
+	return {
+		whatsapp: mapChannelConfig(channels?.whatsapp),
+		sms: mapChannelConfig(channels?.sms),
+		voice: mapChannelConfig(channels?.voice),
+	};
+}
+
 function mapAccount(doc: HydratedDocument<AccountDocument>): Account {
 	return {
 		id: doc._id.toString() as AccountId,
@@ -150,6 +176,7 @@ function mapAccount(doc: HydratedDocument<AccountDocument>): Account {
 		address: doc.address,
 		website: doc.website,
 		timezone: doc.timezone,
+		channels: mapAccountChannels(doc.channels),
 		status: doc.status,
 		canceledAt: doc.canceledAt ? doc.canceledAt.toISOString() : null,
 		createdAt: doc.createdAt.toISOString(),
@@ -452,6 +479,42 @@ export class MongoAccountRepository implements AccountRepository {
 		}
 		const doc = await AccountModel.findByIdAndUpdate(id, { $set: set }, { new: true }).exec();
 		return doc ? mapAccount(doc) : null;
+	}
+
+	async findByChannelAddress(
+		channel: ProvisionedChannel,
+		address: string,
+	): Promise<Account | null> {
+		if (address === '') {
+			return null;
+		}
+		const doc = await AccountModel.findOne({ [`channels.${channel}.address`]: address }).exec();
+		return doc ? mapAccount(doc) : null;
+	}
+
+	async setChannelConfig(
+		id: AccountId,
+		channel: ProvisionedChannel,
+		config: AccountChannelConfig,
+	): Promise<Account | null> {
+		if (!Types.ObjectId.isValid(id)) {
+			return null;
+		}
+		try {
+			const doc = await AccountModel.findByIdAndUpdate(
+				id,
+				{ $set: { [`channels.${channel}`]: config } },
+				{ new: true },
+			).exec();
+			return doc ? mapAccount(doc) : null;
+		} catch (error) {
+			// The partial-unique index rejects an address already held by another
+			// account (a provider double-assigning a number) — surface it as a conflict.
+			if (isDuplicateKeyError(error)) {
+				throw new ConflictError('address', 'That channel number is already in use');
+			}
+			throw error;
+		}
 	}
 
 	async cancel(id: AccountId): Promise<Account | null> {
@@ -940,6 +1003,36 @@ export class MongoCustomerRepository implements CustomerRepository {
 			.sort({ createdAt: -1, _id: -1 })
 			.exec();
 		return doc ? mapCustomer(doc) : null;
+	}
+
+	async findByPhone(accountId: AccountId, phoneE164: string): Promise<Customer | null> {
+		if (phoneE164 === '' || !Types.ObjectId.isValid(accountId)) {
+			return null;
+		}
+		// Stored phones are free text, so E.164 matching can't be a query predicate:
+		// page the account's customers with a phone on file (newest-first, so the
+		// most recent record wins) and normalize each in app code. Bounded at
+		// MAX_PHONE_SCAN_PAGES × 100 — ample for a small business; the documented
+		// upgrade path is a normalized shadow field if an account ever outgrows it.
+		const PAGE_SIZE = 100;
+		const MAX_PHONE_SCAN_PAGES = 50;
+		const filter = { accountId: new Types.ObjectId(accountId), phone: { $ne: '' } };
+		for (let page = 0; page < MAX_PHONE_SCAN_PAGES; page += 1) {
+			const docs = await CustomerModel.find(filter)
+				.sort({ createdAt: -1, _id: -1 })
+				.skip(page * PAGE_SIZE)
+				.limit(PAGE_SIZE)
+				.exec();
+			for (const doc of docs) {
+				if (normalizePhone(doc.phone) === phoneE164) {
+					return mapCustomer(doc);
+				}
+			}
+			if (docs.length < PAGE_SIZE) {
+				break;
+			}
+		}
+		return null;
 	}
 
 	async update(

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -1016,7 +1016,10 @@ export class MongoCustomerRepository implements CustomerRepository {
 		// upgrade path is a normalized shadow field if an account ever outgrows it.
 		const PAGE_SIZE = 100;
 		const MAX_PHONE_SCAN_PAGES = 50;
-		const filter = { accountId: new Types.ObjectId(accountId), phone: { $ne: '' } };
+		// `$gt: ''` (not `$ne: ''`) so only real non-empty string phones are scanned:
+		// `$ne: ''` would also match documents whose `phone` is null/missing, and
+		// `normalizePhone(null)` would throw. Legacy customers may lack the field.
+		const filter = { accountId: new Types.ObjectId(accountId), phone: { $gt: '' } };
 		for (let page = 0; page < MAX_PHONE_SCAN_PAGES; page += 1) {
 			const docs = await CustomerModel.find(filter)
 				.sort({ createdAt: -1, _id: -1 })

--- a/packages/api/src/repositories/mongo.ts
+++ b/packages/api/src/repositories/mongo.ts
@@ -1011,16 +1011,17 @@ export class MongoCustomerRepository implements CustomerRepository {
 		}
 		// Stored phones are free text, so E.164 matching can't be a query predicate:
 		// page the account's customers with a phone on file (newest-first, so the
-		// most recent record wins) and normalize each in app code. Bounded at
-		// MAX_PHONE_SCAN_PAGES × 100 — ample for a small business; the documented
-		// upgrade path is a normalized shadow field if an account ever outgrows it.
-		const PAGE_SIZE = 100;
-		const MAX_PHONE_SCAN_PAGES = 50;
+		// most recent record wins) and normalize each in app code. The scan runs to
+		// exhaustion — a hard page cap would silently miss a real match for a large
+		// account, which is worse than the extra reads; the documented upgrade path
+		// (a normalized shadow field + index for an O(1) lookup) is the answer if an
+		// account's phone-bearing customer count ever makes the scan measurable.
 		// `$gt: ''` (not `$ne: ''`) so only real non-empty string phones are scanned:
 		// `$ne: ''` would also match documents whose `phone` is null/missing, and
 		// `normalizePhone(null)` would throw. Legacy customers may lack the field.
+		const PAGE_SIZE = 100;
 		const filter = { accountId: new Types.ObjectId(accountId), phone: { $gt: '' } };
-		for (let page = 0; page < MAX_PHONE_SCAN_PAGES; page += 1) {
+		for (let page = 0; ; page += 1) {
 			const docs = await CustomerModel.find(filter)
 				.sort({ createdAt: -1, _id: -1 })
 				.skip(page * PAGE_SIZE)
@@ -1032,10 +1033,9 @@ export class MongoCustomerRepository implements CustomerRepository {
 				}
 			}
 			if (docs.length < PAGE_SIZE) {
-				break;
+				return null;
 			}
 		}
-		return null;
 	}
 
 	async update(

--- a/packages/api/src/repositories/types.ts
+++ b/packages/api/src/repositories/types.ts
@@ -1,6 +1,7 @@
 import type {
 	Account,
 	AccountBusinessInput,
+	AccountChannelConfig,
 	AccountId,
 	AgentSlot,
 	AgentThread,
@@ -33,6 +34,7 @@ import type {
 	Message,
 	Notification,
 	NotificationId,
+	ProvisionedChannel,
 	Role,
 	UpdateConversationInput,
 	UpdateCustomerInput,
@@ -173,6 +175,25 @@ export interface AccountRepository {
 	list(options: ListAccountsOptions): Promise<{ accounts: Account[]; total: number }>;
 	/** Apply a partial business-info update; returns the updated account or null. */
 	update(id: AccountId, input: UpdateAccount): Promise<Account | null>;
+	/**
+	 * The account that holds this provisioned channel identifier (exact match on
+	 * the stored, normalized E.164 address), or null. The multi-tenant analog of
+	 * resolving an agent-email local part: how an inbound channel webhook finds
+	 * its tenant. Matches regardless of `enabled` — the route decides what a
+	 * disabled channel does. An empty address never matches.
+	 */
+	findByChannelAddress(channel: ProvisionedChannel, address: string): Promise<Account | null>;
+	/**
+	 * Persist one channel's config (enable/disable/provision), replacing that
+	 * channel's subdocument wholesale. Separate from {@link update} so a business-
+	 * info PATCH can never touch a provisioned identifier. Throws
+	 * {@link ConflictError} when the address is already held by another account.
+	 */
+	setChannelConfig(
+		id: AccountId,
+		channel: ProvisionedChannel,
+		config: AccountChannelConfig,
+	): Promise<Account | null>;
 	/** Soft-delete: mark the account `canceled` (data retained). Returns it, or null. */
 	cancel(id: AccountId): Promise<Account | null>;
 }
@@ -307,6 +328,15 @@ export interface CustomerRepository {
 	 * without an address on file all store `''`.
 	 */
 	findByEmail(accountId: AccountId, email: string): Promise<Customer | null>;
+	/**
+	 * The account's customer whose phone matches this E.164 number, or null — how
+	 * a phone-shaped channel (WhatsApp/SMS) recognizes an inbound sender. Stored
+	 * phones are free text ("(555) 123-4567"), so both sides are normalized via
+	 * `normalizePhone`; the newest record wins on ties, and an unnormalizable
+	 * stored phone (or an empty query) never matches. The phone-space twin of
+	 * {@link findByEmail}.
+	 */
+	findByPhone(accountId: AccountId, phoneE164: string): Promise<Customer | null>;
 	update(
 		accountId: AccountId,
 		id: CustomerId,

--- a/packages/api/src/routes/account-channels.ts
+++ b/packages/api/src/routes/account-channels.ts
@@ -1,0 +1,137 @@
+import { type AccountId, provisionedChannelSchema } from '@rivus/core';
+import type { FastifyPluginAsync } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { accountResponseSchema, errorResponseSchema } from '../http-schemas';
+import { toPublicAccount } from '../presenters';
+import { ConflictError } from '../repositories/errors';
+
+/**
+ * Owner-only provisioning of a messaging channel. Enabling calls the provider to
+ * assign a customer-facing number and stores it on the account (idempotent — a
+ * re-enable never re-provisions); disabling turns the channel off but retains the
+ * number so re-enabling restores the same one. Email isn't here (its address is
+ * derived, always on); v1 supports WhatsApp only.
+ */
+
+const channelParamsSchema = z.object({ channel: provisionedChannelSchema });
+
+export const accountChannelRoutes: FastifyPluginAsync = async (fastify) => {
+	const app = fastify.withTypeProvider<ZodTypeProvider>();
+	const { accounts, whatsappProvisioner } = app.deps;
+
+	app.post(
+		'/channels/:channel/enable',
+		{
+			onRequest: [fastify.authenticate, fastify.requireRole('owner')],
+			schema: {
+				tags: ['account'],
+				summary: 'Enable a messaging channel — provisions a number (owner only)',
+				security: [{ bearerAuth: [] }],
+				params: channelParamsSchema,
+				response: {
+					200: accountResponseSchema,
+					400: errorResponseSchema,
+					401: errorResponseSchema,
+					403: errorResponseSchema,
+					404: errorResponseSchema,
+					409: errorResponseSchema,
+					502: errorResponseSchema,
+				},
+			},
+		},
+		async (request, reply) => {
+			const accountId = request.user.accountId as AccountId;
+			const { channel } = request.params;
+			// Only WhatsApp is wired to a provisioner today; SMS/voice are schema-ready.
+			if (channel !== 'whatsapp') {
+				throw app.httpErrors.badRequest('That channel is not available yet.');
+			}
+			const account = await accounts.findById(accountId);
+			if (!account) {
+				throw app.httpErrors.notFound('Account not found');
+			}
+			const existing = account.channels[channel];
+			// Idempotent: already enabled with a number → return the account unchanged.
+			if (existing.enabled && existing.address !== '') {
+				return toPublicAccount(account);
+			}
+			let provisioned: { address: string; providerRef: string };
+			try {
+				provisioned = await whatsappProvisioner.provision({
+					accountId,
+					accountName: account.name,
+					existing: { address: existing.address, providerRef: existing.providerRef },
+				});
+			} catch (error) {
+				request.log.error({ err: error }, 'WhatsApp provisioning failed');
+				// The provider is the failing dependency, so 502 (not a generic 500). Sent
+				// directly: the central error handler flattens thrown 5xx into a 500.
+				return reply.code(502).send({
+					error: 'Bad Gateway',
+					message: 'Could not provision a WhatsApp number right now. Please try again.',
+					statusCode: 502,
+				});
+			}
+			try {
+				const updated = await accounts.setChannelConfig(accountId, channel, {
+					enabled: true,
+					address: provisioned.address,
+					providerRef: provisioned.providerRef,
+				});
+				if (!updated) {
+					throw app.httpErrors.notFound('Account not found');
+				}
+				return toPublicAccount(updated);
+			} catch (error) {
+				// The unique index rejects a number another account already holds.
+				if (error instanceof ConflictError) {
+					throw app.httpErrors.conflict('That number is already in use.');
+				}
+				throw error;
+			}
+		},
+	);
+
+	app.post(
+		'/channels/:channel/disable',
+		{
+			onRequest: [fastify.authenticate, fastify.requireRole('owner')],
+			schema: {
+				tags: ['account'],
+				summary: 'Disable a messaging channel — retains the number (owner only)',
+				security: [{ bearerAuth: [] }],
+				params: channelParamsSchema,
+				response: {
+					200: accountResponseSchema,
+					400: errorResponseSchema,
+					401: errorResponseSchema,
+					403: errorResponseSchema,
+					404: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const accountId = request.user.accountId as AccountId;
+			const { channel } = request.params;
+			if (channel !== 'whatsapp') {
+				throw app.httpErrors.badRequest('That channel is not available yet.');
+			}
+			const account = await accounts.findById(accountId);
+			if (!account) {
+				throw app.httpErrors.notFound('Account not found');
+			}
+			const existing = account.channels[channel];
+			// Retain the number (address/providerRef) so re-enabling restores it.
+			const updated = await accounts.setChannelConfig(accountId, channel, {
+				enabled: false,
+				address: existing.address,
+				providerRef: existing.providerRef,
+			});
+			if (!updated) {
+				throw app.httpErrors.notFound('Account not found');
+			}
+			return toPublicAccount(updated);
+		},
+	);
+};

--- a/packages/api/src/routes/agent-email.ts
+++ b/packages/api/src/routes/agent-email.ts
@@ -1,20 +1,13 @@
-import {
-	type Account,
-	type AccountId,
-	type AgentSlot,
-	type JobId,
-	stripAgentEmailTag,
-	type UserId,
-} from '@rivus/core';
+import { type Account, type AccountId, stripAgentEmailTag } from '@rivus/core';
 import type { FastifyBaseLogger, FastifyError, FastifyPluginAsync, FastifyRequest } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { errorResponseSchema } from '../http-schemas';
-import { ConflictError } from '../repositories/errors';
-import type { UpdateAgentThread } from '../repositories/types';
+import { defaultCapabilities } from '../services/agent/capabilities';
+import type { InboundAgentMessage } from '../services/agent/channel';
+import { createEmailChannelAdapter } from '../services/agent/email/adapter';
 import {
 	agentAddressLocalPart,
-	cleanSubject,
 	EMAIL_BOUNCED_EVENT,
 	EMAIL_COMPLAINED_EVENT,
 	extractReplyText,
@@ -26,32 +19,21 @@ import {
 	parseAddress,
 	resolveAgentRecipient,
 } from '../services/agent/email/inbound';
-import { agentFromHeader } from '../services/agent/email/outbound';
-import { renderAgentEmail } from '../services/agent/email/templates';
 import { verifyWebhookSignature } from '../services/agent/email/webhook';
-import { type AgentDecision, decideScheduling } from '../services/agent/engine';
-import { buildCustomerSignupUrl } from '../services/agent/signup';
-import {
-	BOOKING_HORIZON_DAYS,
-	type BusyInterval,
-	formatSlotLabel,
-	safeTimeZone,
-	zonedParts,
-} from '../services/agent/slots';
-import { DELIVERY_FAILED_REASON } from '../services/inbox';
+import { flagDeliveryFailure, handleInboundAgentMessage } from '../services/agent/orchestrator';
 
 /**
  * The email channel of the scheduling agent: Resend posts every email received
- * at `*@AGENT_EMAIL_DOMAIN` here, and the agent answers by mail — validating
- * the sender against the account's CRM, offering open slots, and booking the
- * job once a time is agreed. The multi-turn state lives on an `AgentThread`;
- * the human-readable exchange is recorded on an inbox `Conversation`.
+ * at `*@AGENT_EMAIL_DOMAIN` here. This route owns only the email edges —
+ * signature verification, the Resend event schema, resolving the account from the
+ * recipient address, fetching the body, and the auto-responder loop guard — then
+ * hands a normalized {@link InboundAgentMessage} to the channel-agnostic
+ * {@link handleInboundAgentMessage}, which runs the same flow (and the same
+ * capabilities) as every other channel.
  *
- * Everything unactionable (an event type we don't handle, mail to an unknown
- * account, auto-responders) answers `200 {handled:false}` rather than an
- * error: the sender is Resend, not the customer, and a non-2xx only makes it
- * redeliver something that will never become actionable. Bouncing is avoided
- * entirely — replying to arbitrary inbound mail is how backscatter happens.
+ * Everything unactionable answers `200 {handled:false}` rather than an error: the
+ * sender is Resend, not the customer, and a non-2xx only makes it redeliver
+ * something that will never become actionable.
  */
 
 const webhookResponseSchema = z
@@ -62,27 +44,6 @@ const webhookResponseSchema = z
 		outcome: z.string(),
 	})
 	.meta({ id: 'AgentEmailWebhookResult' });
-
-/**
- * How far ahead booked jobs are loaded when computing availability — the whole
- * booking horizon (the engine declines proposals past it precisely because
- * nothing beyond this window was fetched), plus slack for timezone edges.
- */
-const BUSY_WINDOW_DAYS = BOOKING_HORIZON_DAYS + 2;
-/**
- * How far back the busy window reaches. Jobs cap at 24h, so anything that
- * started earlier than a day ago can no longer overlap a future slot — and
- * without this reach-back an in-progress job would be invisible to the
- * conflict check (its startAt is in the past) and same-day proposals could
- * double-book over it.
- */
-const BUSY_LOOKBACK_MINUTES = 24 * 60;
-/**
- * Backstop on calendar pages fetched per webhook (100 jobs each). Far above
- * any real account's bookings for a ~9-week window; if it is ever hit the
- * handler fails the delivery rather than silently booking over unseen jobs.
- */
-const MAX_BUSY_PAGES = 100;
 
 /** First value of a possibly-repeated header, as a string. */
 function headerValue(value: string | string[] | undefined): string {
@@ -98,21 +59,23 @@ export const agentEmailRoutes: FastifyPluginAsync = async (fastify) => {
 		config,
 		accounts,
 		customers,
-		jobs,
 		conversations,
 		agentThreads,
 		memberships,
 		mailer,
 		notifier,
 		receivedEmails,
+		jobs,
 	} = app.deps;
+
+	const adapter = createEmailChannelAdapter({ config, customers, mailer });
+	const capabilities = defaultCapabilities();
+	const orchestratorDeps = { config, jobs, conversations, agentThreads };
 
 	/**
 	 * Resolve the account an agent-domain local part addresses. New addresses are
-	 * `${slug}-${tag}` (see {@link agentEmailLocalPart}); older mail may carry the
-	 * bare slug or the raw account id. Try the local part verbatim first (bare
-	 * slug / id), then peel the hex tag and resolve by slug — so every form maps
-	 * back to the same account.
+	 * `${slug}-${tag}`; older mail may carry the bare slug or the raw account id.
+	 * Try the local part verbatim first, then peel the hex tag and resolve by slug.
 	 */
 	async function resolveAccountByLocalPart(localPart: string): Promise<Account | null> {
 		const direct =
@@ -125,11 +88,10 @@ export const agentEmailRoutes: FastifyPluginAsync = async (fastify) => {
 	}
 
 	/**
-	 * A reply Rivus sent bounced or was marked as spam: the customer never got
-	 * it, so flag the thread's conversation for a human and drop an inline note.
-	 * The account is resolved from the delivery event's `From` (our own agent
-	 * address), the thread from the failed recipient. Idempotent — a redelivered
-	 * failure finds the conversation already flagged and no-ops.
+	 * A reply Rivus sent bounced or was marked as spam: the customer never got it,
+	 * so flag the thread's conversation for a human. The account is resolved from
+	 * the delivery event's `From` (our own agent address), the contact from the
+	 * failed recipient.
 	 */
 	async function handleDeliveryFailure(event: InboundEmailEvent, logger: FastifyBaseLogger) {
 		const bounced = event.type === EMAIL_BOUNCED_EVENT;
@@ -149,49 +111,22 @@ export const agentEmailRoutes: FastifyPluginAsync = async (fastify) => {
 		if (!recipient) {
 			return { handled: false, outcome: 'unparseable_recipient' };
 		}
-		const thread = await agentThreads.findByContact(account.id, 'email', recipient.address);
-		if (!thread) {
-			return { handled: false, outcome: 'no_thread' };
-		}
-		const conversation = await conversations.findById(account.id, thread.conversationId);
-		if (!conversation) {
-			return { handled: false, outcome: 'no_conversation' };
-		}
-		// Idempotency: an agent-email conversation only ever reaches
-		// `needs_attention` via a delivery failure, so the flag itself dedupes a
-		// redelivered webhook (or a second failure before the team clears it).
-		if (conversation.status === 'needs_attention') {
-			return { handled: false, outcome: 'already_flagged' };
-		}
-		await conversations.addMessage(account.id, thread.conversationId, {
-			author: 'note',
-			body: bounced
-				? `Rivus's last email to ${recipient.address} bounced — they didn't receive it. Follow up another way.`
-				: `${recipient.address} marked Rivus's last email as spam — reach out another way before emailing again.`,
-		});
-		await conversations.setReviewState(account.id, thread.conversationId, {
-			status: 'needs_attention',
-			pendingReply: '',
-			flagReason: DELIVERY_FAILED_REASON,
-		});
-		// No human actor for a webhook — notify the whole team.
-		const memberIds = (await memberships.listByAccount(account.id)).map(
-			(membership) => membership.userId,
-		);
-		await notifier.conversationNeedsReview({
-			accountId: account.id,
-			actorId: '' as UserId,
-			memberIds,
-			contactName: conversation.contactName,
+		const noteBody = bounced
+			? `Rivus's last email to ${recipient.address} bounced — they didn't receive it. Follow up another way.`
+			: `${recipient.address} marked Rivus's last email as spam — reach out another way before emailing again.`;
+		return flagDeliveryFailure({
+			deps: { conversations, agentThreads, memberships, notifier },
+			account,
+			channel: 'email',
+			contactAddress: recipient.address,
+			noteBody,
+			outcome: bounced ? 'delivery_bounced' : 'delivery_complained',
 			logger,
 		});
-		return { handled: true, outcome: bounced ? 'delivery_bounced' : 'delivery_complained' };
 	}
 
 	// Webhook signatures cover the exact bytes Resend sent, so this plugin scope
 	// re-parses JSON from a string and keeps the raw payload for verification.
-	// Content-type parsers are encapsulated per plugin, so the rest of the API
-	// keeps Fastify's stock parser.
 	const rawBodies = new WeakMap<FastifyRequest, string>();
 	app.addContentTypeParser('application/json', { parseAs: 'string' }, (request, payload, done) => {
 		rawBodies.set(request as FastifyRequest, payload as string);
@@ -211,8 +146,6 @@ export const agentEmailRoutes: FastifyPluginAsync = async (fastify) => {
 		const secret = config.RESEND_WEBHOOK_SECRET;
 		if (!secret) {
 			if (config.NODE_ENV === 'production') {
-				// Sent directly (not thrown): the central error handler flattens
-				// thrown 5xx into a generic 500, and 503 is the honest status here.
 				return reply.code(503).send({
 					error: 'Service Unavailable',
 					message: 'The email channel is not configured (RESEND_WEBHOOK_SECRET is unset).',
@@ -235,32 +168,6 @@ export const agentEmailRoutes: FastifyPluginAsync = async (fastify) => {
 			throw app.httpErrors.unauthorized('Invalid webhook signature');
 		}
 	});
-
-	/** Booked (non-canceled) windows that could collide with a slot, paged out of the jobs repo. */
-	async function loadBusyIntervals(accountId: AccountId, now: Date): Promise<BusyInterval[]> {
-		const from = new Date(now.getTime() - BUSY_LOOKBACK_MINUTES * 60_000).toISOString();
-		const to = new Date(now.getTime() + BUSY_WINDOW_DAYS * 24 * 60 * 60_000).toISOString();
-		const busy: BusyInterval[] = [];
-		for (let page = 1; ; page += 1) {
-			const { jobs: batch, total } = await jobs.list({ accountId, page, pageSize: 100, from, to });
-			for (const job of batch) {
-				if (job.status !== 'canceled') {
-					busy.push({ startAt: job.startAt, durationMinutes: job.durationMinutes });
-				}
-			}
-			if (page * 100 >= total || batch.length === 0) {
-				break;
-			}
-			if (page >= MAX_BUSY_PAGES) {
-				// An incomplete calendar must not look like an open one — offering or
-				// booking against it could double-book. Fail the delivery instead.
-				throw app.httpErrors.internalServerError(
-					'Calendar too large to load for availability; the delivery will be retried.',
-				);
-			}
-		}
-		return busy;
-	}
 
 	app.post(
 		'/email/inbound',
@@ -299,8 +206,7 @@ export const agentEmailRoutes: FastifyPluginAsync = async (fastify) => {
 				return { handled: false, outcome: 'ignored_event_type' };
 			}
 
-			// Which account was written to? The local part of the agent-domain
-			// recipient is the account's slug (or raw id — Rivus's "customer id").
+			// Which account was written to? The local part of the agent-domain recipient.
 			const localPart = resolveAgentRecipient(event, config.AGENT_EMAIL_DOMAIN);
 			if (!localPart) {
 				return { handled: false, outcome: 'no_agent_recipient' };
@@ -315,8 +221,8 @@ export const agentEmailRoutes: FastifyPluginAsync = async (fastify) => {
 				return { handled: false, outcome: 'unparseable_sender' };
 			}
 
-			// The webhook carries metadata only; pull the body/headers/Message-ID
-			// from the received-emails API unless the payload embedded them.
+			// The webhook carries metadata only; pull the body/headers/Message-ID from
+			// the received-emails API unless the payload embedded them.
 			let text = event.data.text ?? '';
 			let html = event.data.html ?? '';
 			let headers = event.data.headers ?? {};
@@ -324,10 +230,8 @@ export const agentEmailRoutes: FastifyPluginAsync = async (fastify) => {
 			if (text === '' && html === '' && event.data.email_id !== '') {
 				const fetched = await receivedEmails.get(event.data.email_id);
 				if (!fetched) {
-					// The reader failing (rate limit, transient 5xx, or no API key
-					// configured) must not be mistaken for an empty email — a 2xx here
-					// would permanently drop the customer's words, since Resend never
-					// redelivers an acknowledged event. A 5xx makes it retry later.
+					// A 2xx here would permanently drop the customer's words (Resend never
+					// redelivers an acknowledged event); a 5xx makes it retry later.
 					throw app.httpErrors.internalServerError(
 						'Could not fetch the inbound email body; the delivery will be retried.',
 					);
@@ -350,210 +254,20 @@ export const agentEmailRoutes: FastifyPluginAsync = async (fastify) => {
 			}
 
 			const rawText = text !== '' ? text : htmlToText(html);
-			const messageText = extractReplyText(rawText) || rawText.trim();
-			const subject = event.data.subject;
-
-			const customer = await customers.findByEmail(account.id, sender.address);
-
-			// One thread per (account, email, sender): find it or open it together
-			// with the inbox conversation that carries the transcript.
-			let thread = await agentThreads.findByContact(account.id, 'email', sender.address);
-			if (!thread) {
-				const conversation = await conversations.create(account.id, {
-					contactName: customer?.name || sender.name || sender.address,
-					channel: 'email',
-					customerId: customer?.id ?? '',
-					contactPhone: customer?.phone ?? '',
-					status: 'rivus_handling',
-					tags: [],
-					lastInvoice: '',
-				});
-				try {
-					thread = await agentThreads.create({
-						accountId: account.id,
-						channel: 'email',
-						contactAddress: sender.address,
-						conversationId: conversation.id,
-						customerId: customer?.id ?? '',
-						subject,
-					});
-				} catch (error) {
-					if (!(error instanceof ConflictError)) {
-						throw error;
-					}
-					// A concurrent delivery from the same brand-new contact won the
-					// create. Drop the conversation this loser opened and continue on
-					// the winner's thread instead of surfacing a 409 for Resend to retry.
-					await conversations.delete(account.id, conversation.id);
-					thread = await agentThreads.findByContact(account.id, 'email', sender.address);
-					if (!thread) {
-						throw error;
-					}
-				}
-			} else if (messageId !== '' && thread.lastExternalMessageId === messageId) {
-				// Webhook delivery is at-least-once: an email we already answered
-				// (same Message-ID as the thread's last processed inbound) is a
-				// redelivery, not a new customer turn.
-				return { handled: false, outcome: 'duplicate_delivery' };
-			}
-
-			// Record the customer's turn. If the team deleted the conversation since
-			// the thread opened, recreate it so the exchange stays visible.
-			const transcriptBody = messageText || cleanSubject(subject) || '(empty message)';
-			const appended = await conversations.addMessage(account.id, thread.conversationId, {
-				author: 'customer',
-				body: transcriptBody,
+			const message: InboundAgentMessage = {
+				sender: { address: sender.address, name: sender.name },
+				text: extractReplyText(rawText) || rawText.trim(),
+				subject: event.data.subject,
+				externalMessageId: messageId,
+			};
+			return handleInboundAgentMessage({
+				deps: orchestratorDeps,
+				adapter,
+				capabilities,
+				account,
+				message,
+				logger: request.log,
 			});
-			if (!appended) {
-				const conversation = await conversations.create(account.id, {
-					contactName: customer?.name || sender.name || sender.address,
-					channel: 'email',
-					customerId: customer?.id ?? '',
-					contactPhone: customer?.phone ?? '',
-					status: 'rivus_handling',
-					tags: [],
-					lastInvoice: '',
-				});
-				await conversations.addMessage(account.id, conversation.id, {
-					author: 'customer',
-					body: transcriptBody,
-				});
-				thread =
-					(await agentThreads.update(account.id, thread.id, {
-						conversationId: conversation.id,
-					})) ?? thread;
-			}
-
-			// A sender who just self-signed-up gets linked to the thread and the
-			// conversation the first time they write after registering.
-			if (customer && thread.customerId === '') {
-				await conversations.update(account.id, thread.conversationId, {
-					customerId: customer.id,
-					contactName: customer.name,
-					...(customer.phone !== '' ? { contactPhone: customer.phone } : {}),
-				});
-			}
-
-			const timeZone = safeTimeZone(account.timezone);
-			const now = new Date();
-			const busy = await loadBusyIntervals(account.id, now);
-			// The job already booked on this thread (while still upcoming and not
-			// called off), so "see you Tuesday at 9!" confirms it instead of
-			// colliding with it.
-			let bookedSlot: AgentSlot | null = null;
-			if (thread.state === 'booked' && thread.bookedJobId !== '') {
-				const bookedJob = await jobs.findById(account.id, thread.bookedJobId as JobId);
-				if (
-					bookedJob &&
-					bookedJob.status !== 'canceled' &&
-					Date.parse(bookedJob.startAt) + bookedJob.durationMinutes * 60_000 > now.getTime()
-				) {
-					bookedSlot = { startAt: bookedJob.startAt, durationMinutes: bookedJob.durationMinutes };
-				}
-			}
-			const decision = decideScheduling({
-				customerKnown: customer !== null,
-				text: messageText,
-				offeredSlots: thread.state === 'slots_offered' ? thread.offeredSlots : [],
-				busy,
-				timeZone,
-				now,
-				bookedSlot,
-			});
-
-			// The job carries the customer's own words as its title when they wrote a
-			// subject ("Water heater is leaking"), so the calendar reads like the ask.
-			const jobTitle = cleanSubject(subject) || cleanSubject(thread.subject) || 'Appointment';
-			let bookedJobId = '';
-			if (decision.kind === 'book' && customer) {
-				const job = await jobs.create(account.id, {
-					title: jobTitle,
-					customerId: customer.id,
-					assignedUserId: '',
-					startAt: decision.slot.startAt,
-					durationMinutes: decision.slot.durationMinutes,
-					status: 'confirmed',
-					address: customer.address,
-					notes: `Booked by Rivus over email with ${customer.name}.`,
-					estimatedValue: 0,
-				});
-				bookedJobId = job.id;
-			}
-
-			// Reply as the account's own agent address, threaded into the customer's
-			// email client via In-Reply-To/References.
-			const rendered = renderAgentEmail(decision, {
-				accountName: account.name,
-				customerName: customer?.name ?? sender.name,
-				timeZone,
-				signupUrl: buildCustomerSignupUrl(config.WEBSITE_URL, account.slug, sender.address),
-				jobTitle,
-				inboundSubject: subject !== '' ? subject : thread.subject,
-				now,
-			});
-			// Always reply from the account's canonical tagged address, regardless of
-			// which form (tagged or legacy bare slug) the customer happened to write to.
-			try {
-				await mailer.sendAgentEmail({
-					to: sender.address,
-					from: agentFromHeader(account, config.AGENT_EMAIL_DOMAIN),
-					subject: rendered.subject,
-					html: rendered.html,
-					text: rendered.text,
-					inReplyTo: messageId,
-					references: messageId === '' ? [] : [messageId],
-				});
-			} catch (error) {
-				// The confirmation never reached the customer, so the booking must not
-				// stand: an unconfirmed job would make the redelivered webhook see its
-				// own slot as taken. Undo it and let the 500 trigger a redelivery
-				// (thread state hasn't advanced, so the retry reprocesses cleanly).
-				if (bookedJobId !== '') {
-					await jobs.delete(account.id, bookedJobId as JobId).catch(() => false);
-				}
-				throw error;
-			}
-
-			await conversations.addMessage(account.id, thread.conversationId, {
-				author: 'rivus',
-				body: rendered.text,
-			});
-			if (decision.kind === 'book') {
-				await conversations.addMessage(account.id, thread.conversationId, {
-					author: 'note',
-					body: `Rivus booked ${jobTitle} for ${formatSlotLabel(decision.slot.startAt, timeZone, zonedParts(now, timeZone).year)}.`,
-				});
-			}
-
-			await agentThreads.update(account.id, thread.id, {
-				...threadPatchFor(decision, bookedJobId),
-				customerId: customer?.id ?? thread.customerId,
-				lastExternalMessageId: messageId,
-				subject: subject !== '' ? subject : thread.subject,
-			});
-
-			return { handled: true, outcome: decision.kind };
 		},
 	);
 };
-
-/** How each decision advances the thread's machine state. */
-function threadPatchFor(decision: AgentDecision, bookedJobId: string): UpdateAgentThread {
-	switch (decision.kind) {
-		case 'send_signup_link':
-			return { state: 'awaiting_signup', offeredSlots: [] };
-		case 'offer_slots':
-			return { state: 'slots_offered', offeredSlots: decision.slots };
-		case 'confirm_existing':
-			// The thread stays booked exactly as it was.
-			return {};
-		case 'propose_unavailable':
-			return decision.alternatives.length > 0
-				? { state: 'slots_offered', offeredSlots: decision.alternatives }
-				: { state: 'new', offeredSlots: [] };
-		case 'no_availability':
-			return { state: 'new', offeredSlots: [] };
-		case 'book':
-			return { state: 'booked', offeredSlots: [], bookedJobId };
-	}
-}

--- a/packages/api/src/routes/agent-whatsapp.ts
+++ b/packages/api/src/routes/agent-whatsapp.ts
@@ -1,0 +1,232 @@
+import { normalizePhone } from '@rivus/core';
+import type { FastifyError, FastifyPluginAsync, FastifyRequest } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { errorResponseSchema } from '../http-schemas';
+import { defaultCapabilities } from '../services/agent/capabilities';
+import type { InboundAgentMessage } from '../services/agent/channel';
+import { flagDeliveryFailure, handleInboundAgentMessage } from '../services/agent/orchestrator';
+import { verifyWebhookSignature } from '../services/agent/webhook';
+import { createWhatsappChannelAdapter } from '../services/agent/whatsapp/adapter';
+import {
+	parseZernioInbound,
+	WHATSAPP_FAILED_EVENT,
+	WHATSAPP_MESSAGE_EVENT,
+} from '../services/agent/whatsapp/inbound';
+
+/**
+ * The WhatsApp channel of the scheduling agent: zernio posts every message to the
+ * account's provisioned business number here. This route owns only the WhatsApp
+ * edges — signature verification, the verify-token handshake, the zernio payload
+ * shape, resolving the account from the business number, and the loop/unsupported
+ * guards — then hands a normalized {@link InboundAgentMessage} to the same
+ * channel-agnostic {@link handleInboundAgentMessage} the email channel uses, so
+ * WhatsApp inherits scheduling, the inbox, FAQ drafts, and delivery-failure
+ * handling with no channel-specific feature code.
+ *
+ * Everything unactionable answers `200 {handled:false}` (never a non-2xx that
+ * would make zernio redeliver something that will never become actionable).
+ */
+
+const webhookResponseSchema = z
+	.object({
+		handled: z.boolean(),
+		outcome: z.string(),
+	})
+	.meta({ id: 'AgentWhatsappWebhookResult' });
+
+const verifyQuerySchema = z.object({
+	'hub.mode': z.string().optional(),
+	'hub.verify_token': z.string().optional(),
+	'hub.challenge': z.string().optional(),
+});
+
+/** First value of a possibly-repeated header, as a string. */
+function headerValue(value: string | string[] | undefined): string {
+	if (Array.isArray(value)) {
+		return value[0] ?? '';
+	}
+	return value ?? '';
+}
+
+export const agentWhatsappRoutes: FastifyPluginAsync = async (fastify) => {
+	const app = fastify.withTypeProvider<ZodTypeProvider>();
+	const {
+		config,
+		accounts,
+		customers,
+		conversations,
+		agentThreads,
+		memberships,
+		notifier,
+		whatsappSender,
+		jobs,
+	} = app.deps;
+
+	const adapter = createWhatsappChannelAdapter({ customers, sender: whatsappSender });
+	const capabilities = defaultCapabilities();
+	const orchestratorDeps = { config, jobs, conversations, agentThreads };
+
+	// Raw body kept byte-for-byte for signature verification (see the email route).
+	const rawBodies = new WeakMap<FastifyRequest, string>();
+	app.addContentTypeParser('application/json', { parseAs: 'string' }, (request, payload, done) => {
+		rawBodies.set(request as FastifyRequest, payload as string);
+		try {
+			done(null, JSON.parse(payload as string));
+		} catch {
+			const error = new Error('Body is not valid JSON') as FastifyError;
+			error.statusCode = 400;
+			done(error, undefined);
+		}
+	});
+
+	// Authenticity gate for the POST webhook, before any parsing.
+	app.addHook('preValidation', async (request, reply) => {
+		if (request.method !== 'POST') {
+			return;
+		}
+		const secret = config.ZERNIO_WEBHOOK_SECRET;
+		if (!secret) {
+			if (config.NODE_ENV === 'production') {
+				return reply.code(503).send({
+					error: 'Service Unavailable',
+					message: 'The WhatsApp channel is not configured (ZERNIO_WEBHOOK_SECRET is unset).',
+					statusCode: 503,
+				});
+			}
+			return;
+		}
+		// TODO(zernio): confirm zernio's signature header names.
+		const verified = verifyWebhookSignature({
+			secret,
+			headers: {
+				id: headerValue(request.headers['zernio-id']),
+				timestamp: headerValue(request.headers['zernio-timestamp']),
+				signature: headerValue(request.headers['zernio-signature']),
+			},
+			payload: rawBodies.get(request) ?? '',
+			now: new Date(),
+		});
+		if (!verified) {
+			throw app.httpErrors.unauthorized('Invalid webhook signature');
+		}
+	});
+
+	// Provider webhook-registration handshake: echo the challenge when the verify
+	// token matches. Inert (404) until ZERNIO_VERIFY_TOKEN is configured.
+	// TODO(zernio): confirm whether zernio uses this Meta-style handshake.
+	app.get(
+		'/whatsapp/inbound',
+		{
+			schema: {
+				tags: ['channels'],
+				summary: 'zernio WhatsApp webhook verification handshake',
+				querystring: verifyQuerySchema,
+				response: { 200: z.string(), 404: errorResponseSchema },
+			},
+		},
+		async (request, reply) => {
+			const token = config.ZERNIO_VERIFY_TOKEN;
+			const query = request.query;
+			if (token && query['hub.verify_token'] === token && query['hub.challenge'] !== undefined) {
+				return reply.code(200).send(query['hub.challenge']);
+			}
+			throw app.httpErrors.notFound('Not found');
+		},
+	);
+
+	app.post(
+		'/whatsapp/inbound',
+		{
+			schema: {
+				tags: ['channels'],
+				summary: 'zernio WhatsApp webhook (inbound customer messages + delivery status)',
+				description:
+					'zernio delivers WhatsApp events for the account’s provisioned business ' +
+					'number here. On an inbound message Rivus validates the sender against the ' +
+					'account’s customers (by phone), keeps the multi-turn scheduling state on the ' +
+					'thread, and replies over WhatsApp. On a delivery failure it flags the ' +
+					'conversation for a human. Deliveries are authenticated with the signature ' +
+					'header when ZERNIO_WEBHOOK_SECRET is configured.',
+				body: z.unknown(),
+				response: {
+					200: webhookResponseSchema,
+					401: errorResponseSchema,
+					503: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const event = parseZernioInbound(request.body);
+			if (!event) {
+				return { handled: false, outcome: 'unrecognized_payload' };
+			}
+
+			// Delivery failure: a message Rivus sent never reached the customer.
+			if (event.type === WHATSAPP_FAILED_EVENT) {
+				const businessNumber = normalizePhone(event.data.from);
+				const account = await accounts.findByChannelAddress('whatsapp', businessNumber);
+				if (!account || account.status === 'canceled') {
+					return { handled: false, outcome: 'unknown_account' };
+				}
+				const customerNumber = normalizePhone(event.data.to);
+				if (customerNumber === '') {
+					return { handled: false, outcome: 'unparseable_recipient' };
+				}
+				return flagDeliveryFailure({
+					deps: { conversations, agentThreads, memberships, notifier },
+					account,
+					channel: 'whatsapp',
+					contactAddress: customerNumber,
+					noteBody: `Rivus's last WhatsApp message to ${customerNumber} couldn't be delivered — follow up another way.`,
+					outcome: 'delivery_failed',
+					logger: request.log,
+				});
+			}
+
+			if (event.type !== WHATSAPP_MESSAGE_EVENT) {
+				return { handled: false, outcome: 'ignored_event_type' };
+			}
+
+			// Which account owns the business number this was sent to?
+			const businessNumber = normalizePhone(event.data.to);
+			const account = await accounts.findByChannelAddress('whatsapp', businessNumber);
+			if (!account || account.status === 'canceled') {
+				return { handled: false, outcome: 'unknown_account' };
+			}
+			// A disabled channel is off: acknowledge without replying (never a retry).
+			if (!account.channels.whatsapp.enabled) {
+				return { handled: false, outcome: 'channel_disabled' };
+			}
+
+			const senderNumber = normalizePhone(event.data.from);
+			if (senderNumber === '') {
+				return { handled: false, outcome: 'unparseable_sender' };
+			}
+			// Loop guard: never converse with any account's own business number, so two
+			// Rivus accounts can't schedule each other forever.
+			if (await accounts.findByChannelAddress('whatsapp', senderNumber)) {
+				return { handled: false, outcome: 'own_number' };
+			}
+			// v1 handles text only; a media/location/voice message gets no reply.
+			if (event.data.text.trim() === '') {
+				return { handled: false, outcome: 'unsupported_message_type' };
+			}
+
+			const message: InboundAgentMessage = {
+				sender: { address: senderNumber, name: event.data.profileName },
+				text: event.data.text,
+				subject: '',
+				externalMessageId: event.data.messageId,
+			};
+			return handleInboundAgentMessage({
+				deps: orchestratorDeps,
+				adapter,
+				capabilities,
+				account,
+				message,
+				logger: request.log,
+			});
+		},
+	);
+};

--- a/packages/api/src/routes/conversations.ts
+++ b/packages/api/src/routes/conversations.ts
@@ -23,8 +23,8 @@ import {
 	idParamsSchema,
 	needsAttentionCountResponseSchema,
 } from '../http-schemas';
-import { agentFromHeader } from '../services/agent/email/outbound';
-import { renderReplyEmail } from '../services/agent/email/templates';
+import { createChannelAdapters } from '../services/agent/channels';
+import { freeTextResponse } from '../services/agent/response';
 import { awaitingRivusReply, decideRivusReply, latestCustomerMessage } from '../services/inbox';
 
 // The newest page of FAQs handed to Rivus as the knowledge base when drafting a
@@ -54,17 +54,12 @@ async function assertCustomerExists(
 
 export const conversationRoutes: FastifyPluginAsync = async (fastify) => {
 	const app = fastify.withTypeProvider<ZodTypeProvider>();
-	const {
-		accounts,
-		agentThreads,
-		config,
-		conversations,
-		faqs,
-		faqAnswer,
-		mailer,
-		memberships,
-		notifier,
-	} = app.deps;
+	const { accounts, agentThreads, conversations, faqs, faqAnswer, memberships, notifier } =
+		app.deps;
+	// One adapter per channel with an outbound transport; absent channels (phone,
+	// and sms/voice until built) simply have no entry — a reply on them is recorded
+	// without being sent, exactly as before.
+	const adapters = createChannelAdapters(app.deps);
 
 	// Every conversation route requires a valid JWT.
 	app.addHook('onRequest', fastify.authenticate);
@@ -83,35 +78,38 @@ export const conversationRoutes: FastifyPluginAsync = async (fastify) => {
 	}
 
 	/**
-	 * Deliver a customer-facing reply to an email conversation as an actual email.
+	 * Deliver a customer-facing reply (a human's message or an approved Rivus
+	 * draft) out over the conversation's own channel.
 	 *
-	 * The inbox transcript is only a record of the thread; on the `email` channel
-	 * a reply also has to leave the building, or the team believes they answered
-	 * while the customer heard nothing (the reported bug). The scheduling agent
-	 * opens every email conversation alongside an agent thread that holds the
-	 * customer's address and the last inbound message id, so we send from the
-	 * account's own agent address, threaded under the customer's latest message —
-	 * exactly like the agent's own replies. Conversations on other channels, or an
-	 * email conversation with no linked thread (no recipient on file), have no
-	 * transport, so this is a no-op for them.
+	 * The inbox transcript is only a record; a reply also has to leave the
+	 * building, or the team believes they answered while the customer heard
+	 * nothing. The scheduling agent opens every conversation alongside an agent
+	 * thread holding the contact's address and the last inbound id, so the reply
+	 * goes out through that channel's adapter (email from the account's agent
+	 * address threaded under the last message; WhatsApp as a chat message from the
+	 * business number) — exactly like the agent's own replies. A channel with no
+	 * adapter (phone, and sms/voice until built), a conversation with no linked
+	 * thread, or a disabled WhatsApp channel has no transport, so this is a no-op
+	 * for it.
 	 *
-	 * Sent *before* the message is recorded: a delivery failure then surfaces as
-	 * an error with nothing written — so the caller can retry — rather than
-	 * leaving a transcript line for an email that never sent.
+	 * Sent *before* the message is recorded: a delivery failure surfaces as an
+	 * error with nothing written — so the caller can retry — rather than leaving a
+	 * transcript line for a reply that never went out.
 	 */
-	async function sendEmailReply(
+	async function sendChannelReply(
 		conversation: Conversation,
 		body: string,
 		logger: FastifyBaseLogger,
 	): Promise<void> {
-		if (conversation.channel !== 'email') {
+		const adapter = adapters[conversation.channel];
+		if (!adapter) {
 			return;
 		}
 		const thread = await agentThreads.findByConversationId(conversation.accountId, conversation.id);
 		if (!thread || thread.contactAddress === '') {
 			logger.warn(
-				{ conversationId: conversation.id },
-				'email conversation has no linked agent thread; reply recorded but not emailed',
+				{ conversationId: conversation.id, channel: conversation.channel },
+				'conversation has no linked agent thread; reply recorded but not sent',
 			);
 			return;
 		}
@@ -119,21 +117,21 @@ export const conversationRoutes: FastifyPluginAsync = async (fastify) => {
 		if (!account) {
 			return;
 		}
-		const rendered = renderReplyEmail({
-			accountName: account.name,
-			inboundSubject: thread.subject,
-			body,
-		});
-		await mailer.sendAgentEmail({
-			to: thread.contactAddress,
-			from: agentFromHeader(account, config.AGENT_EMAIL_DOMAIN),
-			subject: rendered.subject,
-			html: rendered.html,
-			text: rendered.text,
-			// Thread under the customer's last inbound message so the reply lands in
-			// the same conversation in their mail client; empty when we never saw one.
-			inReplyTo: thread.lastExternalMessageId,
-			references: thread.lastExternalMessageId === '' ? [] : [thread.lastExternalMessageId],
+		// A disabled WhatsApp channel is off: record the reply but don't send it.
+		if (conversation.channel === 'whatsapp' && !account.channels.whatsapp.enabled) {
+			logger.warn(
+				{ conversationId: conversation.id },
+				'whatsapp channel is disabled; reply recorded but not sent',
+			);
+			return;
+		}
+		await adapter.deliver(freeTextResponse(body), {
+			account,
+			thread,
+			to: { address: thread.contactAddress, name: conversation.contactName },
+			// Thread under the contact's last inbound message; empty when we never saw one.
+			replyToExternalId: thread.lastExternalMessageId,
+			subject: thread.subject,
 		});
 	}
 
@@ -316,7 +314,7 @@ export const conversationRoutes: FastifyPluginAsync = async (fastify) => {
 			// On the email channel the reply is emailed to the customer before it's
 			// recorded, so a send failure surfaces instead of a transcript line for
 			// an email that never left.
-			await sendEmailReply(before, request.body.body, request.log);
+			await sendChannelReply(before, request.body.body, request.log);
 			const detail = await conversations.addMessage(accountId, id, {
 				author: 'agent',
 				body: request.body.body,
@@ -394,7 +392,7 @@ export const conversationRoutes: FastifyPluginAsync = async (fastify) => {
 			if (!decision.pause) {
 				// Confident, everyday answer: Rivus sends it and keeps handling the thread —
 				// over email, that means actually mailing it to the customer.
-				await sendEmailReply(conversation, decision.draft, request.log);
+				await sendChannelReply(conversation, decision.draft, request.log);
 				const detail = await conversations.addMessage(accountId, id, {
 					author: 'rivus',
 					body: decision.draft,
@@ -475,7 +473,7 @@ export const conversationRoutes: FastifyPluginAsync = async (fastify) => {
 				throw app.httpErrors.badRequest('There is nothing to send — write a reply first.');
 			}
 			// "Approve & send" has to actually send on the email channel.
-			await sendEmailReply(conversation, finalText, request.log);
+			await sendChannelReply(conversation, finalText, request.log);
 			const detail = await conversations.addMessage(accountId, id, {
 				author: 'rivus',
 				body: finalText,

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -22,6 +22,7 @@ import { createFaqAnswerService } from './services/faq-answer';
 import { createFaqSimilarityService } from './services/faq-similarity';
 import { createNotificationService } from './services/notifications';
 import { createMailer } from './services/resend-mailer';
+import { createWhatsappProvisioner, createWhatsappSender } from './services/zernio-whatsapp';
 
 /** Connect to Mongo, build the app with Mongo-backed repositories, and listen. */
 export async function start(): Promise<void> {
@@ -46,6 +47,8 @@ export async function start(): Promise<void> {
 		verificationCodes: new MongoVerificationCodeRepository(),
 		mailer: createMailer(config),
 		receivedEmails: createReceivedEmailReader(config),
+		whatsappSender: createWhatsappSender(config),
+		whatsappProvisioner: createWhatsappProvisioner(config),
 		notifier: createNotificationService({ notifications }),
 		faqSimilarity: createFaqSimilarityService(config),
 		faqAnswer: createFaqAnswerService(config),

--- a/packages/api/src/services/agent/capabilities.ts
+++ b/packages/api/src/services/agent/capabilities.ts
@@ -1,0 +1,233 @@
+import type {
+	Account,
+	AccountId,
+	AgentThread,
+	ConversationChannel,
+	CreateJobInput,
+	Customer,
+	JobId,
+} from '@rivus/core';
+import type { UpdateAgentThread } from '../../repositories/types';
+import type { AppDeps } from '../../types';
+import type { ChannelCapabilities, InboundAgentMessage } from './channel';
+import { type AgentDecision, decideScheduling } from './engine';
+import { type AgentResponse, composeAgentResponse } from './response';
+import { BOOKING_HORIZON_DAYS, type BusyInterval, formatSlotLabel, zonedParts } from './slots';
+
+/**
+ * The core agent's feature layer. A capability is the ONLY thing a new feature
+ * adds: registered once in {@link defaultCapabilities}, it runs on every channel
+ * the shared orchestrator drives (email, WhatsApp, and every future one) because
+ * the orchestrator is channel-agnostic and the capability speaks only the
+ * channel-neutral {@link AgentResponse}. No channel is edited to gain it.
+ */
+
+/** A 5xx-on-purpose: the provider must redeliver (an incomplete calendar, a failed send). */
+export class RetryDeliveryError extends Error {
+	readonly statusCode = 500;
+	constructor(message: string) {
+		super(message);
+		this.name = 'RetryDeliveryError';
+	}
+}
+
+/** The repositories + config a capability (and the orchestrator) may read. */
+export type OrchestratorDeps = Pick<AppDeps, 'config' | 'jobs' | 'conversations' | 'agentThreads'>;
+
+/** Everything a capability may read to decide and act on one customer turn. */
+export interface TurnContext {
+	account: Account;
+	customer: Customer | null;
+	thread: AgentThread;
+	message: InboundAgentMessage;
+	caps: ChannelCapabilities;
+	timeZone: string;
+	now: Date;
+	/** Absolute self-signup URL, prefilled for this channel by the adapter. */
+	signupUrl: string;
+	/** The service title for a booking ("Water heater install" / "Appointment"). */
+	jobTitle: string;
+	deps: OrchestratorDeps;
+}
+
+/** Declarative side effects the ORCHESTRATOR executes (and rolls back on send failure). */
+export interface CapabilitySideEffects {
+	/** Create this job before delivering; deleted again if delivery fails. */
+	bookJob?: CreateJobInput & {
+		/** The inline transcript note recorded after a successful send. */
+		note: string;
+	};
+}
+
+export interface CapabilityOutcome {
+	response: AgentResponse;
+	/** Reported to the provider + logs ('offer_slots', 'book', …). */
+	outcome: string;
+	/** How the thread's machine state advances (the `bookedJobId` is filled by the orchestrator). */
+	threadPatch: UpdateAgentThread;
+	sideEffects?: CapabilitySideEffects;
+}
+
+/**
+ * A core agent feature. `matches` claims a turn; `handle` produces a neutral
+ * response + declarative effects. The orchestrator dispatches to the first
+ * capability whose `matches` returns true (order = priority; the last must
+ * always match), identically on every channel.
+ */
+export interface AgentCapability {
+	readonly id: string;
+	matches(ctx: TurnContext): boolean;
+	handle(ctx: TurnContext): Promise<CapabilityOutcome>;
+}
+
+// How far ahead/back booked jobs are loaded when computing availability — the whole
+// booking horizon (the engine declines proposals past it precisely because nothing
+// beyond this window was fetched) plus slack for timezone edges, and a day back so an
+// in-progress job (its startAt already past) still blocks same-day proposals.
+const BUSY_WINDOW_DAYS = BOOKING_HORIZON_DAYS + 2;
+const BUSY_LOOKBACK_MINUTES = 24 * 60;
+// Backstop on calendar pages fetched per turn (100 jobs each). Far above any real
+// account's ~9-week bookings; if hit, fail the delivery rather than book over unseen jobs.
+const MAX_BUSY_PAGES = 100;
+
+/** Booked (non-canceled) windows that could collide with a slot, paged out of the jobs repo. */
+export async function loadBusyIntervals(
+	jobs: OrchestratorDeps['jobs'],
+	accountId: AccountId,
+	now: Date,
+): Promise<BusyInterval[]> {
+	const from = new Date(now.getTime() - BUSY_LOOKBACK_MINUTES * 60_000).toISOString();
+	const to = new Date(now.getTime() + BUSY_WINDOW_DAYS * 24 * 60 * 60_000).toISOString();
+	const busy: BusyInterval[] = [];
+	for (let page = 1; ; page += 1) {
+		const { jobs: batch, total } = await jobs.list({ accountId, page, pageSize: 100, from, to });
+		for (const job of batch) {
+			if (job.status !== 'canceled') {
+				busy.push({ startAt: job.startAt, durationMinutes: job.durationMinutes });
+			}
+		}
+		if (page * 100 >= total || batch.length === 0) {
+			break;
+		}
+		if (page >= MAX_BUSY_PAGES) {
+			throw new RetryDeliveryError(
+				'Calendar too large to load for availability; the delivery will be retried.',
+			);
+		}
+	}
+	return busy;
+}
+
+/** How each scheduling decision advances the thread's machine state (`bookedJobId` filled later). */
+export function threadPatchFor(decision: AgentDecision): UpdateAgentThread {
+	switch (decision.kind) {
+		case 'send_signup_link':
+			return { state: 'awaiting_signup', offeredSlots: [] };
+		case 'offer_slots':
+			return { state: 'slots_offered', offeredSlots: decision.slots };
+		case 'confirm_existing':
+			// The thread stays booked exactly as it was.
+			return {};
+		case 'propose_unavailable':
+			return decision.alternatives.length > 0
+				? { state: 'slots_offered', offeredSlots: decision.alternatives }
+				: { state: 'new', offeredSlots: [] };
+		case 'no_availability':
+			return { state: 'new', offeredSlots: [] };
+		case 'book':
+			return { state: 'booked', offeredSlots: [] };
+	}
+}
+
+/** Human-readable channel name for the "Booked by Rivus over …" job note. */
+function channelLabel(channel: ConversationChannel): string {
+	switch (channel) {
+		case 'email':
+			return 'email';
+		case 'whatsapp':
+			return 'WhatsApp';
+		case 'sms':
+			return 'SMS';
+		case 'phone':
+			return 'phone';
+	}
+}
+
+/**
+ * The v1 capability: scheduling. Wraps the pure {@link decideScheduling} engine,
+ * composes its decision into a neutral response, and declares a booking as a
+ * side effect. `matches` is the always-on fallback (it must be last in the
+ * registry). A future `cancelCapability`/`rescheduleCapability` slots in ahead of
+ * it and instantly works on every channel.
+ */
+export const schedulingCapability: AgentCapability = {
+	id: 'scheduling',
+	matches: () => true,
+	async handle(ctx: TurnContext): Promise<CapabilityOutcome> {
+		const { account, customer, thread, message, caps, timeZone, now, deps } = ctx;
+		const busy = await loadBusyIntervals(deps.jobs, account.id, now);
+		// The job already booked on this thread (while still upcoming and not called
+		// off), so a bare "see you then!" confirms it instead of colliding with it.
+		let bookedSlot = null;
+		if (thread.state === 'booked' && thread.bookedJobId !== '') {
+			const bookedJob = await deps.jobs.findById(account.id, thread.bookedJobId as JobId);
+			if (
+				bookedJob &&
+				bookedJob.status !== 'canceled' &&
+				Date.parse(bookedJob.startAt) + bookedJob.durationMinutes * 60_000 > now.getTime()
+			) {
+				bookedSlot = { startAt: bookedJob.startAt, durationMinutes: bookedJob.durationMinutes };
+			}
+		}
+
+		const decision = decideScheduling({
+			customerKnown: customer !== null,
+			text: message.text,
+			offeredSlots: thread.state === 'slots_offered' ? thread.offeredSlots : [],
+			busy,
+			timeZone,
+			now,
+			bookedSlot,
+		});
+
+		const response = composeAgentResponse(decision, {
+			accountName: account.name,
+			customerName: customer?.name ?? message.sender.name,
+			timeZone,
+			signupUrl: ctx.signupUrl,
+			jobTitle: ctx.jobTitle,
+			now,
+			medium: caps.medium,
+		});
+
+		const outcome: CapabilityOutcome = {
+			response,
+			outcome: decision.kind,
+			threadPatch: threadPatchFor(decision),
+		};
+
+		if (decision.kind === 'book' && customer) {
+			const year = zonedParts(now, timeZone).year;
+			outcome.sideEffects = {
+				bookJob: {
+					title: ctx.jobTitle,
+					customerId: customer.id,
+					assignedUserId: '',
+					startAt: decision.slot.startAt,
+					durationMinutes: decision.slot.durationMinutes,
+					status: 'confirmed',
+					address: customer.address,
+					notes: `Booked by Rivus over ${channelLabel(caps.channel)} with ${customer.name}.`,
+					estimatedValue: 0,
+					note: `Rivus booked ${ctx.jobTitle} for ${formatSlotLabel(decision.slot.startAt, timeZone, year)}.`,
+				},
+			};
+		}
+		return outcome;
+	},
+};
+
+/** The v1 capability registry. Adding a feature = adding an entry here. */
+export function defaultCapabilities(): AgentCapability[] {
+	return [schedulingCapability];
+}

--- a/packages/api/src/services/agent/channel.ts
+++ b/packages/api/src/services/agent/channel.ts
@@ -1,0 +1,94 @@
+import type { Account, AccountId, AgentThread, ConversationChannel, Customer } from '@rivus/core';
+import type { AgentResponse, ChannelMedium } from './response';
+
+/**
+ * The seam every messaging channel plugs into. A channel adapter does exactly
+ * three feature-blind things — recognize the sender in its identity space,
+ * generically render a neutral {@link AgentResponse}, and transport it — so the
+ * channel-agnostic core (engine, capabilities, composer) owns all behavior and a
+ * new feature ships on every channel with no adapter change. An adapter that
+ * imported `AgentDecision` (or any capability type) would be a layering
+ * violation; the interfaces are shaped so it never needs to.
+ */
+
+/**
+ * What a channel can PRESENT. Renderers and any medium-aware wording branch on
+ * these declarative flags — never on a feature — so a new capability never needs
+ * a new flag unless it introduces a genuinely new PRESENTATION need.
+ */
+export interface ChannelCapabilities {
+	channel: ConversationChannel;
+	/** Governs the few wording choices that vary by medium ("reply to this email" vs "reply here"). */
+	medium: ChannelMedium;
+	/** Rich/HTML rendering (email's design-system card). */
+	supportsRichText: boolean;
+	/** Native quick-reply buttons for `options` blocks (else a numbered list + prompt). */
+	supportsInteractiveOptions: boolean;
+	/** Tappable link buttons for `action` blocks (else a URL line). */
+	supportsHyperlinkButtons: boolean;
+	/** Hard per-message length limit (SMS segments); null = effectively unbounded. */
+	maxTextLength: number | null;
+	/** Whether the channel carries subjects (email) — drives job-title fallback. */
+	hasSubjects: boolean;
+	/** How a reply attaches to prior messages. */
+	threadingModel: 'message-id' | 'session' | 'none';
+	/** Real-time audio channel (voice) — turns are spoken and latency-bound. */
+	isRealtimeVoice: boolean;
+	supportsAttachments: boolean;
+}
+
+/** A customer turn, stripped of every provider/wire detail. */
+export interface InboundAgentMessage {
+	/**
+	 * The contact's canonical address on this channel — a lower-cased email for
+	 * `email`, an E.164 phone for whatsapp/sms/phone. Exactly what is stored as
+	 * `AgentThread.contactAddress`.
+	 */
+	sender: { address: string; name: string };
+	/** The customer's words, cleaned (reply-extracted for email, verbatim for chat). */
+	text: string;
+	/** Thread subject; '' for subjectless channels. */
+	subject: string;
+	/** Channel-native id of this inbound message ('' when unknown) — the dedup key. */
+	externalMessageId: string;
+}
+
+/** Everything `deliver` needs besides the response — all feature-blind. */
+export interface OutboundContext {
+	account: Account;
+	thread: AgentThread;
+	to: { address: string; name: string };
+	/** External id of the inbound message being answered ('' when none) — for threading. */
+	replyToExternalId: string;
+	/** The conversation subject to thread the reply under ('' for subjectless channels). */
+	subject: string;
+}
+
+/** How a channel prefills the self-signup link for an unrecognized contact. */
+export interface SignupPrefill {
+	param: 'email' | 'phone';
+	value: string;
+}
+
+/**
+ * One channel = an identity space + one generic renderer + transport. Adapters
+ * MUST NOT import `AgentDecision` or a capability's types — they see only
+ * {@link AgentResponse} blocks. That is the structural guarantee that a new core
+ * feature reaches every channel with zero adapter edits.
+ */
+export interface ChannelAdapter {
+	readonly channel: ConversationChannel;
+	readonly capabilities: ChannelCapabilities;
+	/** Recognize the sender in this channel's identity space (email vs phone). */
+	findCustomer(accountId: AccountId, contactAddress: string): Promise<Customer | null>;
+	/** Which self-signup query param this channel prefills, and with what. */
+	signupPrefill(sender: { address: string; name: string }): SignupPrefill;
+	/**
+	 * Generically render the neutral response for this channel and deliver it.
+	 * Rejects on transport failure (the orchestrator rolls back side effects and
+	 * rethrows so the provider redelivers). Resolves with the plain-text
+	 * transcript line to record as the `rivus` turn — each channel's own text
+	 * form, so email's transcript stays byte-for-byte what it was.
+	 */
+	deliver(response: AgentResponse, ctx: OutboundContext): Promise<string>;
+}

--- a/packages/api/src/services/agent/channels.ts
+++ b/packages/api/src/services/agent/channels.ts
@@ -1,0 +1,29 @@
+import type { ConversationChannel } from '@rivus/core';
+import type { AppDeps } from '../../types';
+import type { ChannelAdapter } from './channel';
+import { createEmailChannelAdapter } from './email/adapter';
+import { createWhatsappChannelAdapter } from './whatsapp/adapter';
+
+/**
+ * The channel adapters that have an outbound transport, keyed by channel. This is
+ * where the inbox reply-out finds the right adapter for a conversation, so a
+ * human reply or an approved FAQ draft leaves over the same channel the customer
+ * used. A channel with no entry (`phone`, and `sms`/`voice` until they're built)
+ * has no transport — the caller records the reply without sending it. Adding a
+ * new channel's entry here lights up inbox reply-out for it automatically.
+ */
+export function createChannelAdapters(
+	deps: AppDeps,
+): Partial<Record<ConversationChannel, ChannelAdapter>> {
+	return {
+		email: createEmailChannelAdapter({
+			config: deps.config,
+			customers: deps.customers,
+			mailer: deps.mailer,
+		}),
+		whatsapp: createWhatsappChannelAdapter({
+			customers: deps.customers,
+			sender: deps.whatsappSender,
+		}),
+	};
+}

--- a/packages/api/src/services/agent/email/adapter.ts
+++ b/packages/api/src/services/agent/email/adapter.ts
@@ -1,0 +1,69 @@
+import type { AccountId, Customer } from '@rivus/core';
+import type { Config } from '../../../config';
+import type { CustomerRepository } from '../../../repositories/types';
+import type { Mailer } from '../../email';
+import type {
+	ChannelAdapter,
+	ChannelCapabilities,
+	OutboundContext,
+	SignupPrefill,
+} from '../channel';
+import type { AgentResponse } from '../response';
+import { agentFromHeader } from './outbound';
+import { renderEmailResponse } from './renderer';
+
+/**
+ * The email channel adapter: the identity space (recognize senders by email
+ * address), the generic renderer (design-system card via
+ * {@link renderEmailResponse}), and transport (the account's own agent address
+ * through the {@link Mailer}, threaded via In-Reply-To/References). It holds no
+ * feature logic — every scheduling/FAQ behavior is decided upstream in the core
+ * and reaches it only as a neutral {@link AgentResponse}.
+ */
+
+const EMAIL_CAPABILITIES: ChannelCapabilities = {
+	channel: 'email',
+	medium: 'email',
+	supportsRichText: true,
+	supportsInteractiveOptions: false,
+	supportsHyperlinkButtons: true,
+	maxTextLength: null,
+	hasSubjects: true,
+	threadingModel: 'message-id',
+	isRealtimeVoice: false,
+	supportsAttachments: false,
+};
+
+export function createEmailChannelAdapter(deps: {
+	config: Pick<Config, 'AGENT_EMAIL_DOMAIN'>;
+	customers: CustomerRepository;
+	mailer: Mailer;
+}): ChannelAdapter {
+	return {
+		channel: 'email',
+		capabilities: EMAIL_CAPABILITIES,
+		findCustomer(accountId: AccountId, contactAddress: string): Promise<Customer | null> {
+			return deps.customers.findByEmail(accountId, contactAddress);
+		},
+		signupPrefill(sender): SignupPrefill {
+			return { param: 'email', value: sender.address };
+		},
+		async deliver(response: AgentResponse, ctx: OutboundContext): Promise<string> {
+			const rendered = renderEmailResponse(response, {
+				accountName: ctx.account.name,
+				inboundSubject: ctx.subject,
+			});
+			await deps.mailer.sendAgentEmail({
+				to: ctx.to.address,
+				from: agentFromHeader(ctx.account, deps.config.AGENT_EMAIL_DOMAIN),
+				subject: rendered.subject,
+				html: rendered.html,
+				text: rendered.text,
+				inReplyTo: ctx.replyToExternalId,
+				references: ctx.replyToExternalId === '' ? [] : [ctx.replyToExternalId],
+			});
+			// The transcript records the same text the customer received.
+			return rendered.text;
+		},
+	};
+}

--- a/packages/api/src/services/agent/email/inbound.ts
+++ b/packages/api/src/services/agent/email/inbound.ts
@@ -272,12 +272,6 @@ export function htmlToText(html: string): string {
 	);
 }
 
-/** Strip `Re:`/`Fwd:` chains off a subject; '' stays ''. */
-export function cleanSubject(subject: string): string {
-	let cleaned = subject.trim();
-	const prefix = /^(?:re|fwd?|fw)\s*:\s*/i;
-	while (prefix.test(cleaned)) {
-		cleaned = cleaned.replace(prefix, '');
-	}
-	return cleaned.trim();
-}
+// `cleanSubject` is channel-agnostic (the shared orchestrator uses it too), so it
+// lives in `../subject`; re-exported here for the email channel's existing callers.
+export { cleanSubject } from '../subject';

--- a/packages/api/src/services/agent/email/renderer.ts
+++ b/packages/api/src/services/agent/email/renderer.ts
@@ -1,0 +1,145 @@
+import { escapeHtml, type RenderedEmail } from '../../email';
+import { type AgentResponse, renderResponseText } from '../response';
+import { cleanSubject } from '../subject';
+
+/**
+ * The email channel's ONE generic renderer: any {@link AgentResponse} → the
+ * design-system HTML card + plain text + subject. It switches exhaustively on the
+ * neutral block kinds and knows only chrome (the shell, the footer, the text
+ * sign-off) — never a scheduling decision — so a new core feature renders here
+ * with no change. Every visual value is a DESIGN_SYSTEM.md token (Montserrat, the
+ * surface/hairline/text colors, the 14px card, and the signature gradient
+ * reserved for the single Rivus-the-agent button).
+ */
+
+const FONT_STACK = "Montserrat, -apple-system, 'Segoe UI', Roboto, sans-serif";
+const PAGE_BG = '#f6f7fb';
+const CARD_BG = '#ffffff';
+const HAIRLINE = '#e9eaf0';
+const TEXT_PRIMARY = '#16161f';
+const TEXT_SUB = '#8a8b99';
+const GRADIENT = 'linear-gradient(135deg, #1ebefa, #6e1ec8)';
+
+const FOOTER_NOTE = (accountName: string) =>
+	`Rivus · AI scheduling for ${accountName}. Reply to this email and I'll take care of it.`;
+
+/** `Re:` the customer's own subject, or a sensible thread-starter without one. */
+export function replySubject(inboundSubject: string, accountName: string): string {
+	const cleaned = cleanSubject(inboundSubject);
+	return cleaned === '' ? `Scheduling with ${accountName}` : `Re: ${cleaned}`;
+}
+
+/** One body paragraph in the shared card style (its text is HTML-escaped). */
+function paragraph(line: string): string {
+	return `<p style="margin: 0 0 12px; font-size: 13.5px; line-height: 1.6; color: ${TEXT_PRIMARY};">${escapeHtml(line)}</p>`;
+}
+
+/** A pre-escaped body fragment (already HTML-safe) in the shared paragraph style. */
+function paragraphRaw(inner: string): string {
+	return `<p style="margin: 0 0 12px; font-size: 13.5px; line-height: 1.6; color: ${TEXT_PRIMARY};">${inner}</p>`;
+}
+
+/**
+ * Wrap already-rendered body fragments in the shared design-system chrome — the
+ * page background, the account-headed card, and the Rivus footer — so every agent
+ * email looks like one thread.
+ */
+function emailShell(accountName: string, body: string[]): string {
+	return [
+		'<!doctype html>',
+		'<html lang="en">',
+		`<body style="margin: 0; padding: 24px 12px; background: ${PAGE_BG}; font-family: ${FONT_STACK};">`,
+		`<div style="max-width: 560px; margin: 0 auto; background: ${CARD_BG}; border: 1px solid ${HAIRLINE}; border-radius: 14px; padding: 24px;">`,
+		`<p style="margin: 0 0 16px; font-size: 12px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: ${TEXT_SUB};">${escapeHtml(accountName)}</p>`,
+		...body,
+		'</div>',
+		`<p style="max-width: 560px; margin: 12px auto 0; font-size: 11.5px; font-weight: 500; color: ${TEXT_SUB}; text-align: center;">${escapeHtml(FOOTER_NOTE(accountName))}</p>`,
+		'</body>',
+		'</html>',
+	].join('\n');
+}
+
+/** HTML for the numbered options list — each label escaped, the leading number dropped. */
+function optionsHtml(items: Array<{ label: string }>): string {
+	const list = items
+		.map(
+			(item) =>
+				`<li style="margin: 0 0 8px; font-size: 13.5px; line-height: 1.6; color: ${TEXT_PRIMARY}; font-weight: 600;">${escapeHtml(item.label)}</li>`,
+		)
+		.join('\n');
+	return `<ol style="margin: 0 0 12px; padding-left: 20px;">${list}</ol>`;
+}
+
+/** HTML for a call-to-action: the one gradient button plus a plain-link fallback. */
+function actionHtml(label: string, url: string): string[] {
+	return [
+		`<p style="margin: 16px 0;"><a href="${escapeHtml(url)}" ` +
+			`style="display: inline-block; padding: 12px 22px; background: ${GRADIENT}; ` +
+			`color: #ffffff; border-radius: 11px; text-decoration: none; font-weight: 600; ` +
+			`font-size: 13.5px;">${escapeHtml(label)}</a></p>`,
+		`<p style="margin: 0 0 12px; font-size: 11.5px; color: ${TEXT_SUB};">Or paste this link into your browser:<br>` +
+			`<a href="${escapeHtml(url)}" style="color: ${TEXT_SUB};">${escapeHtml(url)}</a></p>`,
+	];
+}
+
+/** Render a free-text reply (human or approved draft) into the shared card. */
+function renderPlain(accountName: string, inboundSubject: string, body: string): RenderedEmail {
+	// A blank line separates paragraphs; single breaks within one become <br>.
+	// Newlines match `\r?\n` (like the inbound reply parser) so CRLF bodies split
+	// the same as LF ones; the separator tolerates spaces/tabs on a blank line.
+	const paragraphs = body
+		.split(/\r?\n(?:[ \t]*\r?\n)+/)
+		.map((block) =>
+			block
+				.split(/\r?\n/)
+				.map((line) => escapeHtml(line))
+				.join('<br>'),
+		)
+		.filter((block) => block.trim() !== '')
+		.map((block) => paragraphRaw(block));
+	return {
+		subject: replySubject(inboundSubject, accountName),
+		html: emailShell(accountName, paragraphs),
+		text: body,
+	};
+}
+
+/** Render a composed agent response into subject + design-system HTML + text. */
+export function renderEmailResponse(
+	response: AgentResponse,
+	input: { accountName: string; inboundSubject: string },
+): RenderedEmail {
+	// A free-text response carries no agent chrome (greeting/sign-off) and uses the
+	// paragraph-splitting body form; agent decisions get the card + sign-off.
+	const plain = response.blocks.find((block) => block.kind === 'freeText');
+	if (plain) {
+		return renderPlain(input.accountName, input.inboundSubject, plain.text);
+	}
+
+	const body: string[] = [];
+	for (const block of response.blocks) {
+		switch (block.kind) {
+			case 'greeting':
+			case 'paragraph':
+			case 'notice':
+			case 'freeText':
+				// A multi-line block becomes one paragraph per line (matching how the
+				// prior templates mapped each lead/trail line to its own <p>).
+				for (const line of block.text.split('\n')) {
+					body.push(paragraph(line));
+				}
+				break;
+			case 'options':
+				body.push(optionsHtml(block.items));
+				break;
+			case 'action':
+				body.push(...actionHtml(block.label, block.url));
+				break;
+		}
+	}
+	return {
+		subject: replySubject(input.inboundSubject, input.accountName),
+		html: emailShell(input.accountName, body),
+		text: `${renderResponseText(response)}\n\n— Rivus, scheduling for ${input.accountName}`,
+	};
+}

--- a/packages/api/src/services/agent/email/templates.ts
+++ b/packages/api/src/services/agent/email/templates.ts
@@ -1,15 +1,15 @@
-import type { AgentSlot } from '@rivus/core';
-import { escapeHtml, type RenderedEmail } from '../../email';
+import type { RenderedEmail } from '../../email';
 import type { AgentDecision } from '../engine';
-import { formatSlotLabel, zonedParts } from '../slots';
-import { cleanSubject } from './inbound';
+import { composeAgentResponse, freeTextResponse } from '../response';
+import { renderEmailResponse, replySubject } from './renderer';
 
 /**
- * Rendering of the agent's scheduling decisions as email. Every visual value
- * here comes from DESIGN_SYSTEM.md — Montserrat, the surface/hairline/text
- * tokens, 14px cards, and the signature gradient reserved for the one
- * Rivus-the-agent action button. The plain-text body doubles as the message
- * recorded on the inbox conversation, so it must read well on its own.
+ * Backward-compatible email rendering wrappers. The scheduling copy and the
+ * design-system chrome moved to the channel-agnostic composer (`../response.ts`)
+ * and the email renderer (`./renderer.ts`); these thin adapters keep the prior
+ * `renderAgentEmail`/`renderAgentReplyText`/`renderReplyEmail` API (and its
+ * exact output) so the pinned template tests — the byte-parity proof for the
+ * refactor — keep compiling and passing unchanged.
  */
 
 export interface AgentEmailRenderContext {
@@ -25,202 +25,25 @@ export interface AgentEmailRenderContext {
 	/** The inbound email's subject, verbatim ('' when none). */
 	inboundSubject: string;
 	/**
-	 * The current instant — slot labels spell out the year whenever a slot falls
-	 * in a different year than this, so a January booking written in December can
-	 * never read as this week's.
+	 * The current instant — slot labels spell out the year whenever a slot falls in
+	 * a different year than this.
 	 */
 	now: Date;
 }
 
-/** `Re:` the customer's own subject, or a sensible thread-starter without one. */
-export function replySubject(inboundSubject: string, accountName: string): string {
-	const cleaned = cleanSubject(inboundSubject);
-	return cleaned === '' ? `Scheduling with ${accountName}` : `Re: ${cleaned}`;
-}
+export { replySubject };
 
-/** "Hi Dana," / "Hi there," — first name only, matching how people write email. */
-function greeting(customerName: string): string {
-	const first = customerName.trim().split(/\s+/)[0] ?? '';
-	return first === '' ? 'Hi there,' : `Hi ${first},`;
-}
-
-const FOOTER_NOTE = (accountName: string) =>
-	`Rivus · AI scheduling for ${accountName}. Reply to this email and I'll take care of it.`;
-
-/** The year "today" falls in for the account — labels omit it for same-year slots. */
-function currentYearIn(context: AgentEmailRenderContext): number {
-	return zonedParts(context.now, context.timeZone).year;
-}
-
-/** The numbered "reply with 1/2/3" list, in text and HTML forms. */
-function slotLines(slots: AgentSlot[], context: AgentEmailRenderContext): string[] {
-	const year = currentYearIn(context);
-	return slots.map(
-		(slot, index) => `${index + 1}. ${formatSlotLabel(slot.startAt, context.timeZone, year)}`,
-	);
-}
-
-function reasonSentence(
-	reason: 'taken' | 'outside_hours' | 'in_past' | 'beyond_horizon',
-	requestedLabel: string,
-): string {
-	switch (reason) {
-		case 'taken':
-			return `Unfortunately ${requestedLabel} was just taken.`;
-		case 'outside_hours':
-			return `Unfortunately ${requestedLabel} is outside our business hours (Monday to Friday, 9:00 AM to 5:00 PM).`;
-		case 'in_past':
-			return `Unfortunately ${requestedLabel} has already passed.`;
-		case 'beyond_horizon':
-			return `Unfortunately ${requestedLabel} is further out than I can schedule right now — I can book up to about two months ahead.`;
-	}
-}
-
-interface EmailContent {
-	/** Paragraphs before the list/button. */
-	lead: string[];
-	/** Numbered options, when the reply offers times. */
-	options: string[];
-	/** Paragraphs after the list/button. */
-	trail: string[];
-	/** The one gradient action button, when the reply carries a link. */
-	button: { label: string; url: string } | null;
-}
-
-function contentFor(decision: AgentDecision, context: AgentEmailRenderContext): EmailContent {
-	switch (decision.kind) {
-		case 'send_signup_link':
-			return {
-				lead: [
-					`Thanks for reaching out to ${context.accountName}! I'm Rivus, their scheduling assistant.`,
-					`I don't see this email address in ${context.accountName}'s customer list yet. Add yourself in a minute at the link below, then reply to this email and I'll get you booked in.`,
-				],
-				options: [],
-				trail: [],
-				button: { label: `Join ${context.accountName} as a customer`, url: context.signupUrl },
-			};
-		case 'offer_slots':
-			return {
-				lead: [`Great to hear from you! Here are ${context.accountName}'s next openings:`],
-				options: slotLines(decision.slots, context),
-				trail: ['Reply with the number that works for you, or suggest another time.'],
-				button: null,
-			};
-		case 'book':
-			return {
-				lead: [
-					"You're booked!",
-					`${context.jobTitle} — ${formatSlotLabel(decision.slot.startAt, context.timeZone, currentYearIn(context))} (${decision.slot.durationMinutes} minutes).`,
-				],
-				options: [],
-				trail: [
-					// Changes are a human's call (a "move it to Friday" reply would book a
-					// second appointment, not move this one) — and every reply lands in the
-					// team inbox, so pointing at the team is both honest and true.
-					`Need to change or cancel? Reply here and the ${context.accountName} team will take care of it.`,
-				],
-				button: null,
-			};
-		case 'confirm_existing':
-			return {
-				lead: [
-					`You're all set — you're already booked for ${formatSlotLabel(decision.slot.startAt, context.timeZone, currentYearIn(context))}.`,
-				],
-				options: [],
-				trail: ['If you need to change or cancel, just reply and let me know.'],
-				button: null,
-			};
-		case 'propose_unavailable': {
-			const requestedLabel = formatSlotLabel(
-				decision.requestedStartAt,
-				context.timeZone,
-				currentYearIn(context),
-			);
-			if (decision.alternatives.length === 0) {
-				return {
-					lead: [reasonSentence(decision.reason, requestedLabel)],
-					options: [],
-					trail: [
-						`I couldn't find another opening in the next two weeks — reply with a few times that work for you and I'll check them against ${context.accountName}'s calendar.`,
-					],
-					button: null,
-				};
-			}
-			return {
-				lead: [reasonSentence(decision.reason, requestedLabel), 'Here is what we do have open:'],
-				options: slotLines(decision.alternatives, context),
-				trail: ['Reply with the number that works for you, or suggest another time.'],
-				button: null,
-			};
-		}
-		case 'no_availability':
-			return {
-				lead: [
-					`Thanks for reaching out! ${context.accountName}'s calendar is fully booked for the next two weeks.`,
-				],
-				options: [],
-				trail: [
-					"Reply with a few times that work for you and I'll check them against the calendar.",
-				],
-				button: null,
-			};
-	}
-}
-
-/** The plain-text body — also what the inbox conversation records for this turn. */
-export function renderAgentReplyText(
-	decision: AgentDecision,
-	context: AgentEmailRenderContext,
-): string {
-	const content = contentFor(decision, context);
-	const parts: string[] = [greeting(context.customerName), '', ...content.lead];
-	if (content.options.length > 0) {
-		parts.push('', ...content.options);
-	}
-	if (content.button) {
-		parts.push('', `${content.button.label}: ${content.button.url}`);
-	}
-	if (content.trail.length > 0) {
-		parts.push('', ...content.trail);
-	}
-	parts.push('', `— Rivus, scheduling for ${context.accountName}`);
-	return parts.join('\n');
-}
-
-// Design-system tokens (DESIGN_SYSTEM.md): Montserrat with system fallbacks
-// for clients that won't load web fonts, surfaces, hairline, text colors, and
-// the signature gradient — reserved for the single Rivus-the-agent button.
-const FONT_STACK = "Montserrat, -apple-system, 'Segoe UI', Roboto, sans-serif";
-const PAGE_BG = '#f6f7fb';
-const CARD_BG = '#ffffff';
-const HAIRLINE = '#e9eaf0';
-const TEXT_PRIMARY = '#16161f';
-const TEXT_SUB = '#8a8b99';
-const GRADIENT = 'linear-gradient(135deg, #1ebefa, #6e1ec8)';
-
-/** One body paragraph in the shared card style (its text is HTML-escaped). */
-function paragraph(line: string): string {
-	return `<p style="margin: 0 0 12px; font-size: 13.5px; line-height: 1.6; color: ${TEXT_PRIMARY};">${escapeHtml(line)}</p>`;
-}
-
-/**
- * Wrap already-rendered body fragments in the shared design-system chrome — the
- * page background, the account-headed card, and the Rivus footer — so every
- * agent email (a scheduling decision or a plain reply) looks like one thread.
- */
-function emailShell(accountName: string, body: string[]): string {
-	return [
-		'<!doctype html>',
-		'<html lang="en">',
-		`<body style="margin: 0; padding: 24px 12px; background: ${PAGE_BG}; font-family: ${FONT_STACK};">`,
-		`<div style="max-width: 560px; margin: 0 auto; background: ${CARD_BG}; border: 1px solid ${HAIRLINE}; border-radius: 14px; padding: 24px;">`,
-		`<p style="margin: 0 0 16px; font-size: 12px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: ${TEXT_SUB};">${escapeHtml(accountName)}</p>`,
-		...body,
-		'</div>',
-		`<p style="max-width: 560px; margin: 12px auto 0; font-size: 11.5px; font-weight: 500; color: ${TEXT_SUB}; text-align: center;">${escapeHtml(FOOTER_NOTE(accountName))}</p>`,
-		'</body>',
-		'</html>',
-	].join('\n');
+/** Compose a decision into a neutral response worded for the email medium. */
+function toEmailResponse(decision: AgentDecision, context: AgentEmailRenderContext) {
+	return composeAgentResponse(decision, {
+		accountName: context.accountName,
+		customerName: context.customerName,
+		timeZone: context.timeZone,
+		signupUrl: context.signupUrl,
+		jobTitle: context.jobTitle,
+		now: context.now,
+		medium: 'email',
+	});
 }
 
 /** Render a decision as a full email (subject + design-system HTML + text). */
@@ -228,71 +51,32 @@ export function renderAgentEmail(
 	decision: AgentDecision,
 	context: AgentEmailRenderContext,
 ): RenderedEmail {
-	const content = contentFor(decision, context);
-	const subject = replySubject(context.inboundSubject, context.accountName);
-	const text = renderAgentReplyText(decision, context);
+	return renderEmailResponse(toEmailResponse(decision, context), {
+		accountName: context.accountName,
+		inboundSubject: context.inboundSubject,
+	});
+}
 
-	const body: string[] = [
-		paragraph(greeting(context.customerName)),
-		...content.lead.map(paragraph),
-	];
-	if (content.options.length > 0) {
-		const items = content.options
-			.map(
-				(option) =>
-					`<li style="margin: 0 0 8px; font-size: 13.5px; line-height: 1.6; color: ${TEXT_PRIMARY}; font-weight: 600;">${escapeHtml(option.replace(/^\d+\.\s*/, ''))}</li>`,
-			)
-			.join('\n');
-		body.push(`<ol style="margin: 0 0 12px; padding-left: 20px;">${items}</ol>`);
-	}
-	if (content.button) {
-		body.push(
-			`<p style="margin: 16px 0;"><a href="${escapeHtml(content.button.url)}" ` +
-				`style="display: inline-block; padding: 12px 22px; background: ${GRADIENT}; ` +
-				`color: #ffffff; border-radius: 11px; text-decoration: none; font-weight: 600; ` +
-				`font-size: 13.5px;">${escapeHtml(content.button.label)}</a></p>`,
-			`<p style="margin: 0 0 12px; font-size: 11.5px; color: ${TEXT_SUB};">Or paste this link into your browser:<br>` +
-				`<a href="${escapeHtml(content.button.url)}" style="color: ${TEXT_SUB};">${escapeHtml(content.button.url)}</a></p>`,
-		);
-	}
-	body.push(...content.trail.map(paragraph));
-
-	return { subject, html: emailShell(context.accountName, body), text };
+/** The plain-text body — also what the inbox conversation records for this turn. */
+export function renderAgentReplyText(
+	decision: AgentDecision,
+	context: AgentEmailRenderContext,
+): string {
+	return renderAgentEmail(decision, context).text;
 }
 
 /**
- * Render a free-text reply into an email thread: a human team member's message
- * from the inbox, or an approved Rivus draft. There's no scheduling decision
- * behind it — the body is whatever was written — so it carries no slot list or
- * action button, but it wears the same `Re:` subject and design-system card as
- * the agent's own replies, so the customer sees one consistent thread. The
- * writer's paragraph and line breaks are preserved; every line is HTML-escaped.
+ * Render a free-text reply into an email thread (a human team member's message
+ * from the inbox, or an approved Rivus draft): the same `Re:` subject and card as
+ * the agent's own replies, with no slot list, button, or sign-off.
  */
 export function renderReplyEmail(context: {
 	accountName: string;
-	/** The email thread's subject, so the reply threads under `Re: …`. */
 	inboundSubject: string;
-	/** The reply text, exactly as the human wrote it (or the approved draft). */
 	body: string;
 }): RenderedEmail {
-	const subject = replySubject(context.inboundSubject, context.accountName);
-	// A blank line separates paragraphs; single breaks within one become <br>.
-	// Newlines are matched as `\r?\n` (like the inbound reply parser) so CRLF
-	// bodies from Windows/native mail clients split the same as LF ones. The
-	// separator tolerates spaces/tabs left on an otherwise-blank line
-	// (`\r\n \r\n`) while preserving the next paragraph's own leading indent.
-	const paragraphs = context.body
-		.split(/\r?\n(?:[ \t]*\r?\n)+/)
-		.map((block) =>
-			block
-				.split(/\r?\n/)
-				.map((line) => escapeHtml(line))
-				.join('<br>'),
-		)
-		.filter((block) => block.trim() !== '')
-		.map(
-			(block) =>
-				`<p style="margin: 0 0 12px; font-size: 13.5px; line-height: 1.6; color: ${TEXT_PRIMARY};">${block}</p>`,
-		);
-	return { subject, html: emailShell(context.accountName, paragraphs), text: context.body };
+	return renderEmailResponse(freeTextResponse(context.body), {
+		accountName: context.accountName,
+		inboundSubject: context.inboundSubject,
+	});
 }

--- a/packages/api/src/services/agent/email/webhook.ts
+++ b/packages/api/src/services/agent/email/webhook.ts
@@ -1,85 +1,9 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
-
-/**
- * Verification of Resend's inbound-email webhook signatures. Resend signs
- * webhooks the Svix way: an HMAC-SHA256 of `"{id}.{timestamp}.{body}"` keyed
- * with the base64 secret after the `whsec_` prefix, delivered in the
- * `svix-id`/`svix-timestamp`/`svix-signature` headers. Implemented directly on
- * `node:crypto` — the scheme is three lines of HMAC, which isn't worth a new
- * dependency through the supply-chain gate.
- */
-
-/** Reject webhooks whose timestamp is further than this from now (replay guard). */
-export const WEBHOOK_TOLERANCE_SECONDS = 5 * 60;
-
-export interface WebhookHeaders {
-	/** `svix-id` — unique delivery id, part of the signed content. */
-	id: string;
-	/** `svix-timestamp` — unix seconds the delivery was signed. */
-	timestamp: string;
-	/** `svix-signature` — space-separated list of `v1,<base64>` entries. */
-	signature: string;
-}
-
-/** The `whsec_`-prefixed secret's raw key bytes. */
-function secretKey(secret: string): Buffer {
-	const encoded = secret.startsWith('whsec_') ? secret.slice('whsec_'.length) : secret;
-	return Buffer.from(encoded, 'base64');
-}
-
-/**
- * Whether a webhook delivery is authentically signed with `secret` and fresh
- * enough to act on. Comparison is timing-safe; multiple signature entries
- * (present while a secret is being rotated) are each tried.
- */
-export function verifyWebhookSignature(options: {
-	secret: string;
-	headers: WebhookHeaders;
-	/** The raw request body, byte-for-byte as received. */
-	payload: string;
-	/** The current instant — injected so tests are deterministic. */
-	now: Date;
-}): boolean {
-	const { id, timestamp, signature } = options.headers;
-	if (!id || !timestamp || !signature) {
-		return false;
-	}
-	const timestampSeconds = Number(timestamp);
-	if (!Number.isFinite(timestampSeconds)) {
-		return false;
-	}
-	const skew = Math.abs(options.now.getTime() / 1000 - timestampSeconds);
-	if (skew > WEBHOOK_TOLERANCE_SECONDS) {
-		return false;
-	}
-
-	const expected = createHmac('sha256', secretKey(options.secret))
-		.update(`${id}.${timestamp}.${options.payload}`)
-		.digest();
-
-	// The header carries one or more space-separated `v1,<base64>` entries.
-	return signature.split(' ').some((entry) => {
-		const [version, encoded] = entry.split(',');
-		if (version !== 'v1' || !encoded) {
-			return false;
-		}
-		const candidate = Buffer.from(encoded, 'base64');
-		return candidate.length === expected.length && timingSafeEqual(candidate, expected);
-	});
-}
-
-/**
- * Sign a payload the way Svix/Resend does — the counterpart of
- * {@link verifyWebhookSignature}, used by tests (and handy for local `curl`s).
- */
-export function signWebhookPayload(options: {
-	secret: string;
-	id: string;
-	timestamp: string;
-	payload: string;
-}): string {
-	const digest = createHmac('sha256', secretKey(options.secret))
-		.update(`${options.id}.${options.timestamp}.${options.payload}`)
-		.digest('base64');
-	return `v1,${digest}`;
-}
+// The Svix-style HMAC webhook verifier is channel-generic (Resend and other
+// providers sign this way), so it lives in `../webhook`; re-exported here for the
+// email channel's existing callers.
+export {
+	signWebhookPayload,
+	verifyWebhookSignature,
+	WEBHOOK_TOLERANCE_SECONDS,
+	type WebhookHeaders,
+} from '../webhook';

--- a/packages/api/src/services/agent/orchestrator.ts
+++ b/packages/api/src/services/agent/orchestrator.ts
@@ -1,0 +1,254 @@
+import type { Account, ConversationChannel, JobId, UserId } from '@rivus/core';
+import type { FastifyBaseLogger } from 'fastify';
+import { ConflictError } from '../../repositories/errors';
+import type { AppDeps } from '../../types';
+import { DELIVERY_FAILED_REASON } from '../inbox';
+import type { AgentCapability, OrchestratorDeps, TurnContext } from './capabilities';
+import type { ChannelAdapter, InboundAgentMessage, OutboundContext } from './channel';
+import { buildCustomerSignupUrl } from './signup';
+import { safeTimeZone } from './slots';
+import { cleanSubject } from './subject';
+
+/**
+ * The single inbound flow every messaging channel runs — lifted verbatim from
+ * the email route so a new channel reuses it wholesale. It owns everything
+ * channel-agnostic (thread find/create with race recovery, dedup, transcript,
+ * capability dispatch, side-effect execution with rollback-on-failed-send, and
+ * the thread-state update) and delegates only the channel edges — identity,
+ * rendering, transport — to the {@link ChannelAdapter}. Because feature behavior
+ * lives entirely in the dispatched {@link AgentCapability}, a new capability runs
+ * on every channel without either the orchestrator or any adapter changing.
+ */
+
+export interface InboundHandleResult {
+	/** Whether the agent acted on the message (replied/booked) or ignored it. */
+	handled: boolean;
+	/** What the agent did (`offer_slots`, `book`, …) or why it ignored the message. */
+	outcome: string;
+}
+
+export async function handleInboundAgentMessage(options: {
+	deps: OrchestratorDeps;
+	adapter: ChannelAdapter;
+	capabilities: AgentCapability[];
+	account: Account;
+	message: InboundAgentMessage;
+	logger: FastifyBaseLogger;
+	/** The current instant — injected so orchestrator unit tests are deterministic. */
+	now?: Date;
+}): Promise<InboundHandleResult> {
+	const { deps, adapter, capabilities, account, message } = options;
+	const now = options.now ?? new Date();
+	const channel = adapter.channel;
+	const { conversations, agentThreads, config, jobs } = deps;
+
+	const customer = await adapter.findCustomer(account.id, message.sender.address);
+	// For a phone-shaped channel the contact's address *is* their phone, so record
+	// it on the conversation when the CRM has none; email carries no phone here.
+	const senderIsPhone = adapter.capabilities.medium !== 'email';
+	const contactPhone = customer?.phone || (senderIsPhone ? message.sender.address : '');
+
+	const openConversation = () =>
+		conversations.create(account.id, {
+			contactName: customer?.name || message.sender.name || message.sender.address,
+			channel,
+			customerId: customer?.id ?? '',
+			contactPhone,
+			status: 'rivus_handling',
+			tags: [],
+			lastInvoice: '',
+		});
+
+	// One thread per (account, channel, contact): find it or open it together with
+	// the inbox conversation that carries the transcript.
+	let thread = await agentThreads.findByContact(account.id, channel, message.sender.address);
+	if (!thread) {
+		const conversation = await openConversation();
+		try {
+			thread = await agentThreads.create({
+				accountId: account.id,
+				channel,
+				contactAddress: message.sender.address,
+				conversationId: conversation.id,
+				customerId: customer?.id ?? '',
+				subject: message.subject,
+			});
+		} catch (error) {
+			if (!(error instanceof ConflictError)) {
+				throw error;
+			}
+			// A concurrent delivery from the same brand-new contact won the create.
+			// Drop the conversation this loser opened and continue on the winner's.
+			await conversations.delete(account.id, conversation.id);
+			thread = await agentThreads.findByContact(account.id, channel, message.sender.address);
+			if (!thread) {
+				throw error;
+			}
+		}
+	} else if (
+		message.externalMessageId !== '' &&
+		thread.lastExternalMessageId === message.externalMessageId
+	) {
+		// At-least-once delivery: a message we already answered is a redelivery.
+		return { handled: false, outcome: 'duplicate_delivery' };
+	}
+
+	// Record the customer's turn; recreate the conversation if the team deleted it.
+	const transcriptBody = message.text || cleanSubject(message.subject) || '(empty message)';
+	const appended = await conversations.addMessage(account.id, thread.conversationId, {
+		author: 'customer',
+		body: transcriptBody,
+	});
+	if (!appended) {
+		const conversation = await openConversation();
+		await conversations.addMessage(account.id, conversation.id, {
+			author: 'customer',
+			body: transcriptBody,
+		});
+		thread =
+			(await agentThreads.update(account.id, thread.id, {
+				conversationId: conversation.id,
+			})) ?? thread;
+	}
+
+	// A sender who just self-signed-up gets linked to the thread/conversation.
+	if (customer && thread.customerId === '') {
+		await conversations.update(account.id, thread.conversationId, {
+			customerId: customer.id,
+			contactName: customer.name,
+			...(customer.phone !== '' ? { contactPhone: customer.phone } : {}),
+		});
+	}
+
+	const timeZone = safeTimeZone(account.timezone);
+	const signupUrl = buildCustomerSignupUrl(
+		config.WEBSITE_URL,
+		account.slug,
+		adapter.signupPrefill(message.sender),
+	);
+	const jobTitle = cleanSubject(message.subject) || cleanSubject(thread.subject) || 'Appointment';
+
+	const ctx: TurnContext = {
+		account,
+		customer,
+		thread,
+		message,
+		caps: adapter.capabilities,
+		timeZone,
+		now,
+		signupUrl,
+		jobTitle,
+		deps,
+	};
+	// Dispatch to the first capability that claims the turn; the last always matches.
+	const capability =
+		capabilities.find((entry) => entry.matches(ctx)) ?? capabilities[capabilities.length - 1];
+	if (!capability) {
+		throw new Error('No agent capability is registered to handle the turn.');
+	}
+	const result = await capability.handle(ctx);
+
+	// Execute declared side effects before delivering, so a delivery failure can
+	// roll them back (an unconfirmed booking would otherwise block the redelivery).
+	let bookedJobId = '';
+	if (result.sideEffects?.bookJob) {
+		const { note: _note, ...jobInput } = result.sideEffects.bookJob;
+		const job = await jobs.create(account.id, jobInput);
+		bookedJobId = job.id;
+	}
+
+	const outboundCtx: OutboundContext = {
+		account,
+		thread,
+		to: { address: message.sender.address, name: customer?.name ?? message.sender.name },
+		replyToExternalId: message.externalMessageId,
+		subject: message.subject !== '' ? message.subject : thread.subject,
+	};
+	let transcriptLine: string;
+	try {
+		transcriptLine = await adapter.deliver(result.response, outboundCtx);
+	} catch (error) {
+		// The reply never reached the customer, so a just-created booking must not
+		// stand: undo it and let the error surface (5xx → the provider redelivers,
+		// and the thread state hasn't advanced, so the retry reprocesses cleanly).
+		if (bookedJobId !== '') {
+			await jobs.delete(account.id, bookedJobId as JobId).catch(() => false);
+		}
+		throw error;
+	}
+
+	await conversations.addMessage(account.id, thread.conversationId, {
+		author: 'rivus',
+		body: transcriptLine,
+	});
+	if (result.sideEffects?.bookJob) {
+		await conversations.addMessage(account.id, thread.conversationId, {
+			author: 'note',
+			body: result.sideEffects.bookJob.note,
+		});
+	}
+
+	await agentThreads.update(account.id, thread.id, {
+		...result.threadPatch,
+		...(bookedJobId !== '' ? { bookedJobId } : {}),
+		customerId: customer?.id ?? thread.customerId,
+		lastExternalMessageId: message.externalMessageId,
+		subject: message.subject !== '' ? message.subject : thread.subject,
+	});
+
+	return { handled: true, outcome: result.outcome };
+}
+
+/**
+ * The channel-agnostic delivery-failure flow (a reply the agent sent bounced, was
+ * marked spam, or was reported undeliverable): flag the thread's conversation
+ * `needs_attention` with {@link DELIVERY_FAILED_REASON}, drop a channel-worded
+ * inline note, and notify the team. Idempotent — an already-flagged conversation
+ * no-ops. The caller resolves the account + contact from the provider event.
+ */
+export async function flagDeliveryFailure(options: {
+	deps: Pick<AppDeps, 'conversations' | 'agentThreads' | 'memberships' | 'notifier'>;
+	account: Account;
+	channel: ConversationChannel;
+	contactAddress: string;
+	/** The inline note recorded for the team ("… bounced — follow up another way."). */
+	noteBody: string;
+	outcome: string;
+	logger: FastifyBaseLogger;
+}): Promise<InboundHandleResult> {
+	const { deps, account, channel, contactAddress, noteBody, outcome, logger } = options;
+	const thread = await deps.agentThreads.findByContact(account.id, channel, contactAddress);
+	if (!thread) {
+		return { handled: false, outcome: 'no_thread' };
+	}
+	const conversation = await deps.conversations.findById(account.id, thread.conversationId);
+	if (!conversation) {
+		return { handled: false, outcome: 'no_conversation' };
+	}
+	// A delivery-failure is the only path to `needs_attention` for an agent thread,
+	// so the flag itself dedupes a redelivered webhook.
+	if (conversation.status === 'needs_attention') {
+		return { handled: false, outcome: 'already_flagged' };
+	}
+	await deps.conversations.addMessage(account.id, thread.conversationId, {
+		author: 'note',
+		body: noteBody,
+	});
+	await deps.conversations.setReviewState(account.id, thread.conversationId, {
+		status: 'needs_attention',
+		pendingReply: '',
+		flagReason: DELIVERY_FAILED_REASON,
+	});
+	// No human actor for a webhook — notify the whole team.
+	const memberIds = (await deps.memberships.listByAccount(account.id)).map(
+		(membership) => membership.userId,
+	);
+	await deps.notifier.conversationNeedsReview({
+		accountId: account.id,
+		actorId: '' as UserId,
+		memberIds,
+		contactName: conversation.contactName,
+		logger,
+	});
+	return { handled: true, outcome };
+}

--- a/packages/api/src/services/agent/response.ts
+++ b/packages/api/src/services/agent/response.ts
@@ -1,0 +1,236 @@
+import type { AgentSlot } from '@rivus/core';
+import type { AgentDecision } from './engine';
+import { formatSlotLabel, zonedParts } from './slots';
+
+/**
+ * The channel-neutral vocabulary every agent reply is composed from. These are
+ * STRUCTURAL kinds (how content is shaped), never FEATURE kinds (what the agent
+ * decided): a new feature reuses these blocks and touches no channel. Each
+ * channel renderer switches exhaustively over this union, so a genuinely new
+ * block kind is a compile error in every renderer at once (and the render-matrix
+ * test fails until each handles it) — that is what makes "a core feature ships
+ * on every channel" a structural guarantee rather than a convention.
+ */
+export type AgentResponseBlock =
+	/** A short greeting line ("Hi Dana,"). */
+	| { kind: 'greeting'; text: string }
+	/** A body paragraph. May carry internal newlines (rendered as separate lines/paragraphs). */
+	| { kind: 'paragraph'; text: string }
+	/**
+	 * An enumerated choice the contact picks from. `value` is the inbound text a
+	 * pick sends back ('1', '2', …) — so an interactive channel (quick-reply
+	 * buttons) and a plain one (a numbered list + "reply with the number")
+	 * converge on the SAME inbound text, and core parsing works identically
+	 * everywhere.
+	 */
+	| { kind: 'options'; items: Array<{ label: string; value: string }> }
+	/** One call-to-action link. Rich channels render a button; plain ones a URL line. */
+	| { kind: 'action'; label: string; url: string }
+	/** A de-emphasized closing/notice line ("Need to change or cancel? …"). */
+	| { kind: 'notice'; text: string }
+	/**
+	 * Verbatim free text — a human inbox reply or an approved FAQ draft, which has
+	 * no scheduling decision behind it. Carries no agent chrome (greeting/sign-off).
+	 */
+	| { kind: 'freeText'; text: string };
+
+/** A composed, channel-neutral agent reply: an ordered list of structural blocks. */
+export interface AgentResponse {
+	blocks: AgentResponseBlock[];
+}
+
+/** The medium a channel presents in — drives the few wording choices that vary. */
+export type ChannelMedium = 'email' | 'chat' | 'voice';
+
+/** Everything the core composer needs to word a decision, with no channel/provider detail. */
+export interface AgentReplyContext {
+	accountName: string;
+	/** The matched customer's first-namable name; '' when the sender isn't recognized. */
+	customerName: string;
+	/** IANA zone slot labels are written in. */
+	timeZone: string;
+	/** Absolute self-signup URL (only used by `send_signup_link`). */
+	signupUrl: string;
+	/** The service being booked (only used by `book`). */
+	jobTitle: string;
+	/** The current instant — slot labels spell out a differing year. */
+	now: Date;
+	/** How the delivering channel presents, so the composer can pick medium-apt wording. */
+	medium: ChannelMedium;
+}
+
+/** A response that is just free text (human inbox replies, approved FAQ drafts). */
+export function freeTextResponse(body: string): AgentResponse {
+	return { blocks: [{ kind: 'freeText', text: body }] };
+}
+
+/** "Hi Dana," / "Hi there," — first name only, matching how people write. */
+function greeting(customerName: string): string {
+	const first = customerName.trim().split(/\s+/)[0] ?? '';
+	return first === '' ? 'Hi there,' : `Hi ${first},`;
+}
+
+/** The year "today" falls in for the account — labels omit it for same-year slots. */
+function currentYearIn(context: AgentReplyContext): number {
+	return zonedParts(context.now, context.timeZone).year;
+}
+
+function reasonSentence(
+	reason: 'taken' | 'outside_hours' | 'in_past' | 'beyond_horizon',
+	requestedLabel: string,
+): string {
+	switch (reason) {
+		case 'taken':
+			return `Unfortunately ${requestedLabel} was just taken.`;
+		case 'outside_hours':
+			return `Unfortunately ${requestedLabel} is outside our business hours (Monday to Friday, 9:00 AM to 5:00 PM).`;
+		case 'in_past':
+			return `Unfortunately ${requestedLabel} has already passed.`;
+		case 'beyond_horizon':
+			return `Unfortunately ${requestedLabel} is further out than I can schedule right now — I can book up to about two months ahead.`;
+	}
+}
+
+/** How a contact is told to reply, worded for the medium. */
+function replyHere(medium: ChannelMedium): string {
+	return medium === 'email' ? 'reply to this email' : 'reply here';
+}
+
+/** The intermediate shape of a decision's content, before it becomes blocks. */
+interface DecisionContent {
+	lead: string[];
+	slots: AgentSlot[];
+	action: { label: string; url: string } | null;
+	trail: string[];
+}
+
+/** Map a scheduling decision to its channel-neutral content (the promoted `contentFor`). */
+function contentFor(decision: AgentDecision, context: AgentReplyContext): DecisionContent {
+	const year = currentYearIn(context);
+	const none: Pick<DecisionContent, 'slots' | 'action'> = { slots: [], action: null };
+	switch (decision.kind) {
+		case 'send_signup_link':
+			return {
+				lead: [
+					`Thanks for reaching out to ${context.accountName}! I'm Rivus, their scheduling assistant.`,
+					`I don't see this email address in ${context.accountName}'s customer list yet. Add yourself in a minute at the link below, then ${replyHere(context.medium)} and I'll get you booked in.`,
+				],
+				slots: [],
+				action: { label: `Join ${context.accountName} as a customer`, url: context.signupUrl },
+				trail: [],
+			};
+		case 'offer_slots':
+			return {
+				lead: [`Great to hear from you! Here are ${context.accountName}'s next openings:`],
+				slots: decision.slots,
+				action: null,
+				trail: ['Reply with the number that works for you, or suggest another time.'],
+			};
+		case 'book':
+			return {
+				lead: [
+					"You're booked!",
+					`${context.jobTitle} — ${formatSlotLabel(decision.slot.startAt, context.timeZone, year)} (${decision.slot.durationMinutes} minutes).`,
+				],
+				...none,
+				trail: [
+					`Need to change or cancel? Reply here and the ${context.accountName} team will take care of it.`,
+				],
+			};
+		case 'confirm_existing':
+			return {
+				lead: [
+					`You're all set — you're already booked for ${formatSlotLabel(decision.slot.startAt, context.timeZone, year)}.`,
+				],
+				...none,
+				trail: ['If you need to change or cancel, just reply and let me know.'],
+			};
+		case 'propose_unavailable': {
+			const requestedLabel = formatSlotLabel(decision.requestedStartAt, context.timeZone, year);
+			if (decision.alternatives.length === 0) {
+				return {
+					lead: [reasonSentence(decision.reason, requestedLabel)],
+					...none,
+					trail: [
+						`I couldn't find another opening in the next two weeks — reply with a few times that work for you and I'll check them against ${context.accountName}'s calendar.`,
+					],
+				};
+			}
+			return {
+				lead: [reasonSentence(decision.reason, requestedLabel), 'Here is what we do have open:'],
+				slots: decision.alternatives,
+				action: null,
+				trail: ['Reply with the number that works for you, or suggest another time.'],
+			};
+		}
+		case 'no_availability':
+			return {
+				lead: [
+					`Thanks for reaching out! ${context.accountName}'s calendar is fully booked for the next two weeks.`,
+				],
+				...none,
+				trail: [
+					"Reply with a few times that work for you and I'll check them against the calendar.",
+				],
+			};
+	}
+}
+
+/**
+ * The one place decision kinds become content — the switch that used to live
+ * inside `email/templates.ts` `contentFor`, promoted to the channel-agnostic
+ * core. Adding or changing a decision kind edits ONLY this function; every
+ * channel renders the resulting blocks without a change.
+ */
+export function composeAgentResponse(
+	decision: AgentDecision,
+	context: AgentReplyContext,
+): AgentResponse {
+	const content = contentFor(decision, context);
+	const blocks: AgentResponseBlock[] = [{ kind: 'greeting', text: greeting(context.customerName) }];
+	if (content.lead.length > 0) {
+		blocks.push({ kind: 'paragraph', text: content.lead.join('\n') });
+	}
+	if (content.slots.length > 0) {
+		const year = currentYearIn(context);
+		blocks.push({
+			kind: 'options',
+			items: content.slots.map((slot, index) => ({
+				label: formatSlotLabel(slot.startAt, context.timeZone, year),
+				value: String(index + 1),
+			})),
+		});
+	}
+	if (content.action) {
+		blocks.push({ kind: 'action', label: content.action.label, url: content.action.url });
+	}
+	if (content.trail.length > 0) {
+		blocks.push({ kind: 'notice', text: content.trail.join('\n') });
+	}
+	return { blocks };
+}
+
+/** One block → its plain-text form (a numbered option list, a URL line, …). */
+function blockText(block: AgentResponseBlock): string {
+	switch (block.kind) {
+		case 'greeting':
+		case 'paragraph':
+		case 'notice':
+		case 'freeText':
+			return block.text;
+		case 'options':
+			return block.items.map((item) => `${item.value}. ${item.label}`).join('\n');
+		case 'action':
+			return `${block.label}: ${block.url}`;
+	}
+}
+
+/**
+ * The canonical plain-text flattening of a response — blank line between blocks —
+ * the universal fallback every channel can produce and the basis of chat/voice
+ * rendering. Channel chrome (an email sign-off, a footer) is renderer-owned
+ * presentation, not content, so it stays out of this function.
+ */
+export function renderResponseText(response: AgentResponse): string {
+	return response.blocks.map(blockText).join('\n\n');
+}

--- a/packages/api/src/services/agent/signup.ts
+++ b/packages/api/src/services/agent/signup.ts
@@ -1,10 +1,20 @@
+import type { SignupPrefill } from './channel';
+
 /**
- * The self-signup link the agent hands an unrecognized contact, on any
- * channel. Points at the website's public "join as a customer" view for the
- * account, with the contact's address prefilled so the form recognizes them
- * the moment they submit.
+ * The self-signup link the agent hands an unrecognized contact, on any channel.
+ * Points at the website's public "join as a customer" view for the account, with
+ * the contact's address prefilled so the form recognizes them the moment they
+ * submit. The prefill is channel-shaped: email channels prefill `?email=`, phone
+ * channels (WhatsApp/SMS) prefill `?phone=`. A bare string is accepted as the
+ * email form for callers (and tests) that predate the multi-channel prefill.
  */
-export function buildCustomerSignupUrl(websiteUrl: string, slug: string, email: string): string {
+export function buildCustomerSignupUrl(
+	websiteUrl: string,
+	slug: string,
+	prefill: string | SignupPrefill,
+): string {
 	const base = websiteUrl.replace(/\/+$/, '');
-	return `${base}/customers/join/${encodeURIComponent(slug)}?email=${encodeURIComponent(email)}`;
+	const { param, value } =
+		typeof prefill === 'string' ? { param: 'email' as const, value: prefill } : prefill;
+	return `${base}/customers/join/${encodeURIComponent(slug)}?${param}=${encodeURIComponent(value)}`;
 }

--- a/packages/api/src/services/agent/subject.ts
+++ b/packages/api/src/services/agent/subject.ts
@@ -1,0 +1,18 @@
+/**
+ * Subject normalization shared by every channel. Stripping `Re:`/`Fwd:` chains
+ * is an email convention, but the helper is channel-agnostic (a no-op on a
+ * subjectless channel's `''`) so the shared orchestrator and scheduling
+ * capability can derive a job title from whatever subject a channel carries
+ * without importing anything from the email channel.
+ */
+
+const SUBJECT_PREFIX = /^(?:re|fwd?|fw)\s*:\s*/i;
+
+/** Strip `Re:`/`Fwd:` chains off a subject; '' stays ''. */
+export function cleanSubject(subject: string): string {
+	let cleaned = subject.trim();
+	while (SUBJECT_PREFIX.test(cleaned)) {
+		cleaned = cleaned.replace(SUBJECT_PREFIX, '');
+	}
+	return cleaned.trim();
+}

--- a/packages/api/src/services/agent/webhook.ts
+++ b/packages/api/src/services/agent/webhook.ts
@@ -1,0 +1,86 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Channel-generic verification of Svix-style webhook signatures — an HMAC-SHA256
+ * of `"{id}.{timestamp}.{body}"` keyed with the base64 secret after a `whsec_`
+ * prefix, delivered in `{id}`/`{timestamp}`/`{signature}` headers. Resend signs
+ * its inbound-email webhooks this way, and other providers (mapped to these
+ * fields at the route) can reuse it. Implemented directly on `node:crypto` — the
+ * scheme is a few lines of HMAC, not worth a dependency through the supply-chain
+ * gate.
+ */
+
+/** Reject webhooks whose timestamp is further than this from now (replay guard). */
+export const WEBHOOK_TOLERANCE_SECONDS = 5 * 60;
+
+export interface WebhookHeaders {
+	/** Unique delivery id, part of the signed content. */
+	id: string;
+	/** Unix seconds the delivery was signed. */
+	timestamp: string;
+	/** Space-separated list of `v1,<base64>` entries. */
+	signature: string;
+}
+
+/** The `whsec_`-prefixed secret's raw key bytes. */
+function secretKey(secret: string): Buffer {
+	const encoded = secret.startsWith('whsec_') ? secret.slice('whsec_'.length) : secret;
+	return Buffer.from(encoded, 'base64');
+}
+
+/**
+ * Whether a webhook delivery is authentically signed with `secret` and fresh
+ * enough to act on. Comparison is timing-safe; multiple signature entries
+ * (present while a secret is being rotated) are each tried.
+ */
+export function verifyWebhookSignature(options: {
+	secret: string;
+	headers: WebhookHeaders;
+	/** The raw request body, byte-for-byte as received. */
+	payload: string;
+	/** The current instant — injected so tests are deterministic. */
+	now: Date;
+}): boolean {
+	const { id, timestamp, signature } = options.headers;
+	if (!id || !timestamp || !signature) {
+		return false;
+	}
+	const timestampSeconds = Number(timestamp);
+	if (!Number.isFinite(timestampSeconds)) {
+		return false;
+	}
+	const skew = Math.abs(options.now.getTime() / 1000 - timestampSeconds);
+	if (skew > WEBHOOK_TOLERANCE_SECONDS) {
+		return false;
+	}
+
+	const expected = createHmac('sha256', secretKey(options.secret))
+		.update(`${id}.${timestamp}.${options.payload}`)
+		.digest();
+
+	// The header carries one or more space-separated `v1,<base64>` entries.
+	return signature.split(' ').some((entry) => {
+		const [version, encoded] = entry.split(',');
+		if (version !== 'v1' || !encoded) {
+			return false;
+		}
+		const candidate = Buffer.from(encoded, 'base64');
+		return candidate.length === expected.length && timingSafeEqual(candidate, expected);
+	});
+}
+
+/**
+ * Sign a payload the Svix way — the counterpart of {@link verifyWebhookSignature},
+ * used by tests (and handy for local `curl`s).
+ */
+export function signWebhookPayload(options: {
+	secret: string;
+	id: string;
+	timestamp: string;
+	payload: string;
+}): string {
+	const digest = createHmac('sha256', secretKey(options.secret))
+		.update(`${options.id}.${options.timestamp}.${options.payload}`)
+		.digest('base64');
+	return `v1,${digest}`;
+}

--- a/packages/api/src/services/agent/whatsapp/adapter.ts
+++ b/packages/api/src/services/agent/whatsapp/adapter.ts
@@ -1,0 +1,57 @@
+import type { AccountId, Customer } from '@rivus/core';
+import type { CustomerRepository } from '../../../repositories/types';
+import type { WhatsappSender } from '../../whatsapp';
+import type {
+	ChannelAdapter,
+	ChannelCapabilities,
+	OutboundContext,
+	SignupPrefill,
+} from '../channel';
+import type { AgentResponse } from '../response';
+import { renderChatResponse } from './renderer';
+
+/**
+ * The WhatsApp channel adapter: recognize senders by phone (`findByPhone`),
+ * render the neutral response as a chat message, and send it through the
+ * {@link WhatsappSender}. Like every adapter it holds no feature logic — the
+ * scheduling engine, capabilities, and composer upstream decide everything, and
+ * this only translates a decision-blind {@link AgentResponse} to WhatsApp.
+ */
+
+const WHATSAPP_CAPABILITIES: ChannelCapabilities = {
+	channel: 'whatsapp',
+	medium: 'chat',
+	supportsRichText: false,
+	supportsInteractiveOptions: false,
+	supportsHyperlinkButtons: false,
+	maxTextLength: 4096,
+	hasSubjects: false,
+	threadingModel: 'session',
+	isRealtimeVoice: false,
+	supportsAttachments: false,
+};
+
+export function createWhatsappChannelAdapter(deps: {
+	customers: CustomerRepository;
+	sender: WhatsappSender;
+}): ChannelAdapter {
+	return {
+		channel: 'whatsapp',
+		capabilities: WHATSAPP_CAPABILITIES,
+		findCustomer(accountId: AccountId, contactAddress: string): Promise<Customer | null> {
+			return deps.customers.findByPhone(accountId, contactAddress);
+		},
+		signupPrefill(sender): SignupPrefill {
+			return { param: 'phone', value: sender.address };
+		},
+		async deliver(response: AgentResponse, ctx: OutboundContext): Promise<string> {
+			const text = renderChatResponse(response, WHATSAPP_CAPABILITIES);
+			await deps.sender.sendMessage({
+				from: ctx.account.channels.whatsapp.address,
+				to: ctx.to.address,
+				text,
+			});
+			return text;
+		},
+	};
+}

--- a/packages/api/src/services/agent/whatsapp/inbound.ts
+++ b/packages/api/src/services/agent/whatsapp/inbound.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+/**
+ * Parsing of zernio's WhatsApp webhook into a canonical channel event. All
+ * knowledge of zernio's wire format lives here (marked `TODO(zernio)`), so the
+ * route and orchestrator see only the normalized event and finalizing against
+ * zernio's real docs touches only this module.
+ */
+
+/** A customer sent an inbound WhatsApp message to the account's business number. */
+export const WHATSAPP_MESSAGE_EVENT = 'whatsapp.message.received';
+/** A message Rivus sent could not be delivered. */
+export const WHATSAPP_FAILED_EVENT = 'whatsapp.message.failed';
+
+/** The canonical inbound event, after mapping from zernio's payload. */
+export const whatsappInboundEventSchema = z.discriminatedUnion('type', [
+	z.object({
+		type: z.literal(WHATSAPP_MESSAGE_EVENT),
+		data: z.object({
+			/** The account's business number the message was sent to (E.164-ish). */
+			to: z.string().default(''),
+			/** The customer's number (E.164-ish). */
+			from: z.string().default(''),
+			/** Message text; '' for non-text messages (which the route declines). */
+			text: z.string().default(''),
+			/** Provider message id — the dedup key. */
+			messageId: z.string().default(''),
+			/** The customer's WhatsApp profile name, when present. */
+			profileName: z.string().default(''),
+		}),
+	}),
+	z.object({
+		type: z.literal(WHATSAPP_FAILED_EVENT),
+		data: z.object({
+			/** The account's business number the failed message was sent from. */
+			from: z.string().default(''),
+			/** The customer's number the message failed to reach. */
+			to: z.string().default(''),
+			reason: z.string().default(''),
+		}),
+	}),
+]);
+export type WhatsappInboundEvent = z.infer<typeof whatsappInboundEventSchema>;
+
+/**
+ * Map a zernio webhook payload into a canonical {@link WhatsappInboundEvent},
+ * or null when it isn't a delivery we handle. zernio's exact payload is TBD, so
+ * v1 validates a payload already shaped like the canonical event (which is what
+ * the local `curl`/test flow posts); the real zernio field mapping slots in here.
+ *
+ * TODO(zernio): translate zernio's actual webhook body (message envelope, media
+ * types, status callbacks) into the canonical event.
+ */
+export function parseZernioInbound(body: unknown): WhatsappInboundEvent | null {
+	const parsed = whatsappInboundEventSchema.safeParse(body);
+	return parsed.success ? parsed.data : null;
+}

--- a/packages/api/src/services/agent/whatsapp/renderer.ts
+++ b/packages/api/src/services/agent/whatsapp/renderer.ts
@@ -1,0 +1,22 @@
+import type { ChannelCapabilities } from '../channel';
+import { type AgentResponse, renderResponseText } from '../response';
+
+/**
+ * The chat-family generic renderer (WhatsApp today; SMS will reuse it): any
+ * {@link AgentResponse} → one plain-text message. It leans on the neutral
+ * `renderResponseText`, which already flattens an `options` block to a numbered
+ * list and an `action` block to a URL line, so it needs no per-decision logic —
+ * a new core feature renders here unchanged. `maxTextLength` is honored so the
+ * same renderer serves length-capped channels (SMS) without change.
+ *
+ * v1 ships text-only (`supportsInteractiveOptions: false`); when zernio's
+ * interactive quick-reply support is confirmed, mapping `options` to native
+ * buttons is a rendering-only change here — no feature or channel edits.
+ */
+export function renderChatResponse(response: AgentResponse, caps: ChannelCapabilities): string {
+	const text = renderResponseText(response);
+	if (caps.maxTextLength !== null && text.length > caps.maxTextLength) {
+		return `${text.slice(0, Math.max(0, caps.maxTextLength - 1))}…`;
+	}
+	return text;
+}

--- a/packages/api/src/services/channel-provisioning.ts
+++ b/packages/api/src/services/channel-provisioning.ts
@@ -1,0 +1,54 @@
+import { type AccountId, agentEmailTag } from '@rivus/core';
+
+/**
+ * Provisioning of a channel's customer-facing identifier. Unlike email (whose
+ * address is derived from the account and always on), WhatsApp/SMS/voice numbers
+ * are assigned by the provider when an owner enables the channel, then stored on
+ * the account. This seam keeps that provider call behind an interface so the API
+ * boots and tests without credentials.
+ */
+
+/** A provisioned identifier plus the provider's opaque handle for it. */
+export interface ProvisionedIdentifier {
+	/** The customer-facing E.164 number. */
+	address: string;
+	/** The provider's reference for the provisioned resource; '' when none. */
+	providerRef: string;
+}
+
+export interface ChannelProvisioner {
+	/**
+	 * Assign (or re-confirm) this account's identifier. Idempotent: when
+	 * `existing.address` is non-empty it is returned unchanged (re-enabling never
+	 * re-provisions). Rejects on provider failure — the route maps that to 502 and
+	 * persists nothing.
+	 */
+	provision(input: {
+		accountId: AccountId;
+		accountName: string;
+		existing: ProvisionedIdentifier;
+	}): Promise<ProvisionedIdentifier>;
+}
+
+/**
+ * A provisioner that hands out a deterministic fake number derived from the
+ * account id (the same FNV-1a tag the agent email address uses), so development
+ * and tests get a stable, unique `+1555…` number without a provider — and
+ * re-enabling returns the same one.
+ */
+export class NoopChannelProvisioner implements ChannelProvisioner {
+	async provision(input: {
+		accountId: AccountId;
+		accountName: string;
+		existing: ProvisionedIdentifier;
+	}): Promise<ProvisionedIdentifier> {
+		if (input.existing.address !== '') {
+			return input.existing;
+		}
+		// 7 subscriber digits from the account's hex tag → +1 555 XXX XXXX.
+		const subscriber = (Number.parseInt(agentEmailTag(input.accountId), 16) % 10_000_000)
+			.toString()
+			.padStart(7, '0');
+		return { address: `+1555${subscriber}`, providerRef: 'noop' };
+	}
+}

--- a/packages/api/src/services/whatsapp.ts
+++ b/packages/api/src/services/whatsapp.ts
@@ -1,0 +1,31 @@
+/**
+ * The WhatsApp transport seam — the messaging counterpart of {@link Mailer}. The
+ * scheduling agent and the inbox reply-out both send through this interface, so
+ * the provider (zernio) stays behind an adapter and tests inject a recording or
+ * no-op sender.
+ */
+
+/** A WhatsApp text message to deliver. */
+export interface WhatsappMessage {
+	/** The account's provisioned business number (E.164). */
+	from: string;
+	/** The customer's number (E.164). */
+	to: string;
+	/** Plain-text message body. */
+	text: string;
+}
+
+/** Delivers WhatsApp messages. Implementations reject on delivery failure. */
+export interface WhatsappSender {
+	sendMessage(message: WhatsappMessage): Promise<void>;
+}
+
+/**
+ * A sender that delivers nothing — used when no zernio key is configured so the
+ * API still runs in development and tests without attempting real delivery.
+ */
+export class NoopWhatsappSender implements WhatsappSender {
+	async sendMessage(_message: WhatsappMessage): Promise<void> {
+		// Intentionally does nothing.
+	}
+}

--- a/packages/api/src/services/zernio-whatsapp.ts
+++ b/packages/api/src/services/zernio-whatsapp.ts
@@ -1,0 +1,145 @@
+import { type AccountId, normalizePhone } from '@rivus/core';
+import { z } from 'zod';
+import type { Config } from '../config';
+import {
+	type ChannelProvisioner,
+	NoopChannelProvisioner,
+	type ProvisionedIdentifier,
+} from './channel-provisioning';
+import type { FetchLike } from './resend-mailer';
+import { NoopWhatsappSender, type WhatsappMessage, type WhatsappSender } from './whatsapp';
+
+/**
+ * The zernio adapter for the WhatsApp seams — the only module that knows zernio's
+ * wire format. It calls the documented REST endpoints with `fetch` (the same
+ * injectable-transport pattern as `ResendMailer`), so it adds no dependency and
+ * is trivially faked in tests. Every zernio-specific assumption (endpoint paths,
+ * request/response field names) is marked `TODO(zernio)` and lives here alone, so
+ * finalizing against the real docs touches only this file.
+ */
+
+// TODO(zernio): confirm the send + provision endpoint paths against zernio's docs.
+const SEND_PATH = '/v1/messages';
+const NUMBERS_PATH = '/v1/numbers';
+
+interface ZernioOptions {
+	apiKey: string;
+	apiUrl: string;
+	fetchImpl?: FetchLike;
+}
+
+function bearer(apiKey: string): Record<string, string> {
+	return { authorization: `Bearer ${apiKey}`, 'content-type': 'application/json' };
+}
+
+export class ZernioWhatsappSender implements WhatsappSender {
+	private readonly apiKey: string;
+	private readonly endpoint: string;
+	private readonly fetchImpl: FetchLike;
+
+	constructor(options: ZernioOptions) {
+		this.apiKey = options.apiKey;
+		this.endpoint = `${options.apiUrl.replace(/\/+$/, '')}${SEND_PATH}`;
+		this.fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+	}
+
+	async sendMessage(message: WhatsappMessage): Promise<void> {
+		const response = await this.fetchImpl(this.endpoint, {
+			method: 'POST',
+			headers: bearer(this.apiKey),
+			// TODO(zernio): confirm the send payload field names.
+			body: JSON.stringify({
+				from: message.from,
+				to: message.to,
+				type: 'text',
+				text: { body: message.text },
+			}),
+		});
+		if (!response.ok) {
+			const detail = await response.text().catch(() => '');
+			throw new Error(
+				`zernio rejected the WhatsApp message (status ${response.status})${detail ? `: ${detail}` : ''}`,
+			);
+		}
+	}
+}
+
+// TODO(zernio): confirm the provisioning response shape.
+const provisionResponseSchema = z.object({
+	phone_number: z.string(),
+	id: z.string().nullish(),
+});
+
+export class ZernioProvisioner implements ChannelProvisioner {
+	private readonly apiKey: string;
+	private readonly endpoint: string;
+	private readonly fetchImpl: FetchLike;
+
+	constructor(options: ZernioOptions) {
+		this.apiKey = options.apiKey;
+		this.endpoint = `${options.apiUrl.replace(/\/+$/, '')}${NUMBERS_PATH}`;
+		this.fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+	}
+
+	async provision(input: {
+		accountId: AccountId;
+		accountName: string;
+		existing: ProvisionedIdentifier;
+	}): Promise<ProvisionedIdentifier> {
+		// Idempotent: never re-provision an account that already holds a number.
+		if (input.existing.address !== '') {
+			return input.existing;
+		}
+		const response = await this.fetchImpl(this.endpoint, {
+			method: 'POST',
+			headers: bearer(this.apiKey),
+			// TODO(zernio): confirm the provisioning request payload.
+			body: JSON.stringify({ account_name: input.accountName }),
+		});
+		if (!response.ok) {
+			const detail = await response.text().catch(() => '');
+			throw new Error(
+				`zernio failed to provision a WhatsApp number (status ${response.status})${detail ? `: ${detail}` : ''}`,
+			);
+		}
+		const parsed = provisionResponseSchema.safeParse(JSON.parse(await response.text()));
+		if (!parsed.success) {
+			throw new Error('zernio returned an unrecognized provisioning response.');
+		}
+		const address = normalizePhone(parsed.data.phone_number);
+		if (address === '') {
+			throw new Error('zernio provisioned a number that is not valid E.164.');
+		}
+		return { address, providerRef: parsed.data.id ?? '' };
+	}
+}
+
+/** A WhatsApp sender for the config: real zernio when a key is present, else a no-op. */
+export function createWhatsappSender(
+	config: Pick<Config, 'ZERNIO_API_KEY' | 'ZERNIO_API_URL'>,
+	fetchImpl?: FetchLike,
+): WhatsappSender {
+	if (!config.ZERNIO_API_KEY) {
+		return new NoopWhatsappSender();
+	}
+	return new ZernioWhatsappSender({
+		apiKey: config.ZERNIO_API_KEY,
+		apiUrl: config.ZERNIO_API_URL,
+		fetchImpl,
+	});
+}
+
+/** A channel provisioner for the config: real zernio when a key is present, else a no-op. */
+export function createWhatsappProvisioner(
+	config: Pick<Config, 'ZERNIO_API_KEY' | 'ZERNIO_API_URL'>,
+	fetchImpl?: FetchLike,
+): ChannelProvisioner {
+	if (!config.ZERNIO_API_KEY) {
+		return new NoopChannelProvisioner();
+	}
+	return new ZernioProvisioner({
+		apiKey: config.ZERNIO_API_KEY,
+		apiUrl: config.ZERNIO_API_URL,
+		fetchImpl,
+	});
+}

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -17,10 +17,12 @@ import type {
 	VerificationCodeRepository,
 } from './repositories/types';
 import type { ReceivedEmailReader } from './services/agent/email/received';
+import type { ChannelProvisioner } from './services/channel-provisioning';
 import type { Mailer } from './services/email';
 import type { FaqAnswerService } from './services/faq-answer';
 import type { FaqSimilarityService } from './services/faq-similarity';
 import type { NotificationService } from './services/notifications';
+import type { WhatsappSender } from './services/whatsapp';
 
 /** Result of a readiness check: whether dependencies are usable, and why not. */
 export interface ReadinessResult {
@@ -54,6 +56,10 @@ export interface AppDeps {
 	mailer: Mailer;
 	/** Fetches inbound email bodies (Resend's webhook delivers metadata only). */
 	receivedEmails: ReceivedEmailReader;
+	/** Sends WhatsApp messages (the scheduling agent's replies and inbox reply-out). */
+	whatsappSender: WhatsappSender;
+	/** Provisions a WhatsApp business number when an owner enables the channel. */
+	whatsappProvisioner: ChannelProvisioner;
 	/** Turns domain events (job assigned, invite accepted, …) into notifications. */
 	notifier: NotificationService;
 	/** AI check for near-duplicate FAQs (a no-op when no provider key is set). */

--- a/packages/api/test/account-channels-route.test.ts
+++ b/packages/api/test/account-channels-route.test.ts
@@ -1,0 +1,119 @@
+import { faker } from '@faker-js/faker';
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ChannelProvisioner } from '../src/services/channel-provisioning';
+import { addMember, authHeader, buildTestApp, signupOwner } from './helpers';
+
+const ENABLE = '/v1/account/channels/whatsapp/enable';
+const DISABLE = '/v1/account/channels/whatsapp/disable';
+
+describe('account channel provisioning', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('provisions and persists a number when the owner enables WhatsApp', async () => {
+		app = await buildTestApp();
+		const owner = await signupOwner(app);
+		const res = await app.inject({ method: 'POST', url: ENABLE, headers: authHeader(owner.token) });
+		expect(res.statusCode).toBe(200);
+		const whatsapp = res.json().channels.whatsapp;
+		expect(whatsapp.enabled).toBe(true);
+		expect(whatsapp.address).toMatch(/^\+1555\d{7}$/);
+		// The public shape never leaks the provider reference.
+		expect(whatsapp.providerRef).toBeUndefined();
+	});
+
+	it('is idempotent — re-enabling returns the same number', async () => {
+		app = await buildTestApp();
+		const owner = await signupOwner(app);
+		const first = await app.inject({
+			method: 'POST',
+			url: ENABLE,
+			headers: authHeader(owner.token),
+		});
+		const second = await app.inject({
+			method: 'POST',
+			url: ENABLE,
+			headers: authHeader(owner.token),
+		});
+		expect(second.statusCode).toBe(200);
+		expect(second.json().channels.whatsapp.address).toBe(first.json().channels.whatsapp.address);
+	});
+
+	it('retains the number when disabled and restores it on re-enable', async () => {
+		app = await buildTestApp();
+		const owner = await signupOwner(app);
+		const enabled = await app.inject({
+			method: 'POST',
+			url: ENABLE,
+			headers: authHeader(owner.token),
+		});
+		const number = enabled.json().channels.whatsapp.address;
+
+		const disabled = await app.inject({
+			method: 'POST',
+			url: DISABLE,
+			headers: authHeader(owner.token),
+		});
+		expect(disabled.statusCode).toBe(200);
+		expect(disabled.json().channels.whatsapp).toMatchObject({ enabled: false, address: number });
+
+		const reEnabled = await app.inject({
+			method: 'POST',
+			url: ENABLE,
+			headers: authHeader(owner.token),
+		});
+		expect(reEnabled.json().channels.whatsapp).toMatchObject({ enabled: true, address: number });
+	});
+
+	it('forbids a non-owner from enabling a channel', async () => {
+		app = await buildTestApp();
+		const owner = await signupOwner(app);
+		const member = await addMember(app, owner.token, 'member', faker.internet.email());
+		const res = await app.inject({
+			method: 'POST',
+			url: ENABLE,
+			headers: authHeader(member.token),
+		});
+		expect(res.statusCode).toBe(403);
+	});
+
+	it('returns 502 and persists nothing when provisioning fails', async () => {
+		const failingProvisioner: ChannelProvisioner = {
+			async provision() {
+				throw new Error('provider down');
+			},
+		};
+		app = await buildTestApp({ whatsappProvisioner: failingProvisioner });
+		const owner = await signupOwner(app);
+		const res = await app.inject({ method: 'POST', url: ENABLE, headers: authHeader(owner.token) });
+		expect(res.statusCode).toBe(502);
+		// The account is untouched — the channel stays off.
+		const me = await app.inject({
+			method: 'GET',
+			url: '/v1/auth/me',
+			headers: authHeader(owner.token),
+		});
+		expect(me.json().account.channels.whatsapp.enabled).toBe(false);
+	});
+
+	it('rejects an unknown channel (400) and a not-yet-available one (400)', async () => {
+		app = await buildTestApp();
+		const owner = await signupOwner(app);
+		const unknown = await app.inject({
+			method: 'POST',
+			url: '/v1/account/channels/email/enable',
+			headers: authHeader(owner.token),
+		});
+		expect(unknown.statusCode).toBe(400);
+		const notYet = await app.inject({
+			method: 'POST',
+			url: '/v1/account/channels/sms/enable',
+			headers: authHeader(owner.token),
+		});
+		expect(notYet.statusCode).toBe(400);
+	});
+});

--- a/packages/api/test/account-repository.test.ts
+++ b/packages/api/test/account-repository.test.ts
@@ -1,6 +1,17 @@
-import type { Account, AccountId } from '@rivus/core';
+import {
+	type Account,
+	type AccountId,
+	type Customer,
+	type CustomerId,
+	emptyAccountChannels,
+} from '@rivus/core';
 import { describe, expect, it } from 'vitest';
-import { createInMemoryData, InMemoryAccountRepository } from '../src/repositories/memory';
+import { ConflictError } from '../src/repositories/errors';
+import {
+	createInMemoryData,
+	InMemoryAccountRepository,
+	InMemoryCustomerRepository,
+} from '../src/repositories/memory';
 
 /**
  * Direct unit tests for the account list filter, which powers the staff company
@@ -27,8 +38,30 @@ function makeAccount(fields: {
 		address: '',
 		website: '',
 		timezone: 'UTC',
+		channels: emptyAccountChannels(),
 		status: fields.status ?? 'active',
 		canceledAt: null,
+		createdAt: TIMESTAMP,
+		updatedAt: TIMESTAMP,
+	};
+}
+
+function makeCustomer(fields: {
+	id: string;
+	accountId: string;
+	name: string;
+	phone: string;
+}): Customer {
+	return {
+		id: fields.id as CustomerId,
+		accountId: fields.accountId as AccountId,
+		name: fields.name,
+		email: '',
+		phone: fields.phone,
+		address: '',
+		lifetimeValue: 0,
+		balance: 0,
+		notes: '',
 		createdAt: TIMESTAMP,
 		updatedAt: TIMESTAMP,
 	};
@@ -89,5 +122,134 @@ describe('InMemoryAccountRepository.list — status filtering', () => {
 		const { accounts } = await repo.list({ page: 1, pageSize: 50, search: 'beacon' });
 
 		expect(accounts.map((account) => account.name)).toEqual(['Beacon Electric']);
+	});
+});
+
+describe('InMemoryAccountRepository — provisioned channels', () => {
+	async function seededRepo() {
+		const repo = new InMemoryAccountRepository(createInMemoryData());
+		const account = await repo.create({
+			name: 'Cascade Plumbing',
+			slug: 'cascade-plumbing',
+			phone: '',
+			address: '',
+			website: '',
+			timezone: 'UTC',
+		});
+		return { repo, account };
+	}
+
+	it('defaults every channel to off/empty on a new account', async () => {
+		const { account } = await seededRepo();
+		expect(account.channels).toEqual({
+			whatsapp: { enabled: false, address: '', providerRef: '' },
+			sms: { enabled: false, address: '', providerRef: '' },
+			voice: { enabled: false, address: '', providerRef: '' },
+		});
+	});
+
+	it('setChannelConfig provisions a number and findByChannelAddress resolves it', async () => {
+		const { repo, account } = await seededRepo();
+		await repo.setChannelConfig(account.id, 'whatsapp', {
+			enabled: true,
+			address: '+15551234567',
+			providerRef: 'zwa_1',
+		});
+
+		const found = await repo.findByChannelAddress('whatsapp', '+15551234567');
+		expect(found?.id).toBe(account.id);
+		expect(found?.channels.whatsapp).toEqual({
+			enabled: true,
+			address: '+15551234567',
+			providerRef: 'zwa_1',
+		});
+		// The number is scoped to its channel — SMS with the same digits doesn't resolve.
+		expect(await repo.findByChannelAddress('sms', '+15551234567')).toBeNull();
+	});
+
+	it('findByChannelAddress never matches an empty address', async () => {
+		const { repo } = await seededRepo();
+		expect(await repo.findByChannelAddress('whatsapp', '')).toBeNull();
+	});
+
+	it('rejects a number already provisioned to another account', async () => {
+		const { repo, account } = await seededRepo();
+		await repo.setChannelConfig(account.id, 'whatsapp', {
+			enabled: true,
+			address: '+15551234567',
+			providerRef: 'zwa_1',
+		});
+		const other = await repo.create({
+			name: 'Beacon Electric',
+			slug: 'beacon-electric',
+			phone: '',
+			address: '',
+			website: '',
+			timezone: 'UTC',
+		});
+
+		await expect(
+			repo.setChannelConfig(other.id, 'whatsapp', {
+				enabled: true,
+				address: '+15551234567',
+				providerRef: 'zwa_2',
+			}),
+		).rejects.toBeInstanceOf(ConflictError);
+	});
+
+	it('keeps the same account able to re-set its own number', async () => {
+		const { repo, account } = await seededRepo();
+		const config = { enabled: true, address: '+15551234567', providerRef: 'zwa_1' };
+		await repo.setChannelConfig(account.id, 'whatsapp', config);
+		// Disabling retains the number (address unchanged) without a self-conflict.
+		const disabled = await repo.setChannelConfig(account.id, 'whatsapp', {
+			...config,
+			enabled: false,
+		});
+		expect(disabled?.channels.whatsapp.enabled).toBe(false);
+		expect(disabled?.channels.whatsapp.address).toBe('+15551234567');
+	});
+});
+
+describe('InMemoryCustomerRepository.findByPhone', () => {
+	it('matches a free-text CRM phone against an E.164 sender, newest-first', async () => {
+		const data = createInMemoryData();
+		const accountId = 'acct-1';
+		data.customers.set(
+			'old',
+			makeCustomer({ id: 'old', accountId, name: 'Old Dana', phone: '(555) 123-4567' }),
+		);
+		data.customers.set(
+			'new',
+			makeCustomer({ id: 'new', accountId, name: 'New Dana', phone: '555.123.4567' }),
+		);
+		const repo = new InMemoryCustomerRepository(data);
+
+		const match = await repo.findByPhone(accountId as AccountId, '+15551234567');
+		expect(match?.name).toBe('New Dana');
+	});
+
+	it('returns null for an empty query, no match, or a different account', async () => {
+		const data = createInMemoryData();
+		data.customers.set(
+			'c1',
+			makeCustomer({ id: 'c1', accountId: 'acct-1', name: 'Dana', phone: '(555) 123-4567' }),
+		);
+		const repo = new InMemoryCustomerRepository(data);
+
+		expect(await repo.findByPhone('acct-1' as AccountId, '')).toBeNull();
+		expect(await repo.findByPhone('acct-1' as AccountId, '+15559999999')).toBeNull();
+		expect(await repo.findByPhone('acct-2' as AccountId, '+15551234567')).toBeNull();
+	});
+
+	it('never matches an unnormalizable stored phone', async () => {
+		const data = createInMemoryData();
+		data.customers.set(
+			'c1',
+			makeCustomer({ id: 'c1', accountId: 'acct-1', name: 'Dana', phone: 'call the office' }),
+		);
+		const repo = new InMemoryCustomerRepository(data);
+
+		expect(await repo.findByPhone('acct-1' as AccountId, '+15551234567')).toBeNull();
 	});
 });

--- a/packages/api/test/agent-email-route.test.ts
+++ b/packages/api/test/agent-email-route.test.ts
@@ -7,9 +7,11 @@ import { createInMemoryRepositories } from '../src/repositories/memory';
 import type { ReceivedEmailContent } from '../src/services/agent/email/received';
 import { NoopReceivedEmailReader } from '../src/services/agent/email/received';
 import { signWebhookPayload } from '../src/services/agent/email/webhook';
+import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
 import { NoopFaqAnswerService } from '../src/services/faq-answer';
 import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
 import { createNotificationService } from '../src/services/notifications';
+import { NoopWhatsappSender } from '../src/services/whatsapp';
 import { buildTestApp, buildTestAppWithRepos, RecordingMailer, signupOwner } from './helpers';
 
 const WEBHOOK_URL = '/v1/channels/email/inbound';
@@ -616,6 +618,8 @@ describe('POST /v1/channels/email/inbound — signatures', () => {
 			...repos,
 			mailer: new RecordingMailer(),
 			receivedEmails: new NoopReceivedEmailReader(),
+			whatsappSender: new NoopWhatsappSender(),
+			whatsappProvisioner: new NoopChannelProvisioner(),
 			notifier: createNotificationService({ notifications: repos.notifications }),
 			faqSimilarity: new NoopFaqSimilarityService(),
 			faqAnswer: new NoopFaqAnswerService(),

--- a/packages/api/test/agent-response-matrix.test.ts
+++ b/packages/api/test/agent-response-matrix.test.ts
@@ -1,0 +1,154 @@
+import type { Account, AccountId, AgentThread, AgentThreadId, ConversationId } from '@rivus/core';
+import { emptyAccountChannels } from '@rivus/core';
+import { describe, expect, it } from 'vitest';
+import { createInMemoryRepositories } from '../src/repositories/memory';
+import type { ChannelAdapter } from '../src/services/agent/channel';
+import { createEmailChannelAdapter } from '../src/services/agent/email/adapter';
+import type { AgentDecision } from '../src/services/agent/engine';
+import { type AgentReplyContext, composeAgentResponse } from '../src/services/agent/response';
+import type { AgentEmail, Mailer } from '../src/services/email';
+
+/**
+ * The invariant that makes "a core feature ships on every channel" structural:
+ * every registered channel adapter must render EVERY agent decision into a
+ * non-empty message and a non-empty transcript line. A future decision kind a
+ * channel can't render fails here — for that channel, in one run — long before it
+ * could silently go missing in production. (The block-kind switches in each
+ * renderer are also TypeScript-exhaustive, so a new block kind is a compile error
+ * in every renderer first.) When a channel is added, it joins the `CHANNELS`
+ * list below and is covered automatically.
+ */
+
+const SLOT_A = { startAt: '2026-07-07T16:00:00.000Z', durationMinutes: 60 };
+const SLOT_B = { startAt: '2026-07-09T21:00:00.000Z', durationMinutes: 60 };
+const SLOTS = [SLOT_A, SLOT_B];
+
+const DECISIONS: AgentDecision[] = [
+	{ kind: 'send_signup_link' },
+	{ kind: 'offer_slots', slots: SLOTS },
+	{ kind: 'book', slot: SLOT_A },
+	{ kind: 'confirm_existing', slot: SLOT_A },
+	{
+		kind: 'propose_unavailable',
+		reason: 'taken',
+		requestedStartAt: SLOT_A.startAt,
+		alternatives: SLOTS,
+	},
+	{
+		kind: 'propose_unavailable',
+		reason: 'beyond_horizon',
+		requestedStartAt: SLOT_A.startAt,
+		alternatives: [],
+	},
+	{ kind: 'no_availability' },
+];
+
+/** A mailer that records the last agent email it was asked to send. */
+class RecordingMailer implements Mailer {
+	last: AgentEmail | null = null;
+	async sendInviteEmail(): Promise<void> {}
+	async sendVerificationCode(): Promise<void> {}
+	async sendAgentEmail(email: AgentEmail): Promise<void> {
+		this.last = email;
+	}
+}
+
+function account(): Account {
+	const timestamp = '2026-01-01T00:00:00.000Z';
+	return {
+		id: 'acct-1' as AccountId,
+		name: 'Cascade Plumbing',
+		slug: 'cascade-plumbing',
+		phone: '',
+		address: '',
+		website: '',
+		timezone: 'America/Los_Angeles',
+		channels: emptyAccountChannels(),
+		status: 'active',
+		canceledAt: null,
+		createdAt: timestamp,
+		updatedAt: timestamp,
+	};
+}
+
+function thread(): AgentThread {
+	const timestamp = '2026-01-01T00:00:00.000Z';
+	return {
+		id: 'thread-1' as AgentThreadId,
+		accountId: 'acct-1' as AccountId,
+		channel: 'email',
+		contactAddress: 'dana@example.com',
+		conversationId: 'conv-1' as ConversationId,
+		customerId: '',
+		state: 'new',
+		offeredSlots: [],
+		lastExternalMessageId: '',
+		subject: 'Water heater',
+		bookedJobId: '',
+		createdAt: timestamp,
+		updatedAt: timestamp,
+	};
+}
+
+function replyContext(medium: AgentReplyContext['medium']): AgentReplyContext {
+	return {
+		accountName: 'Cascade Plumbing',
+		customerName: 'Dana Fox',
+		timeZone: 'America/Los_Angeles',
+		signupUrl: 'https://www.rivus.ai/customers/join/cascade-plumbing?email=d%40x.io',
+		jobTitle: 'Water heater install',
+		now: new Date('2026-07-03T17:00:00.000Z'),
+		medium,
+	};
+}
+
+interface ChannelUnderTest {
+	name: string;
+	adapter: ChannelAdapter;
+	/** The transport's last-sent rendered body, for the non-empty assertion. */
+	lastRendered(): string;
+}
+
+function emailChannel(): ChannelUnderTest {
+	const mailer = new RecordingMailer();
+	const { customers } = createInMemoryRepositories();
+	const adapter = createEmailChannelAdapter({
+		config: { AGENT_EMAIL_DOMAIN: 'riv.us' },
+		customers,
+		mailer,
+	});
+	return { name: 'email', adapter, lastRendered: () => mailer.last?.html ?? '' };
+}
+
+// Every channel with an outbound transport. Adding one here covers it for all decisions.
+const CHANNELS: Array<() => ChannelUnderTest> = [emailChannel];
+
+describe('agent response render matrix (channels × decisions)', () => {
+	for (const makeChannel of CHANNELS) {
+		const { name } = makeChannel();
+		describe(name, () => {
+			for (const decision of DECISIONS) {
+				const label =
+					decision.kind === 'propose_unavailable'
+						? `${decision.kind}:${decision.reason}:${decision.alternatives.length ? 'alt' : 'none'}`
+						: decision.kind;
+				it(`renders ${label} into a non-empty message and transcript line`, async () => {
+					const channel = makeChannel();
+					const response = composeAgentResponse(
+						decision,
+						replyContext(channel.adapter.capabilities.medium),
+					);
+					const transcriptLine = await channel.adapter.deliver(response, {
+						account: account(),
+						thread: thread(),
+						to: { address: 'dana@example.com', name: 'Dana Fox' },
+						replyToExternalId: '<m1@mail.example.com>',
+						subject: 'Water heater',
+					});
+					expect(transcriptLine.trim().length).toBeGreaterThan(0);
+					expect(channel.lastRendered().trim().length).toBeGreaterThan(0);
+				});
+			}
+		});
+	}
+});

--- a/packages/api/test/agent-response-matrix.test.ts
+++ b/packages/api/test/agent-response-matrix.test.ts
@@ -6,7 +6,9 @@ import type { ChannelAdapter } from '../src/services/agent/channel';
 import { createEmailChannelAdapter } from '../src/services/agent/email/adapter';
 import type { AgentDecision } from '../src/services/agent/engine';
 import { type AgentReplyContext, composeAgentResponse } from '../src/services/agent/response';
+import { createWhatsappChannelAdapter } from '../src/services/agent/whatsapp/adapter';
 import type { AgentEmail, Mailer } from '../src/services/email';
+import { RecordingWhatsappSender } from './helpers';
 
 /**
  * The invariant that makes "a core feature ships on every channel" structural:
@@ -120,8 +122,15 @@ function emailChannel(): ChannelUnderTest {
 	return { name: 'email', adapter, lastRendered: () => mailer.last?.html ?? '' };
 }
 
+function whatsappChannel(): ChannelUnderTest {
+	const sender = new RecordingWhatsappSender();
+	const { customers } = createInMemoryRepositories();
+	const adapter = createWhatsappChannelAdapter({ customers, sender });
+	return { name: 'whatsapp', adapter, lastRendered: () => sender.messages.at(-1)?.text ?? '' };
+}
+
 // Every channel with an outbound transport. Adding one here covers it for all decisions.
-const CHANNELS: Array<() => ChannelUnderTest> = [emailChannel];
+const CHANNELS: Array<() => ChannelUnderTest> = [emailChannel, whatsappChannel];
 
 describe('agent response render matrix (channels × decisions)', () => {
 	for (const makeChannel of CHANNELS) {

--- a/packages/api/test/agent-response.test.ts
+++ b/packages/api/test/agent-response.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentDecision } from '../src/services/agent/engine';
+import {
+	type AgentReplyContext,
+	type ChannelMedium,
+	composeAgentResponse,
+	freeTextResponse,
+	renderResponseText,
+} from '../src/services/agent/response';
+
+/**
+ * The core `AgentDecision → AgentResponse` composer. This is the single place
+ * decision kinds become content (the switch that used to live in each channel's
+ * templates), so covering every kind here is what lets every channel render every
+ * decision without its own per-kind logic.
+ */
+
+const NOW = new Date('2026-07-03T17:00:00.000Z');
+
+function context(overrides: Partial<AgentReplyContext> = {}): AgentReplyContext {
+	return {
+		accountName: 'Cascade Plumbing',
+		customerName: 'Dana Fox',
+		timeZone: 'America/Los_Angeles',
+		signupUrl: 'https://www.rivus.ai/customers/join/cascade-plumbing?email=d%40x.io',
+		jobTitle: 'Water heater install',
+		now: NOW,
+		medium: 'email',
+		...overrides,
+	};
+}
+
+const SLOT_A = { startAt: '2026-07-07T16:00:00.000Z', durationMinutes: 60 };
+const SLOT_B = { startAt: '2026-07-09T21:00:00.000Z', durationMinutes: 60 };
+const SLOTS = [SLOT_A, SLOT_B];
+
+/** Every decision kind, with a representative payload. */
+const DECISIONS: AgentDecision[] = [
+	{ kind: 'send_signup_link' },
+	{ kind: 'offer_slots', slots: SLOTS },
+	{ kind: 'book', slot: SLOT_A },
+	{ kind: 'confirm_existing', slot: SLOT_A },
+	{
+		kind: 'propose_unavailable',
+		reason: 'taken',
+		requestedStartAt: SLOT_A.startAt,
+		alternatives: SLOTS,
+	},
+	{
+		kind: 'propose_unavailable',
+		reason: 'outside_hours',
+		requestedStartAt: SLOT_A.startAt,
+		alternatives: [],
+	},
+	{ kind: 'no_availability' },
+];
+
+describe('composeAgentResponse', () => {
+	it('always opens with a greeting block naming the customer', () => {
+		for (const decision of DECISIONS) {
+			const [first] = composeAgentResponse(decision, context()).blocks;
+			expect(first).toEqual({ kind: 'greeting', text: 'Hi Dana,' });
+		}
+	});
+
+	it('greets an unrecognized contact generically', () => {
+		const [first] = composeAgentResponse(
+			{ kind: 'send_signup_link' },
+			context({ customerName: '' }),
+		).blocks;
+		expect(first).toEqual({ kind: 'greeting', text: 'Hi there,' });
+	});
+
+	it('renders offered slots as an options block with 1-based values', () => {
+		const response = composeAgentResponse({ kind: 'offer_slots', slots: SLOTS }, context());
+		const options = response.blocks.find((block) => block.kind === 'options');
+		expect(options).toBeDefined();
+		expect(options?.kind === 'options' && options.items.map((item) => item.value)).toEqual([
+			'1',
+			'2',
+		]);
+	});
+
+	it('renders the signup link as an action block', () => {
+		const response = composeAgentResponse({ kind: 'send_signup_link' }, context());
+		const action = response.blocks.find((block) => block.kind === 'action');
+		expect(action).toEqual({
+			kind: 'action',
+			label: 'Join Cascade Plumbing as a customer',
+			url: context().signupUrl,
+		});
+	});
+
+	it('words the reply prompt for the medium', () => {
+		const email = renderResponseText(
+			composeAgentResponse({ kind: 'send_signup_link' }, context({ medium: 'email' })),
+		);
+		const chat = renderResponseText(
+			composeAgentResponse({ kind: 'send_signup_link' }, context({ medium: 'chat' })),
+		);
+		expect(email).toContain('reply to this email');
+		expect(chat).toContain('reply here');
+		expect(chat).not.toContain('reply to this email');
+	});
+
+	it('produces non-empty, decision-appropriate text for every kind', () => {
+		expect(
+			renderResponseText(composeAgentResponse({ kind: 'book', slot: SLOT_A }, context())),
+		).toContain("You're booked!");
+		expect(
+			renderResponseText(composeAgentResponse({ kind: 'no_availability' }, context())),
+		).toContain('fully booked');
+		expect(
+			renderResponseText(
+				composeAgentResponse(
+					{
+						kind: 'propose_unavailable',
+						reason: 'in_past',
+						requestedStartAt: SLOT_A.startAt,
+						alternatives: [],
+					},
+					context(),
+				),
+			),
+		).toContain('already passed');
+		for (const decision of DECISIONS) {
+			for (const medium of ['email', 'chat', 'voice'] as ChannelMedium[]) {
+				const text = renderResponseText(composeAgentResponse(decision, context({ medium })));
+				expect(text.trim().length).toBeGreaterThan(0);
+			}
+		}
+	});
+});
+
+describe('freeTextResponse + renderResponseText', () => {
+	it('round-trips a free-text body verbatim', () => {
+		const body = 'Hi Dana,\n\nWe can be there at noon.\n— Sam';
+		expect(renderResponseText(freeTextResponse(body))).toBe(body);
+	});
+});

--- a/packages/api/test/agent-whatsapp-channel.test.ts
+++ b/packages/api/test/agent-whatsapp-channel.test.ts
@@ -1,0 +1,239 @@
+import type { AccountId } from '@rivus/core';
+import { describe, expect, it, vi } from 'vitest';
+import type { ChannelCapabilities } from '../src/services/agent/channel';
+import { composeAgentResponse } from '../src/services/agent/response';
+import { parseZernioInbound, WHATSAPP_MESSAGE_EVENT } from '../src/services/agent/whatsapp/inbound';
+import { renderChatResponse } from '../src/services/agent/whatsapp/renderer';
+import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
+import type { FetchLike } from '../src/services/resend-mailer';
+import {
+	createWhatsappProvisioner,
+	createWhatsappSender,
+	ZernioProvisioner,
+	ZernioWhatsappSender,
+} from '../src/services/zernio-whatsapp';
+
+const CHAT_CAPS: ChannelCapabilities = {
+	channel: 'whatsapp',
+	medium: 'chat',
+	supportsRichText: false,
+	supportsInteractiveOptions: false,
+	supportsHyperlinkButtons: false,
+	maxTextLength: 4096,
+	hasSubjects: false,
+	threadingModel: 'session',
+	isRealtimeVoice: false,
+	supportsAttachments: false,
+};
+
+function replyContext(medium: 'chat' | 'email' = 'chat') {
+	return {
+		accountName: 'Cascade Plumbing',
+		customerName: 'Dana',
+		timeZone: 'America/Los_Angeles',
+		signupUrl: 'https://www.rivus.ai/customers/join/cascade-plumbing?phone=%2B15559990000',
+		jobTitle: 'Appointment',
+		now: new Date('2026-07-03T17:00:00.000Z'),
+		medium,
+	} as const;
+}
+
+describe('parseZernioInbound', () => {
+	it('parses a canonical inbound message event', () => {
+		const event = parseZernioInbound({
+			type: WHATSAPP_MESSAGE_EVENT,
+			data: { to: '+15550001111', from: '+15559990000', text: 'Hi', messageId: 'wamid.1' },
+		});
+		expect(event?.type).toBe(WHATSAPP_MESSAGE_EVENT);
+		expect(event?.type === WHATSAPP_MESSAGE_EVENT && event.data.profileName).toBe('');
+	});
+
+	it('parses a delivery-failure event', () => {
+		const event = parseZernioInbound({
+			type: 'whatsapp.message.failed',
+			data: { from: '+15550001111', to: '+15559990000', reason: 'undeliverable' },
+		});
+		expect(event?.type).toBe('whatsapp.message.failed');
+	});
+
+	it('returns null for an unrecognized payload', () => {
+		expect(parseZernioInbound({ type: 'nope' })).toBeNull();
+		expect(parseZernioInbound(null)).toBeNull();
+		expect(parseZernioInbound('garbage')).toBeNull();
+	});
+});
+
+describe('ZernioWhatsappSender', () => {
+	it('POSTs the message with a bearer token and resolves on 2xx', async () => {
+		const fetchImpl = vi.fn<FetchLike>().mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => '{"id":"m1"}',
+		});
+		const sender = new ZernioWhatsappSender({
+			apiKey: 'zk_1',
+			apiUrl: 'https://api.zernio.com',
+			fetchImpl,
+		});
+		await sender.sendMessage({ from: '+15550001111', to: '+15559990000', text: 'Hello' });
+		const [url, init] = fetchImpl.mock.calls[0] as [
+			string,
+			{ headers: Record<string, string>; body: string },
+		];
+		expect(url).toBe('https://api.zernio.com/v1/messages');
+		expect(init.headers.authorization).toBe('Bearer zk_1');
+		expect(JSON.parse(init.body)).toMatchObject({ from: '+15550001111', to: '+15559990000' });
+	});
+
+	it('throws on a non-2xx response', async () => {
+		const fetchImpl = vi.fn<FetchLike>().mockResolvedValue({
+			ok: false,
+			status: 422,
+			text: async () => 'bad number',
+		});
+		const sender = new ZernioWhatsappSender({
+			apiKey: 'zk_1',
+			apiUrl: 'https://api.zernio.com',
+			fetchImpl,
+		});
+		await expect(sender.sendMessage({ from: '+1', to: '+2', text: 'x' })).rejects.toThrow(
+			/status 422/,
+		);
+	});
+});
+
+describe('ZernioProvisioner', () => {
+	it('does not call the provider when a number is already provisioned', async () => {
+		const fetchImpl = vi.fn<FetchLike>();
+		const provisioner = new ZernioProvisioner({
+			apiKey: 'zk_1',
+			apiUrl: 'https://api.zernio.com',
+			fetchImpl,
+		});
+		const existing = { address: '+15550001111', providerRef: 'zwa_1' };
+		const result = await provisioner.provision({
+			accountId: 'a1' as AccountId,
+			accountName: 'Acme',
+			existing,
+		});
+		expect(result).toEqual(existing);
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it('provisions a number from the provider response', async () => {
+		const fetchImpl = vi.fn<FetchLike>().mockResolvedValue({
+			ok: true,
+			status: 201,
+			text: async () => '{"phone_number":"+1 (555) 010-2020","id":"num_9"}',
+		});
+		const provisioner = new ZernioProvisioner({
+			apiKey: 'zk_1',
+			apiUrl: 'https://api.zernio.com',
+			fetchImpl,
+		});
+		const result = await provisioner.provision({
+			accountId: 'a1' as AccountId,
+			accountName: 'Acme',
+			existing: { address: '', providerRef: '' },
+		});
+		expect(result).toEqual({ address: '+15550102020', providerRef: 'num_9' });
+	});
+
+	it('throws when the provider rejects', async () => {
+		const fetchImpl = vi
+			.fn<FetchLike>()
+			.mockResolvedValue({ ok: false, status: 500, text: async () => '' });
+		const provisioner = new ZernioProvisioner({
+			apiKey: 'zk_1',
+			apiUrl: 'https://api.zernio.com',
+			fetchImpl,
+		});
+		await expect(
+			provisioner.provision({
+				accountId: 'a1' as AccountId,
+				accountName: 'Acme',
+				existing: { address: '', providerRef: '' },
+			}),
+		).rejects.toThrow(/provision/);
+	});
+});
+
+describe('NoopChannelProvisioner', () => {
+	it('returns a deterministic +1555 number derived from the account id', async () => {
+		const provisioner = new NoopChannelProvisioner();
+		const first = await provisioner.provision({
+			accountId: 'account-xyz' as AccountId,
+			accountName: 'Acme',
+			existing: { address: '', providerRef: '' },
+		});
+		const again = await provisioner.provision({
+			accountId: 'account-xyz' as AccountId,
+			accountName: 'Acme',
+			existing: { address: '', providerRef: '' },
+		});
+		expect(first.address).toMatch(/^\+1555\d{7}$/);
+		expect(again.address).toBe(first.address);
+		expect(first.providerRef).toBe('noop');
+	});
+
+	it('returns the existing identifier unchanged', async () => {
+		const provisioner = new NoopChannelProvisioner();
+		const existing = { address: '+15550001111', providerRef: 'zwa_1' };
+		expect(
+			await provisioner.provision({ accountId: 'a1' as AccountId, accountName: 'Acme', existing }),
+		).toEqual(existing);
+	});
+});
+
+describe('createWhatsappSender / createWhatsappProvisioner', () => {
+	it('return no-ops when no zernio key is configured', async () => {
+		const sender = createWhatsappSender({ ZERNIO_API_URL: 'https://api.zernio.com' });
+		// A no-op send resolves without a transport.
+		await expect(sender.sendMessage({ from: '+1', to: '+2', text: 'x' })).resolves.toBeUndefined();
+		const provisioner = createWhatsappProvisioner({ ZERNIO_API_URL: 'https://api.zernio.com' });
+		const provisioned = await provisioner.provision({
+			accountId: 'a1' as AccountId,
+			accountName: 'Acme',
+			existing: { address: '', providerRef: '' },
+		});
+		expect(provisioned.address).toMatch(/^\+1555\d{7}$/);
+	});
+
+	it('return zernio adapters when a key is configured', () => {
+		const sender = createWhatsappSender({
+			ZERNIO_API_KEY: 'zk_1',
+			ZERNIO_API_URL: 'https://api.zernio.com',
+		});
+		expect(sender).toBeInstanceOf(ZernioWhatsappSender);
+		const provisioner = createWhatsappProvisioner({
+			ZERNIO_API_KEY: 'zk_1',
+			ZERNIO_API_URL: 'https://api.zernio.com',
+		});
+		expect(provisioner).toBeInstanceOf(ZernioProvisioner);
+	});
+});
+
+describe('renderChatResponse', () => {
+	it('flattens an options block to a numbered list', () => {
+		const slots = [
+			{ startAt: '2026-07-07T16:00:00.000Z', durationMinutes: 60 },
+			{ startAt: '2026-07-09T21:00:00.000Z', durationMinutes: 60 },
+		];
+		const text = renderChatResponse(
+			composeAgentResponse({ kind: 'offer_slots', slots }, replyContext()),
+			CHAT_CAPS,
+		);
+		expect(text).toContain('1.');
+		expect(text).toContain('2.');
+		expect(text).toContain('Reply with the number');
+	});
+
+	it('truncates to a channel length cap', () => {
+		const text = renderChatResponse(
+			composeAgentResponse({ kind: 'no_availability' }, replyContext()),
+			{ ...CHAT_CAPS, maxTextLength: 12 },
+		);
+		expect(text.length).toBeLessThanOrEqual(12);
+		expect(text.endsWith('…')).toBe(true);
+	});
+});

--- a/packages/api/test/agent-whatsapp-route.test.ts
+++ b/packages/api/test/agent-whatsapp-route.test.ts
@@ -1,0 +1,338 @@
+import type { AccountId } from '@rivus/core';
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { loadConfig } from '../src/config';
+import { createInMemoryRepositories } from '../src/repositories/memory';
+import { NoopReceivedEmailReader } from '../src/services/agent/email/received';
+import { signWebhookPayload } from '../src/services/agent/webhook';
+import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
+import { NoopFaqAnswerService } from '../src/services/faq-answer';
+import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
+import { createNotificationService } from '../src/services/notifications';
+import {
+	buildTestAppWithRepos,
+	RecordingMailer,
+	RecordingWhatsappSender,
+	signupOwner,
+} from './helpers';
+
+const WEBHOOK_URL = '/v1/channels/whatsapp/inbound';
+const BIZ = '+15550001111';
+const SENDER = '+15559990000';
+
+interface InboundOverrides {
+	to?: string;
+	from?: string;
+	text?: string;
+	messageId?: string;
+	profileName?: string;
+}
+
+function inbound(overrides: InboundOverrides = {}) {
+	return {
+		type: 'whatsapp.message.received',
+		data: {
+			to: BIZ,
+			from: SENDER,
+			text: 'Hi there',
+			messageId: 'wamid.001',
+			profileName: 'Dana',
+			...overrides,
+		},
+	};
+}
+
+function sender(app: FastifyInstance): RecordingWhatsappSender {
+	return app.deps.whatsappSender as RecordingWhatsappSender;
+}
+
+/** Build an app + repos and enable WhatsApp on the signed-up owner's account. */
+async function setup() {
+	const { app, repos } = await buildTestAppWithRepos();
+	const owner = await signupOwner(app);
+	const accountId = owner.account.id as AccountId;
+	await repos.accounts.setChannelConfig(accountId, 'whatsapp', {
+		enabled: true,
+		address: BIZ,
+		providerRef: 'zwa_1',
+	});
+	return { app, repos, accountId, owner };
+}
+
+describe('POST /v1/channels/whatsapp/inbound', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('ignores a message to a number no account has provisioned', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ to: '+15557778888' }),
+		});
+		expect(res.json()).toEqual({ handled: false, outcome: 'unknown_account' });
+	});
+
+	it('acknowledges without replying when the channel is disabled', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.accounts.setChannelConfig(accountId, 'whatsapp', {
+			enabled: false,
+			address: BIZ,
+			providerRef: 'zwa_1',
+		});
+		const res = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(res.json()).toEqual({ handled: false, outcome: 'channel_disabled' });
+		expect(sender(app).messages).toHaveLength(0);
+	});
+
+	it('sends an unknown sender a signup link prefilled with their phone', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(res.json()).toEqual({ handled: true, outcome: 'send_signup_link' });
+		const sent = sender(app).messages.at(-1);
+		expect(sent?.from).toBe(BIZ);
+		expect(sent?.to).toBe(SENDER);
+		expect(sent?.text).toContain(`phone=${encodeURIComponent(SENDER)}`);
+	});
+
+	it('offers slots to a recognized customer whose CRM phone is free text', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.customers.create(accountId, {
+			name: 'Dana Fox',
+			email: '',
+			phone: '(555) 999-0000',
+			address: '12 Pine St',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ text: 'When are you free?' }),
+		});
+		expect(res.json()).toEqual({ handled: true, outcome: 'offer_slots' });
+		expect(sender(app).messages.at(-1)?.text).toContain('1.');
+	});
+
+	it('books the job when the customer picks an offered slot', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.customers.create(accountId, {
+			name: 'Dana Fox',
+			email: '',
+			phone: '+1 (555) 999-0000',
+			address: '12 Pine St',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+		await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ text: 'When are you free?', messageId: 'wamid.a' }),
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ text: '1', messageId: 'wamid.b' }),
+		});
+		expect(res.json()).toEqual({ handled: true, outcome: 'book' });
+		const { total } = await repos.jobs.list({ accountId, page: 1, pageSize: 10 });
+		expect(total).toBe(1);
+		const thread = await repos.agentThreads.findByContact(accountId, 'whatsapp', SENDER);
+		const messages = thread
+			? await repos.conversations.listMessages(accountId, thread.conversationId)
+			: [];
+		expect(messages?.some((m) => m.author === 'note' && m.body.includes('Rivus booked'))).toBe(
+			true,
+		);
+	});
+
+	it('ignores an exact redelivery of an already-processed message', async () => {
+		const built = await setup();
+		app = built.app;
+		const first = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(first.json()).toEqual({ handled: true, outcome: 'send_signup_link' });
+		const second = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(second.json()).toEqual({ handled: false, outcome: 'duplicate_delivery' });
+	});
+
+	it('rolls back a booking when the WhatsApp send fails, and returns 5xx', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.customers.create(accountId, {
+			name: 'Dana Fox',
+			email: '',
+			phone: '(555) 999-0000',
+			address: '',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+		await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ text: 'When are you free?', messageId: 'wamid.a' }),
+		});
+		sender(app).failNext = true;
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ text: '1', messageId: 'wamid.b' }),
+		});
+		expect(res.statusCode).toBeGreaterThanOrEqual(500);
+		const { total } = await repos.jobs.list({ accountId, page: 1, pageSize: 10 });
+		expect(total).toBe(0);
+	});
+
+	it('refuses to converse with any account’s own business number (loop guard)', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ from: BIZ }),
+		});
+		expect(res.json()).toEqual({ handled: false, outcome: 'own_number' });
+	});
+
+	it('declines a non-text message', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ text: '' }),
+		});
+		expect(res.json()).toEqual({ handled: false, outcome: 'unsupported_message_type' });
+	});
+
+	it('flags the conversation on a delivery failure, and is idempotent', async () => {
+		const built = await setup();
+		app = built.app;
+		// Open a thread first (an unknown sender gets a signup link).
+		await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		const failure = {
+			type: 'whatsapp.message.failed',
+			data: { from: BIZ, to: SENDER, reason: 'undeliverable' },
+		};
+		const first = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: failure });
+		expect(first.json()).toEqual({ handled: true, outcome: 'delivery_failed' });
+		const second = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: failure });
+		expect(second.json()).toEqual({ handled: false, outcome: 'already_flagged' });
+	});
+
+	it('keeps two accounts’ numbers isolated', async () => {
+		const { app: built, repos } = await setup();
+		app = built;
+		// A second account with a different business number.
+		const other = await signupOwner(app);
+		await repos.accounts.setChannelConfig(other.account.id as AccountId, 'whatsapp', {
+			enabled: true,
+			address: '+15552223333',
+			providerRef: 'zwa_2',
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ to: '+15552223333', from: '+15558887777' }),
+		});
+		// Resolves to the OTHER account (not the first), and handles it there.
+		expect(res.json()).toEqual({ handled: true, outcome: 'send_signup_link' });
+		expect(sender(app).messages.at(-1)?.from).toBe('+15552223333');
+	});
+});
+
+// --- Signature + handshake (separate config) --------------------------------
+
+const SECRET = 'whsec_dGVzdHNlY3JldA==';
+
+function buildWhatsappApp(extraConfig: Record<string, string> = {}): FastifyInstance {
+	const repos = createInMemoryRepositories();
+	return buildApp({
+		config: loadConfig({
+			NODE_ENV: 'test',
+			JWT_SECRET: 'test-secret-value-1234',
+			...extraConfig,
+		} as NodeJS.ProcessEnv),
+		...repos,
+		mailer: new RecordingMailer(),
+		receivedEmails: new NoopReceivedEmailReader(),
+		whatsappSender: new RecordingWhatsappSender(),
+		whatsappProvisioner: new NoopChannelProvisioner(),
+		notifier: createNotificationService({ notifications: repos.notifications }),
+		faqSimilarity: new NoopFaqSimilarityService(),
+		faqAnswer: new NoopFaqAnswerService(),
+		ping: async () => ({ ready: true }),
+	});
+}
+
+describe('POST /v1/channels/whatsapp/inbound — signature + handshake', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('accepts a validly signed delivery and rejects a tampered one', async () => {
+		app = buildWhatsappApp({ ZERNIO_WEBHOOK_SECRET: SECRET });
+		const body = JSON.stringify(inbound({ to: '+19998887777' }));
+		const id = 'msg_1';
+		const timestamp = String(Math.floor(Date.now() / 1000));
+		const signature = signWebhookPayload({ secret: SECRET, id, timestamp, payload: body });
+		const headers = {
+			'content-type': 'application/json',
+			'zernio-id': id,
+			'zernio-timestamp': timestamp,
+			'zernio-signature': signature,
+		};
+		const ok = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: body, headers });
+		// Unknown account, but the signature passed (a 401 would mean it didn't).
+		expect(ok.json()).toEqual({ handled: false, outcome: 'unknown_account' });
+
+		const tampered = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: JSON.stringify(inbound({ text: 'changed' })),
+			headers,
+		});
+		expect(tampered.statusCode).toBe(401);
+	});
+
+	it('refuses to serve unsigned in production (503, fail closed)', async () => {
+		app = buildWhatsappApp({
+			NODE_ENV: 'production',
+			JWT_SECRET: 'x'.repeat(32),
+			RESEND_API_KEY: 're_test_key',
+			LOG_LEVEL: 'silent',
+			CORS_ORIGIN: 'https://app.rivus.ai',
+		});
+		const res = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(res.statusCode).toBe(503);
+	});
+
+	it('echoes the challenge when the verify token matches, else 404s', async () => {
+		app = buildWhatsappApp({ ZERNIO_VERIFY_TOKEN: 'verify-me' });
+		const ok = await app.inject({
+			method: 'GET',
+			url: `${WEBHOOK_URL}?hub.mode=subscribe&hub.verify_token=verify-me&hub.challenge=echo123`,
+		});
+		expect(ok.statusCode).toBe(200);
+		expect(ok.body).toBe('echo123');
+
+		const bad = await app.inject({
+			method: 'GET',
+			url: `${WEBHOOK_URL}?hub.verify_token=wrong&hub.challenge=echo123`,
+		});
+		expect(bad.statusCode).toBe(404);
+	});
+});

--- a/packages/api/test/conversations.test.ts
+++ b/packages/api/test/conversations.test.ts
@@ -8,6 +8,7 @@ import {
 	buildTestApp,
 	buildTestAppWithRepos,
 	RecordingMailer,
+	type RecordingWhatsappSender,
 	signupOwner,
 } from './helpers';
 
@@ -830,5 +831,80 @@ describe('inbox replies dispatch email on the email channel', () => {
 		expect(messages).toEqual([]);
 
 		await failingApp.close();
+	});
+});
+
+describe('conversation reply-out over WhatsApp', () => {
+	const BIZ = '+15550001111';
+	const SENDER = '+15559990000';
+
+	async function openWhatsappConversation() {
+		const { app, repos } = await buildTestAppWithRepos();
+		const owner = await signupOwner(app);
+		const accountId = owner.account.id as AccountId;
+		await repos.accounts.setChannelConfig(accountId, 'whatsapp', {
+			enabled: true,
+			address: BIZ,
+			providerRef: 'zwa_1',
+		});
+		// An inbound WhatsApp message opens the conversation + agent thread.
+		await app.inject({
+			method: 'POST',
+			url: '/v1/channels/whatsapp/inbound',
+			payload: {
+				type: 'whatsapp.message.received',
+				data: { to: BIZ, from: SENDER, text: 'Hi', messageId: 'wamid.1', profileName: 'Dana' },
+			},
+		});
+		const list = await app.inject({
+			method: 'GET',
+			url: '/v1/conversations',
+			headers: authHeader(owner.token),
+		});
+		const convo = (list.json().data as Array<{ id: string; channel: string }>).find(
+			(c) => c.channel === 'whatsapp',
+		);
+		const sender = app.deps.whatsappSender as RecordingWhatsappSender;
+		return { app, repos, owner, accountId, convo, sender };
+	}
+
+	it('sends a human reply out over WhatsApp', async () => {
+		const { app, owner, convo, sender } = await openWhatsappConversation();
+		expect(convo).toBeDefined();
+		const before = sender.messages.length;
+		const res = await app.inject({
+			method: 'POST',
+			url: `/v1/conversations/${convo?.id}/messages`,
+			headers: authHeader(owner.token),
+			payload: { body: 'See you then!' },
+		});
+		expect(res.statusCode).toBe(201);
+		expect(sender.messages.length).toBe(before + 1);
+		expect(sender.messages.at(-1)).toMatchObject({ from: BIZ, to: SENDER, text: 'See you then!' });
+		await app.close();
+	});
+
+	it('records but does not send when the channel is disabled', async () => {
+		const { app, repos, owner, accountId, convo, sender } = await openWhatsappConversation();
+		await repos.accounts.setChannelConfig(accountId, 'whatsapp', {
+			enabled: false,
+			address: BIZ,
+			providerRef: 'zwa_1',
+		});
+		const before = sender.messages.length;
+		const res = await app.inject({
+			method: 'POST',
+			url: `/v1/conversations/${convo?.id}/messages`,
+			headers: authHeader(owner.token),
+			payload: { body: 'See you then!' },
+		});
+		expect(res.statusCode).toBe(201);
+		// Recorded in the transcript, but nothing left the building.
+		expect(sender.messages.length).toBe(before);
+		const detail = res.json() as { messages: Array<{ author: string; body: string }> };
+		expect(detail.messages.some((m) => m.author === 'agent' && m.body === 'See you then!')).toBe(
+			true,
+		);
+		await app.close();
 	});
 });

--- a/packages/api/test/cors.test.ts
+++ b/packages/api/test/cors.test.ts
@@ -5,9 +5,11 @@ import { loadConfig } from '../src/config';
 import { SESSION_COOKIE } from '../src/plugins/auth';
 import { createInMemoryRepositories } from '../src/repositories/memory';
 import { NoopReceivedEmailReader } from '../src/services/agent/email/received';
+import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
 import { NoopFaqAnswerService } from '../src/services/faq-answer';
 import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
 import { createNotificationService } from '../src/services/notifications';
+import { NoopWhatsappSender } from '../src/services/whatsapp';
 import { authHeader, RecordingMailer, signupOwner } from './helpers';
 
 /** Build an app with a specific CORS_ORIGIN so we can exercise both origin branches. */
@@ -22,6 +24,8 @@ function buildAppWithCors(corsOrigin: string): FastifyInstance {
 		...repos,
 		mailer: new RecordingMailer(),
 		receivedEmails: new NoopReceivedEmailReader(),
+		whatsappSender: new NoopWhatsappSender(),
+		whatsappProvisioner: new NoopChannelProvisioner(),
 		notifier: createNotificationService({ notifications: repos.notifications }),
 		faqSimilarity: new NoopFaqSimilarityService(),
 		faqAnswer: new NoopFaqAnswerService(),
@@ -43,6 +47,8 @@ function buildProdApp(corsOrigin: string): FastifyInstance {
 		...repos,
 		mailer: new RecordingMailer(),
 		receivedEmails: new NoopReceivedEmailReader(),
+		whatsappSender: new NoopWhatsappSender(),
+		whatsappProvisioner: new NoopChannelProvisioner(),
 		notifier: createNotificationService({ notifications: repos.notifications }),
 		faqSimilarity: new NoopFaqSimilarityService(),
 		faqAnswer: new NoopFaqAnswerService(),

--- a/packages/api/test/helpers.ts
+++ b/packages/api/test/helpers.ts
@@ -5,10 +5,12 @@ import { buildApp } from '../src/app';
 import { loadConfig } from '../src/config';
 import { createInMemoryRepositories, type InMemoryRepositories } from '../src/repositories/memory';
 import { NoopReceivedEmailReader } from '../src/services/agent/email/received';
+import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
 import type { AgentEmail, InviteEmail, Mailer, VerificationEmail } from '../src/services/email';
 import { NoopFaqAnswerService } from '../src/services/faq-answer';
 import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
 import { createNotificationService } from '../src/services/notifications';
+import type { WhatsappMessage, WhatsappSender } from '../src/services/whatsapp';
 import type { AppDeps } from '../src/types';
 
 /** A mailer that records every send so tests can assert on (and read) delivered email. */
@@ -27,6 +29,21 @@ export class RecordingMailer implements Mailer {
 
 	async sendAgentEmail(email: AgentEmail): Promise<void> {
 		this.agentEmails.push(email);
+	}
+}
+
+/** A WhatsApp sender that records every message so tests can assert on delivery. */
+export class RecordingWhatsappSender implements WhatsappSender {
+	readonly messages: WhatsappMessage[] = [];
+	/** When set, the next send rejects once (to exercise the booking-rollback path). */
+	failNext = false;
+
+	async sendMessage(message: WhatsappMessage): Promise<void> {
+		if (this.failNext) {
+			this.failNext = false;
+			throw new Error('WhatsApp send failed (test)');
+		}
+		this.messages.push(message);
 	}
 }
 
@@ -70,6 +87,8 @@ export async function buildTestApp(overrides: Partial<AppDeps> = {}): Promise<Fa
 		mailer: new RecordingMailer(),
 		// No inbound-email fetching in tests — webhook payloads embed their content.
 		receivedEmails: new NoopReceivedEmailReader(),
+		whatsappSender: new RecordingWhatsappSender(),
+		whatsappProvisioner: new NoopChannelProvisioner(),
 		// A real notification service over the in-memory store, so route emission is
 		// exercised end-to-end in tests.
 		notifier: createNotificationService({ notifications }),
@@ -124,6 +143,8 @@ export async function buildTestAppWithRepos(): Promise<{
 		verificationCodes,
 		mailer: new RecordingMailer(),
 		receivedEmails: new NoopReceivedEmailReader(),
+		whatsappSender: new RecordingWhatsappSender(),
+		whatsappProvisioner: new NoopChannelProvisioner(),
 		notifier: createNotificationService({ notifications }),
 		faqSimilarity: new NoopFaqSimilarityService(),
 		faqAnswer: new NoopFaqAnswerService(),

--- a/packages/app/app/settings.tsx
+++ b/packages/app/app/settings.tsx
@@ -20,6 +20,7 @@ import {
 	OutlineButton,
 	Pill,
 	SectionLabel,
+	Segmented,
 	Select,
 	TextField,
 	Txt,
@@ -105,7 +106,7 @@ function DevSeedCard() {
 
 export default function SettingsScreen() {
 	useDocumentTitle('Settings');
-	const { session, client, updateAccount, cancelAccount } = useAuth();
+	const { session, client, updateAccount, cancelAccount, setChannelEnabled } = useAuth();
 	const account = session?.account;
 	const isOwner = session?.role === 'owner';
 	// Stack the danger-zone buttons once the row is too narrow to hold both
@@ -122,6 +123,9 @@ export default function SettingsScreen() {
 	const [saving, setSaving] = useState(false);
 	const [saved, setSaved] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+
+	const [whatsappBusy, setWhatsappBusy] = useState(false);
+	const [whatsappError, setWhatsappError] = useState<string | null>(null);
 
 	const [confirmingCancel, setConfirmingCancel] = useState(false);
 	const [canceling, setCanceling] = useState(false);
@@ -237,6 +241,25 @@ export default function SettingsScreen() {
 		}
 	}
 
+	const whatsapp = session.account.channels.whatsapp;
+
+	async function onToggleWhatsapp(next: string) {
+		const enabled = next === 'on';
+		if (whatsappBusy || enabled === whatsapp.enabled) {
+			return;
+		}
+		setWhatsappError(null);
+		setWhatsappBusy(true);
+		try {
+			// Enabling provisions a number on the first call; the session updates in place.
+			await setChannelEnabled('whatsapp', enabled);
+		} catch (caught) {
+			setWhatsappError(messageFor(caught, `Could not ${enabled ? 'enable' : 'disable'} WhatsApp.`));
+		} finally {
+			setWhatsappBusy(false);
+		}
+	}
+
 	// The inbound address customers email to reach Rivus. The local part pairs the
 	// business slug with a stable per-account hex tag (so look-alike names never
 	// collide); the domain comes from the session (`AGENT_EMAIL_DOMAIN`).
@@ -311,6 +334,29 @@ export default function SettingsScreen() {
 					them automatically. Share it, or add it to your website.
 				</Txt>
 				<CopyField label="Your agent address" value={agentEmail} />
+			</Card>
+
+			<Card style={styles.card}>
+				<SectionLabel>WhatsApp Business</SectionLabel>
+				<Txt style={styles.agentEmailHint}>
+					Customers can message this number on WhatsApp — Rivus books them the same way it does over
+					email. Turn it on to get a number.
+				</Txt>
+				<View style={styles.whatsappRow}>
+					<Segmented
+						options={[
+							{ label: 'Off', value: 'off' },
+							{ label: 'On', value: 'on' },
+						]}
+						value={whatsapp.enabled ? 'on' : 'off'}
+						onChange={onToggleWhatsapp}
+					/>
+					{whatsappBusy ? <ActivityIndicator color={colors.brandPurple} /> : null}
+				</View>
+				{whatsapp.enabled && whatsapp.address ? (
+					<CopyField label="Your WhatsApp number" value={whatsapp.address} />
+				) : null}
+				{whatsappError ? <Txt style={styles.errorTxt}>{whatsappError}</Txt> : null}
 			</Card>
 
 			<Card style={styles.card}>
@@ -410,6 +456,12 @@ const styles = StyleSheet.create({
 		color: colors.textMuted,
 		marginTop: -2,
 		marginBottom: 4,
+	},
+	whatsappRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 12,
+		marginBottom: 12,
 	},
 	errorTxt: {
 		fontFamily: font.medium,

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -570,6 +570,32 @@ describe('createApiClient', () => {
 		});
 	});
 
+	describe('enableChannel / disableChannel', () => {
+		it('POSTs to the enable endpoint and returns the account with the provisioned number', async () => {
+			const account = makeAccount();
+			account.channels.whatsapp = { enabled: true, address: '+15551234567', providerRef: '' };
+			fetchMock.mockResolvedValueOnce(jsonResponse(account));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.enableChannel('owner-token', 'whatsapp');
+
+			expect(result.channels.whatsapp).toMatchObject({ enabled: true, address: '+15551234567' });
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/account/channels/whatsapp/enable`);
+			expect(init.method).toBe('POST');
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer owner-token' });
+		});
+
+		it('POSTs to the disable endpoint with the bearer token', async () => {
+			fetchMock.mockResolvedValueOnce(jsonResponse(makeAccount()));
+			const client = createApiClient(BASE, fetchMock);
+			await client.disableChannel('owner-token', 'whatsapp');
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/account/channels/whatsapp/disable`);
+			expect(init.method).toBe('POST');
+		});
+	});
+
 	describe('cancelAccount', () => {
 		it('POSTs to the cancel endpoint and returns the canceled account', async () => {
 			const account = {

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -46,6 +46,11 @@ function makeAccount() {
 		address: '',
 		website: '',
 		timezone: 'UTC',
+		channels: {
+			whatsapp: { enabled: false, address: '', providerRef: '' },
+			sms: { enabled: false, address: '', providerRef: '' },
+			voice: { enabled: false, address: '', providerRef: '' },
+		},
 		status: 'active' as const,
 		canceledAt: null,
 		createdAt: now,

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -194,6 +194,15 @@ const userResponseSchema = z.object({
 /** The signed-in user as returned by the API (id is a plain string on the wire). */
 export type ProfileUser = z.infer<typeof userResponseSchema>;
 
+// The API omits `providerRef` (a server-only handle) from channel configs, so it
+// defaults to '' here — keeping the parsed shape assignable to the full `Account`
+// type. Channels default as a whole so a session from an older API still parses.
+const channelConfigResponseSchema = z.object({
+	enabled: z.boolean(),
+	address: z.string(),
+	providerRef: z.string().default(''),
+});
+
 const accountResponseSchema = z.object({
 	id: accountId(),
 	name: z.string(),
@@ -202,6 +211,17 @@ const accountResponseSchema = z.object({
 	address: z.string(),
 	website: z.string(),
 	timezone: z.string(),
+	channels: z
+		.object({
+			whatsapp: channelConfigResponseSchema,
+			sms: channelConfigResponseSchema,
+			voice: channelConfigResponseSchema,
+		})
+		.default({
+			whatsapp: { enabled: false, address: '', providerRef: '' },
+			sms: { enabled: false, address: '', providerRef: '' },
+			voice: { enabled: false, address: '', providerRef: '' },
+		}),
 	status: accountStatusSchema,
 	canceledAt: z.string().nullable(),
 	createdAt: z.string(),

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -44,6 +44,7 @@ import {
 	notificationTypeSchema,
 	type PaginationMeta,
 	type PaginationQuery,
+	type ProvisionedChannel,
 	paginationQuerySchema,
 	type Role,
 	roleSchema,
@@ -616,6 +617,10 @@ export interface RivusApiClient {
 	updateAccount(token: string, input: UpdateAccountInput): Promise<Account>;
 	/** Cancel (soft-delete) the account (owner only). */
 	cancelAccount(token: string): Promise<Account>;
+	/** Enable a messaging channel — the API provisions a number (owner only). */
+	enableChannel(token: string, channel: ProvisionedChannel): Promise<Account>;
+	/** Disable a messaging channel; its number is retained (owner only). */
+	disableChannel(token: string, channel: ProvisionedChannel): Promise<Account>;
 	/** Read the account's billing summary (owner only). */
 	getBilling(token: string): Promise<Billing>;
 	listItems(token: string, query?: Partial<PaginationQuery>): Promise<ItemListResponse>;
@@ -893,6 +898,22 @@ export function createApiClient(
 
 		cancelAccount(token: string) {
 			return request('/v1/account/cancel', accountResponseSchema, {
+				method: 'POST',
+				headers: authHeaders(token),
+			});
+		},
+
+		/** Enable a messaging channel — the API provisions a number (owner only). */
+		enableChannel(token: string, channel: ProvisionedChannel) {
+			return request(`/v1/account/channels/${channel}/enable`, accountResponseSchema, {
+				method: 'POST',
+				headers: authHeaders(token),
+			});
+		},
+
+		/** Disable a messaging channel; its number is retained for re-enabling (owner only). */
+		disableChannel(token: string, channel: ProvisionedChannel) {
+			return request(`/v1/account/channels/${channel}/disable`, accountResponseSchema, {
 				method: 'POST',
 				headers: authHeaders(token),
 			});

--- a/packages/app/src/auth/AuthContext.tsx
+++ b/packages/app/src/auth/AuthContext.tsx
@@ -2,6 +2,7 @@ import {
 	type AccountId,
 	isRivusStaffEmail,
 	type LoginInput,
+	type ProvisionedChannel,
 	type UpdateAccountInput,
 	type UpdateProfileInput,
 	type VerifyCodeInput,
@@ -50,6 +51,11 @@ export interface AuthContextValue {
 	acceptInvite: (token: string) => Promise<void>;
 	/** Update the account's business settings, keeping the session in sync (owner only). */
 	updateAccount: (input: UpdateAccountInput) => Promise<void>;
+	/**
+	 * Enable or disable a provisioned messaging channel (WhatsApp today), keeping the
+	 * session in sync (owner only). Enabling provisions a number the first time.
+	 */
+	setChannelEnabled: (channel: ProvisionedChannel, enabled: boolean) => Promise<void>;
 	/**
 	 * Update your own profile (name, phone, email, profile image), keeping the
 	 * session in sync. Changing the email stages it on `session.user.pendingEmail`
@@ -145,6 +151,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 					return;
 				}
 				const account = await client.updateAccount(session.token, input);
+				setSession({ ...session, account });
+			},
+			async setChannelEnabled(channel, enabled) {
+				if (!session) {
+					return;
+				}
+				const account = enabled
+					? await client.enableChannel(session.token, channel)
+					: await client.disableChannel(session.token, channel);
 				setSession({ ...session, account });
 			},
 			async verifyEmailChange(input) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './agent-email';
 export * from './gravatar';
 export * from './pagination';
+export * from './phone';
 export * from './regex';
 export * from './schemas';
 export * from './slug';

--- a/packages/core/src/phone.test.ts
+++ b/packages/core/src/phone.test.ts
@@ -14,6 +14,14 @@ describe('normalizePhone', () => {
 		expect(normalizePhone('+1 (555) 123-4567')).toBe('+15551234567');
 	});
 
+	it('strips a trailing extension so it matches the base line', () => {
+		expect(normalizePhone('(555) 123-4567 ext 89')).toBe('+15551234567');
+		expect(normalizePhone('(555) 123-4567 ext. 89')).toBe('+15551234567');
+		expect(normalizePhone('+1 555-123-4567 x89')).toBe('+15551234567');
+		expect(normalizePhone('555.123.4567 #12')).toBe('+15551234567');
+		expect(normalizePhone('5551234567, 89')).toBe('+15551234567');
+	});
+
 	it('treats 11 bare digits beginning with 1 as North American', () => {
 		expect(normalizePhone('15551234567')).toBe('+15551234567');
 		expect(normalizePhone('1 (555) 123-4567')).toBe('+15551234567');

--- a/packages/core/src/phone.test.ts
+++ b/packages/core/src/phone.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePhone, phonesMatch } from './phone';
+
+describe('normalizePhone', () => {
+	it('normalizes common free-text US formats to E.164', () => {
+		expect(normalizePhone('(555) 123-4567')).toBe('+15551234567');
+		expect(normalizePhone('555.123.4567')).toBe('+15551234567');
+		expect(normalizePhone('555-123-4567')).toBe('+15551234567');
+		expect(normalizePhone('5551234567')).toBe('+15551234567');
+	});
+
+	it('keeps an already-normalized number and strips separators', () => {
+		expect(normalizePhone('+15551234567')).toBe('+15551234567');
+		expect(normalizePhone('+1 (555) 123-4567')).toBe('+15551234567');
+	});
+
+	it('treats 11 bare digits beginning with 1 as North American', () => {
+		expect(normalizePhone('15551234567')).toBe('+15551234567');
+		expect(normalizePhone('1 (555) 123-4567')).toBe('+15551234567');
+	});
+
+	it('accepts a plus-prefixed international number within E.164 length', () => {
+		expect(normalizePhone('+44 20 7946 0958')).toBe('+442079460958');
+		expect(normalizePhone('+442079460958')).toBe('+442079460958');
+	});
+
+	it('returns empty string for values it cannot confidently normalize', () => {
+		expect(normalizePhone('')).toBe('');
+		expect(normalizePhone('   ')).toBe('');
+		expect(normalizePhone('not a phone')).toBe('');
+		// Too short even for a plus number (7 digits < 8).
+		expect(normalizePhone('+1234567')).toBe('');
+		// Bare digits that are neither 10 nor 11-with-1.
+		expect(normalizePhone('12345')).toBe('');
+		expect(normalizePhone('442079460958')).toBe('');
+		// Longer than E.164 permits (16 digits).
+		expect(normalizePhone('+1234567890123456')).toBe('');
+	});
+
+	it('is idempotent on its own output', () => {
+		const once = normalizePhone('(555) 123-4567');
+		expect(normalizePhone(once)).toBe(once);
+	});
+});
+
+describe('phonesMatch', () => {
+	it('matches two free-text forms of the same line', () => {
+		expect(phonesMatch('(555) 123-4567', '+15551234567')).toBe(true);
+		expect(phonesMatch('1-555-123-4567', '555.123.4567')).toBe(true);
+	});
+
+	it('does not match different numbers', () => {
+		expect(phonesMatch('(555) 123-4567', '(555) 765-4321')).toBe(false);
+	});
+
+	it('never matches when either side is unnormalizable or empty', () => {
+		expect(phonesMatch('', '+15551234567')).toBe(false);
+		expect(phonesMatch('+15551234567', '')).toBe(false);
+		expect(phonesMatch('nope', 'nope')).toBe(false);
+	});
+});

--- a/packages/core/src/phone.ts
+++ b/packages/core/src/phone.ts
@@ -1,0 +1,61 @@
+/**
+ * Phone-number canonicalization shared by every phone-shaped channel (WhatsApp,
+ * SMS, voice). The CRM stores customer phones as free text ("(555) 123-4567"),
+ * while messaging providers deliver senders in E.164 ("+15551234567"), so a
+ * match has to normalize both sides to the same canonical form. Kept
+ * dependency-free on purpose: a full libphonenumber would never clear the 7-day
+ * supply-chain gate and is far more than a small business's US-centric CRM
+ * needs. The rules are deliberately conservative — an ambiguous number returns
+ * `''` (no match) rather than guessing a country and mislinking two people.
+ */
+
+/** The E.164 minimum/maximum significant-digit counts (country code + subscriber). */
+const E164_MIN_DIGITS = 8;
+const E164_MAX_DIGITS = 15;
+
+/**
+ * Canonicalize a free-text phone number to E.164 (`+` followed by 8–15 digits),
+ * or `''` when it can't be done confidently. Rules:
+ *
+ * - A value that already starts with `+` keeps its digits when there are 8–15 of
+ *   them (separators, spaces, and parentheses are stripped): `+44 20 7946 0958`
+ *   → `+442079460958`.
+ * - 11 bare digits beginning with `1` are treated as North American: `15551234567`
+ *   → `+15551234567`.
+ * - 10 bare digits are assumed to be in `defaultCountry` (only `US` today), so
+ *   `(555) 123-4567` → `+15551234567`.
+ * - Anything else (too short, too long, a non-US bare international number) → `''`.
+ *
+ * @example normalizePhone('(555) 123-4567') // '+15551234567'
+ * @example normalizePhone('+44 20 7946 0958') // '+442079460958'
+ * @example normalizePhone('nope') // ''
+ */
+export function normalizePhone(raw: string, options?: { defaultCountry?: 'US' }): string {
+	const trimmed = raw.trim();
+	const hasPlus = trimmed.startsWith('+');
+	// `\D` drops the leading `+` too, leaving only the significant digits.
+	const digits = trimmed.replace(/\D/g, '');
+
+	if (hasPlus) {
+		return digits.length >= E164_MIN_DIGITS && digits.length <= E164_MAX_DIGITS ? `+${digits}` : '';
+	}
+	if (digits.length === 11 && digits.startsWith('1')) {
+		return `+${digits}`;
+	}
+	// The option type only admits `US`, so a 10-digit bare number is always +1.
+	if (digits.length === 10 && (options?.defaultCountry ?? 'US') === 'US') {
+		return `+1${digits}`;
+	}
+	return '';
+}
+
+/**
+ * Whether two free-text phone numbers denote the same line — true only when both
+ * normalize to a non-empty E.164 and those forms are equal. Two unnormalizable
+ * (or empty) numbers never match, so a customer with no phone on file is never
+ * mistaken for an inbound sender.
+ */
+export function phonesMatch(a: string, b: string): boolean {
+	const left = normalizePhone(a);
+	return left !== '' && left === normalizePhone(b);
+}

--- a/packages/core/src/phone.ts
+++ b/packages/core/src/phone.ts
@@ -26,12 +26,21 @@ const E164_MAX_DIGITS = 15;
  *   `(555) 123-4567` → `+15551234567`.
  * - Anything else (too short, too long, a non-US bare international number) → `''`.
  *
+ * A trailing extension (`ext`, `extension`, `x`, or a `#`/`,`/`;` separator
+ * followed by digits) is stripped first, so `(555) 123-4567 ext 89` matches the
+ * base line `+15551234567` instead of folding `89` into the subscriber number.
+ *
  * @example normalizePhone('(555) 123-4567') // '+15551234567'
+ * @example normalizePhone('(555) 123-4567 ext 89') // '+15551234567'
  * @example normalizePhone('+44 20 7946 0958') // '+442079460958'
  * @example normalizePhone('nope') // ''
  */
+// A trailing extension: an `ext`/`extension`/`x` word or a `#`/`,`/`;` separator,
+// then the extension digits, at the very end of the value.
+const EXTENSION_SUFFIX = /\s*(?:ext\.?|extension|x|[#,;])\s*\d{1,6}\s*$/i;
+
 export function normalizePhone(raw: string, options?: { defaultCountry?: 'US' }): string {
-	const trimmed = raw.trim();
+	const trimmed = raw.trim().replace(EXTENSION_SUFFIX, '').trim();
 	const hasPlus = trimmed.startsWith('+');
 	// `\D` drops the leading `+` too, leaving only the significant digits.
 	const digits = trimmed.replace(/\D/g, '');

--- a/packages/core/src/phone.ts
+++ b/packages/core/src/phone.ts
@@ -36,8 +36,11 @@ const E164_MAX_DIGITS = 15;
  * @example normalizePhone('nope') // ''
  */
 // A trailing extension: an `ext`/`extension`/`x` word or a `#`/`,`/`;` separator,
-// then the extension digits, at the very end of the value.
-const EXTENSION_SUFFIX = /\s*(?:ext\.?|extension|x|[#,;])\s*\d{1,6}\s*$/i;
+// then the extension digits, at the very end of the value. Whitespace is a single
+// bounded run (`\s{0,4}`) and there is no leading `\s*` — any space left before the
+// marker is removed by the outer `.trim()` — so the pattern stays linear-time (no
+// adjacent unbounded quantifiers that could backtrack polynomially).
+const EXTENSION_SUFFIX = /(?:ext\.?|extension|x|[#,;])\s{0,4}\d{1,6}$/i;
 
 export function normalizePhone(raw: string, options?: { defaultCountry?: 'US' }): string {
 	const trimmed = raw.trim().replace(EXTENSION_SUFFIX, '').trim();

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	acceptInviteSchema,
 	accountBusinessSchema,
+	accountChannelsSchema,
 	accountStatusSchema,
 	agentSlotSchema,
 	agentThreadStateSchema,
@@ -26,6 +27,7 @@ import {
 	notificationReadStateSchema,
 	notificationTypeSchema,
 	paginationQuerySchema,
+	provisionedChannelSchema,
 	publicCustomerSignupSchema,
 	SEED_COUNT_MAX,
 	seedAccountSchema,
@@ -237,6 +239,38 @@ describe('updateAccountSchema', () => {
 
 	it('rejects a malformed website', () => {
 		expect(() => updateAccountSchema.parse({ website: 'not a url' })).toThrow();
+	});
+});
+
+describe('provisionedChannelSchema', () => {
+	it('accepts the provisioned channels and rejects email (derived, not provisioned)', () => {
+		for (const channel of ['whatsapp', 'sms', 'voice'] as const) {
+			expect(provisionedChannelSchema.parse(channel)).toBe(channel);
+		}
+		expect(provisionedChannelSchema.safeParse('email').success).toBe(false);
+		expect(provisionedChannelSchema.safeParse('telegram').success).toBe(false);
+	});
+});
+
+describe('accountChannelsSchema', () => {
+	it('defaults every channel to off/empty', () => {
+		expect(accountChannelsSchema.parse({})).toEqual({
+			whatsapp: { enabled: false, address: '', providerRef: '' },
+			sms: { enabled: false, address: '', providerRef: '' },
+			voice: { enabled: false, address: '', providerRef: '' },
+		});
+	});
+
+	it('keeps a provisioned channel config and defaults the rest', () => {
+		const parsed = accountChannelsSchema.parse({
+			whatsapp: { enabled: true, address: '+15551234567', providerRef: 'zwa_1' },
+		});
+		expect(parsed.whatsapp).toEqual({
+			enabled: true,
+			address: '+15551234567',
+			providerRef: 'zwa_1',
+		});
+		expect(parsed.sms.enabled).toBe(false);
 	});
 });
 

--- a/packages/core/src/schemas.test.ts
+++ b/packages/core/src/schemas.test.ts
@@ -18,6 +18,7 @@ import {
 	createJobSchema,
 	createMessageSchema,
 	createNotificationSchema,
+	emptyAccountChannels,
 	inviteMemberSchema,
 	jobConflictQuerySchema,
 	jobListQuerySchema,
@@ -271,6 +272,16 @@ describe('accountChannelsSchema', () => {
 			providerRef: 'zwa_1',
 		});
 		expect(parsed.sms.enabled).toBe(false);
+	});
+
+	it('emptyAccountChannels builds a fresh all-off map', () => {
+		expect(emptyAccountChannels()).toEqual({
+			whatsapp: { enabled: false, address: '', providerRef: '' },
+			sms: { enabled: false, address: '', providerRef: '' },
+			voice: { enabled: false, address: '', providerRef: '' },
+		});
+		// A fresh object each call — never a shared reference callers could mutate.
+		expect(emptyAccountChannels()).not.toBe(emptyAccountChannels());
 	});
 });
 

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -218,6 +218,45 @@ export const updateAccountSchema = z
 	});
 export type UpdateAccountInput = z.infer<typeof updateAccountSchema>;
 
+// --- Provisioned messaging channels -------------------------------------------
+
+// `ProvisionedChannel` is the source-of-truth union in `types.ts`; here we add
+// the runtime schema. Email is excluded on purpose — its address is derived, not
+// provisioned — so this is a narrower set than `conversationChannelSchema`.
+/** A channel an account can provision an identifier for (see {@link ProvisionedChannel}). */
+export const provisionedChannelSchema = z.enum(['whatsapp', 'sms', 'voice'], {
+	error: 'Choose a valid channel.',
+});
+
+/**
+ * One provisioned channel's stored configuration. Not part of any client-writable
+ * update shape: a channel is turned on or off through the provisioning endpoint
+ * (which assigns the identifier), never by a direct settings PATCH.
+ */
+export const accountChannelConfigSchema = z.object({
+	enabled: z.boolean().default(false),
+	/** The provisioned E.164 identifier; `''` until assigned. */
+	address: optionalText('Channel address', 40).default(''),
+	/** The provider's opaque handle for the provisioned resource; `''` when none. */
+	providerRef: optionalText('Provider reference', 200).default(''),
+});
+export type AccountChannelConfigInput = z.infer<typeof accountChannelConfigSchema>;
+
+const emptyChannelConfig = { enabled: false, address: '', providerRef: '' } as const;
+
+/** Every provisioned channel's config; each key defaults to off/empty. */
+export const accountChannelsSchema = z.object({
+	whatsapp: accountChannelConfigSchema.default(emptyChannelConfig),
+	sms: accountChannelConfigSchema.default(emptyChannelConfig),
+	voice: accountChannelConfigSchema.default(emptyChannelConfig),
+});
+export type AccountChannelsInput = z.infer<typeof accountChannelsSchema>;
+
+/** A fresh all-off channel map — every provisioned channel disabled with no identifier. */
+export function emptyAccountChannels(): AccountChannelsInput {
+	return accountChannelsSchema.parse({});
+}
+
 // --- Profile (the signed-in user's own account) -------------------------------
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -55,6 +55,35 @@ export type Role = 'owner' | 'manager' | 'member';
  */
 export type AccountStatus = 'active' | 'canceled';
 
+/**
+ * A messaging channel an account can provision a customer-facing identifier for.
+ * Email is deliberately excluded — its address is derived from the account
+ * (`agentEmailLocalPart(slug, id)`), needs no provisioning, and is always on —
+ * so `channels` only tracks the ones with an externally-assigned identifier.
+ */
+export type ProvisionedChannel = 'whatsapp' | 'sms' | 'voice';
+
+/** One provisioned channel's per-account configuration. */
+export interface AccountChannelConfig {
+	/** Whether the channel is turned on — inbound is handled and the identifier is shown. */
+	enabled: boolean;
+	/**
+	 * The provisioned, customer-facing identifier (an E.164 phone number for
+	 * whatsapp/sms/voice); `''` until provisioned. Retained when the channel is
+	 * disabled so re-enabling restores the same number.
+	 */
+	address: string;
+	/** The provider's opaque reference for the provisioned resource; `''` when none. */
+	providerRef: string;
+}
+
+/**
+ * Every provisioned channel's config, one key per {@link ProvisionedChannel}.
+ * All keys are always present (defaulting to off/empty) so a channel's config is
+ * a plain read, never an existence check.
+ */
+export type AccountChannels = Record<ProvisionedChannel, AccountChannelConfig>;
+
 /** A business account — the tenant that owns all of its members' data. */
 export interface Account {
 	id: AccountId;
@@ -67,6 +96,11 @@ export interface Account {
 	website: string;
 	/** IANA time zone, e.g. `America/Los_Angeles`. */
 	timezone: string;
+	/**
+	 * Provisioned messaging channels (WhatsApp today; SMS and voice reserved).
+	 * Email is derived from `slug`+`id`, always on, and never stored here.
+	 */
+	channels: AccountChannels;
 	/** Lifecycle state; `canceled` accounts are soft-deleted and locked out. */
 	status: AccountStatus;
 	/** When the account was canceled, or `null` while it is active. */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — a **unified multi-channel conversational-agent architecture**, with **WhatsApp Business via the zernio provider** as the first channel built on it. Email, WhatsApp, and (later) SMS/voice share one feature set.

## The governing design goal

> Adding a feature to the **core agent** makes it work across **all channels** automatically, with zero per-channel code changes.

This is enforced structurally, not by convention:

- **Channels are dumb adapters** — a `ChannelAdapter` only normalizes an inbound provider payload, generically renders a neutral response, and transports/verifies. No feature logic lives in a channel (they never import `engine.ts`/`capabilities.ts`/`AgentDecision`).
- **A channel-neutral response content model** replaces per-channel `switch (decision.kind)` rendering. The core composes any decision into structural blocks; each channel has **one** generic renderer that adapts by a `ChannelCapabilities` descriptor.
- **A capability registry** — features register once (`defaultCapabilities()`) and the single shared orchestrator dispatches to them for every channel.
- **Compile-time + test-time enforcement** — renderers are typed to `AgentResponse` (they can't see decisions); block switches are exhaustive; and `agent-response-matrix.test.ts` crosses every channel × every decision so nothing silently goes missing.

## What's included

- **Core (`@rivus/core`)** — dependency-free `normalizePhone`/`phonesMatch` (E.164, extension-stripping, ReDoS-safe); `Account.channels` (provisioned channel config) + schemas.
- **Neutral agent core (`services/agent/`)** — `response.ts` (block model + composer), `channel.ts` (adapter/capabilities), `capabilities.ts` (registry + scheduling), `orchestrator.ts` (the one inbound flow + delivery-failure), `channels.ts` (adapter registry). Email refactored onto it with **zero behavior change** (pinned email tests pass unchanged).
- **WhatsApp via zernio** — provider seams (sender/provisioner/inbound-parse/webhook, all Noop-able, **zero new deps**, wire details behind `TODO(zernio)`), a chat renderer + adapter, and `routes/agent-whatsapp.ts` (signature gate, verify handshake, account-by-number resolution, channel-disabled/own-number guards).
- **Provisioning** — Rivus assigns a WhatsApp number when an owner enables the channel: owner-only `POST /v1/account/channels/:channel/{enable,disable}` (idempotent, 502 on provider failure, retain-on-disable).
- **Inbox reply-out generalized** — human replies and approved FAQ drafts now leave over WhatsApp too (email output unchanged).
- **App** — a "WhatsApp Business" settings card (Off/On toggle that provisions a number, read-only number display) + client methods.
- **Docs** — AGENTS.md documents the architecture and the add-a-feature / add-a-channel recipes; OpenAPI regenerated.

Every phase keeps `pnpm lint && pnpm type-check && pnpm test` (and `test:coverage`) green with coverage thresholds untouched. All external review feedback (Gemini, Codex, CodeQL) has been triaged, addressed, and replied to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E623EWd33DkMJbqN68w3PM