### PR TITLE
fix(api): verify zernio's real webhook signature + API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,8 @@ WEBSITE_URL=https://rivus.ai
 # Rivus assigns a WhatsApp Business number (via zernio) when an owner enables the
 # channel in settings, then answers over WhatsApp with the same scheduling agent
 # as email. zernio posts inbound messages to POST /v1/channels/whatsapp/inbound.
-# Base URL of the zernio API.
-ZERNIO_API_URL=https://api.zernio.com
+# Base URL of the zernio API (per zernio's docs).
+ZERNIO_API_URL=https://zernio.com/api/v1
 # zernio API key. When unset, WhatsApp degrades to a no-op sender + provisioner
 # (a deterministic fake number in development) so the API runs without credentials.
 # ZERNIO_API_KEY=zk_xxxxxxxx

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -238,7 +238,8 @@ Wiring it up:
    `message.received` (inbound customer messages) and `message.failed` (undelivered
    WhatsApp replies) events — the one endpoint handles both and branches on the
    type. `ZERNIO_VERIFY_TOKEN` applies only if zernio requires a `GET` registration
-   handshake (see the reconciliation note below).
+   handshake (still unconfirmed — the handshake endpoint stays inert, 404, until
+   the token is set).
 3. An account **owner** enables the channel — in the app (Settings → WhatsApp
    Business → On) or via `POST /v1/account/channels/whatsapp/enable`. Rivus
    provisions the number and starts answering; `…/disable` turns it off but
@@ -246,33 +247,36 @@ Wiring it up:
 
 | Variable                | Default                  | Notes                                                                                                                   |
 | ----------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| `ZERNIO_API_URL`        | `https://api.zernio.com` | Base URL of the zernio API.                                                                                             |
+| `ZERNIO_API_URL`        | `https://zernio.com/api/v1` | Base URL of the zernio API (per zernio's docs).                                                                     |
 | `ZERNIO_API_KEY`        | _(unset)_                | Unset: WhatsApp degrades to a no-op sender + provisioner (a deterministic fake number in dev) so the API runs without credentials. |
-| `ZERNIO_WEBHOOK_SECRET` | _(unset)_                | zernio webhook signing secret. Unset: dev/test accept unsigned deliveries; **production refuses the route (503)**. See the signature-scheme delta in the note below. |
+| `ZERNIO_WEBHOOK_SECRET` | _(unset)_                | zernio webhook signing secret; the route verifies the `X-Zernio-Signature` (raw-body HMAC-SHA256) header. Unset: dev/test accept unsigned deliveries; **production refuses the route (503)**. |
 | `ZERNIO_VERIFY_TOKEN`   | _(unset)_                | Verify token for the `GET` registration handshake. Unset: that handshake endpoint 404s.                               |
 
 v1 is **WhatsApp only** (SMS and voice are schema-ready but not yet
 provisionable) and **text only** (media/location/voice messages get no reply).
 
-> **Note — the current zernio wire-format placeholders don't match zernio's live
-> API, so enabling the channel with a real `ZERNIO_API_KEY` / `ZERNIO_WEBHOOK_SECRET`
-> will not work until the code is reconciled.** The provider specifics are marked
-> `TODO(zernio)` and confined to three files:
+> **Note — the WhatsApp channel is not yet fully wired to zernio's live API.** The
+> remaining provider specifics are marked `TODO(zernio)` and confined to two files:
 >
-> - `src/services/zernio-whatsapp.ts` — send + provision endpoints/payloads
-> - `src/routes/agent-whatsapp.ts` — webhook signature + verify handshake
+> - `src/services/zernio-whatsapp.ts` — send + provision leaf paths/payloads
 > - `src/services/agent/whatsapp/inbound.ts` — `parseZernioInbound`, the payload→event mapping
 >
-> Reconciling against [zernio's docs](https://docs.zernio.com/) touches only those
-> three files. The known deltas, from zernio's published API:
+> **Resolved** (verified against [zernio's docs](https://docs.zernio.com/webhooks)):
+> the webhook signature is now the real scheme — `X-Zernio-Signature` (legacy
+> `X-Late-Signature`) = lowercase hex HMAC-SHA256 of the raw body — and the API base
+> URL default is `https://zernio.com/api/v1`.
 >
-> - **Signature:** the code checks Svix-style `zernio-id` / `zernio-timestamp` /
->   `zernio-signature`; zernio signs with a single `X-Zernio-Signature` = lowercase
->   hex HMAC-SHA256 of the raw request body, keyed by the secret.
-> - **Events:** `parseZernioInbound` expects `whatsapp.message.received` /
->   `whatsapp.message.failed`; zernio fires `message.received` / `message.failed`.
-> - **Base URL:** the default is `https://api.zernio.com` with `/v1/…` paths
->   appended; zernio documents the base as `https://zernio.com/api/v1`.
+> **Still open**, so enabling the channel with a real `ZERNIO_API_KEY` won't work
+> end-to-end until reconciled:
 >
-> Until these are reconciled, the no-op path (no `ZERNIO_API_KEY`) is the supported
-> way to exercise the flow.
+> - **Inbound payload mapping:** `parseZernioInbound` still expects a canonical
+>   `whatsapp.message.received` / `whatsapp.message.failed` shape; zernio's real
+>   events are `message.received` / `message.failed` with the message in a nested
+>   `message` object whose schema must be mapped in.
+> - **Send + provision endpoints:** the leaf paths (`/messages`, `/numbers`) and
+>   their payloads are still assumptions, and zernio's WhatsApp model looks like
+>   *connect credentials + select a number* rather than *provision a new number* —
+>   so `ZernioProvisioner` may need rethinking, not just endpoint tweaks.
+>
+> Until then, the no-op path (no `ZERNIO_API_KEY`) is the supported way to exercise
+> the flow.

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -56,10 +56,10 @@ const envSchema = z
 		// hard boot failure for deployments that don't use the email channel.
 		RESEND_WEBHOOK_SECRET: z.string().min(1).optional(),
 		// --- WhatsApp channel (zernio) ---
-		// Base URL of the zernio API (WhatsApp Business provider). Overridable so a
-		// self-hosted/staging zernio can be targeted; the send + provision endpoints
-		// hang off it.
-		ZERNIO_API_URL: z.url().default('https://api.zernio.com'),
+		// Base URL of the zernio API (WhatsApp Business provider), per zernio's docs.
+		// Overridable so a self-hosted/staging zernio can be targeted; the send +
+		// provision leaf paths hang off it.
+		ZERNIO_API_URL: z.url().default('https://zernio.com/api/v1'),
 		// API key for zernio. When unset, WhatsApp degrades to a no-op sender +
 		// provisioner (a deterministic fake number in development) so the API still
 		// runs and tests without zernio credentials — mirroring the Resend gate.

--- a/packages/api/src/routes/agent-whatsapp.ts
+++ b/packages/api/src/routes/agent-whatsapp.ts
@@ -6,13 +6,13 @@ import { errorResponseSchema } from '../http-schemas';
 import { defaultCapabilities } from '../services/agent/capabilities';
 import type { InboundAgentMessage } from '../services/agent/channel';
 import { flagDeliveryFailure, handleInboundAgentMessage } from '../services/agent/orchestrator';
-import { verifyWebhookSignature } from '../services/agent/webhook';
 import { createWhatsappChannelAdapter } from '../services/agent/whatsapp/adapter';
 import {
 	parseZernioInbound,
 	WHATSAPP_FAILED_EVENT,
 	WHATSAPP_MESSAGE_EVENT,
 } from '../services/agent/whatsapp/inbound';
+import { verifyZernioSignature } from '../services/zernio-whatsapp';
 
 /**
  * The WhatsApp channel of the scheduling agent: zernio posts every message to the
@@ -96,16 +96,15 @@ export const agentWhatsappRoutes: FastifyPluginAsync = async (fastify) => {
 			}
 			return;
 		}
-		// TODO(zernio): confirm zernio's signature header names.
-		const verified = verifyWebhookSignature({
+		// zernio signs the raw body with HMAC-SHA256 and sends the lowercase hex
+		// digest in X-Zernio-Signature (legacy deliveries: X-Late-Signature).
+		const signature =
+			headerValue(request.headers['x-zernio-signature']) ||
+			headerValue(request.headers['x-late-signature']);
+		const verified = verifyZernioSignature({
 			secret,
-			headers: {
-				id: headerValue(request.headers['zernio-id']),
-				timestamp: headerValue(request.headers['zernio-timestamp']),
-				signature: headerValue(request.headers['zernio-signature']),
-			},
+			signature,
 			payload: rawBodies.get(request) ?? '',
-			now: new Date(),
 		});
 		if (!verified) {
 			throw app.httpErrors.unauthorized('Invalid webhook signature');

--- a/packages/api/src/services/zernio-whatsapp.ts
+++ b/packages/api/src/services/zernio-whatsapp.ts
@@ -1,3 +1,4 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
 import { type AccountId, normalizePhone } from '@rivus/core';
 import { z } from 'zod';
 import type { Config } from '../config';
@@ -18,9 +19,13 @@ import { NoopWhatsappSender, type WhatsappMessage, type WhatsappSender } from '.
  * finalizing against the real docs touches only this file.
  */
 
-// TODO(zernio): confirm the send + provision endpoint paths against zernio's docs.
-const SEND_PATH = '/v1/messages';
-const NUMBERS_PATH = '/v1/numbers';
+// The API base is `https://zernio.com/api/v1` (see `ZERNIO_API_URL` in config), so
+// these are the leaf resource paths under it.
+// TODO(zernio): confirm the send + provision leaf paths and their payloads against
+// zernio's docs — the base URL is confirmed, but these exact endpoints (and whether
+// WhatsApp numbers are "provisioned" here at all vs. connected/selected) are not.
+const SEND_PATH = '/messages';
+const NUMBERS_PATH = '/numbers';
 
 interface ZernioOptions {
 	apiKey: string;
@@ -30,6 +35,44 @@ interface ZernioOptions {
 
 function bearer(apiKey: string): Record<string, string> {
 	return { authorization: `Bearer ${apiKey}`, 'content-type': 'application/json' };
+}
+
+/**
+ * Compute a zernio webhook signature — the lowercase hex HMAC-SHA256 of the raw
+ * request body keyed by the webhook secret. The counterpart of
+ * {@link verifyZernioSignature}, used by tests (and handy for local `curl`s).
+ */
+export function signZernioPayload(secret: string, payload: string): string {
+	return createHmac('sha256', secret).update(payload).digest('hex');
+}
+
+/**
+ * Verify a zernio webhook delivery. zernio signs the **raw request body** with
+ * HMAC-SHA256 keyed by the webhook secret and sends the lowercase hex digest in
+ * the `X-Zernio-Signature` header (legacy deliveries use `X-Late-Signature`; the
+ * route passes whichever is present). Unlike the Svix scheme in
+ * `services/agent/webhook.ts` that the email channel uses, there is no id or
+ * timestamp envelope and no replay window — the body alone is signed — so this is
+ * a distinct verifier. See https://docs.zernio.com/webhooks.
+ */
+export function verifyZernioSignature(options: {
+	secret: string;
+	/** The `X-Zernio-Signature` (or legacy `X-Late-Signature`) header value. */
+	signature: string;
+	/** The raw request body, byte-for-byte as received. */
+	payload: string;
+}): boolean {
+	const provided = options.signature.trim().toLowerCase();
+	if (!options.secret || !provided) {
+		return false;
+	}
+	const expected = signZernioPayload(options.secret, options.payload);
+	// Compare the fixed-width hex digests as byte strings, in constant time.
+	const providedBytes = Buffer.from(provided, 'utf8');
+	const expectedBytes = Buffer.from(expected, 'utf8');
+	return (
+		providedBytes.length === expectedBytes.length && timingSafeEqual(providedBytes, expectedBytes)
+	);
 }
 
 export class ZernioWhatsappSender implements WhatsappSender {

--- a/packages/api/test/agent-whatsapp-channel.test.ts
+++ b/packages/api/test/agent-whatsapp-channel.test.ts
@@ -9,6 +9,8 @@ import type { FetchLike } from '../src/services/resend-mailer';
 import {
 	createWhatsappProvisioner,
 	createWhatsappSender,
+	signZernioPayload,
+	verifyZernioSignature,
 	ZernioProvisioner,
 	ZernioWhatsappSender,
 } from '../src/services/zernio-whatsapp';
@@ -80,7 +82,7 @@ describe('ZernioWhatsappSender', () => {
 			string,
 			{ headers: Record<string, string>; body: string },
 		];
-		expect(url).toBe('https://api.zernio.com/v1/messages');
+		expect(url).toBe('https://api.zernio.com/messages');
 		expect(init.headers.authorization).toBe('Bearer zk_1');
 		expect(JSON.parse(init.body)).toMatchObject({ from: '+15550001111', to: '+15559990000' });
 	});
@@ -210,6 +212,38 @@ describe('createWhatsappSender / createWhatsappProvisioner', () => {
 			ZERNIO_API_URL: 'https://api.zernio.com',
 		});
 		expect(provisioner).toBeInstanceOf(ZernioProvisioner);
+	});
+});
+
+describe('verifyZernioSignature / signZernioPayload', () => {
+	const SECRET = 'zwh_secret';
+	const BODY = '{"event":"message.received"}';
+
+	it('accepts a signature it produced and rejects a tampered body', () => {
+		const signature = signZernioPayload(SECRET, BODY);
+		expect(verifyZernioSignature({ secret: SECRET, signature, payload: BODY })).toBe(true);
+		expect(verifyZernioSignature({ secret: SECRET, signature, payload: `${BODY} ` })).toBe(false);
+	});
+
+	it('is case-insensitive on the hex digest and tolerant of surrounding space', () => {
+		const signature = signZernioPayload(SECRET, BODY).toUpperCase();
+		expect(
+			verifyZernioSignature({ secret: SECRET, signature: `  ${signature}  `, payload: BODY }),
+		).toBe(true);
+	});
+
+	it('rejects an empty secret, empty signature, or wrong-length digest', () => {
+		const signature = signZernioPayload(SECRET, BODY);
+		expect(verifyZernioSignature({ secret: '', signature, payload: BODY })).toBe(false);
+		expect(verifyZernioSignature({ secret: SECRET, signature: '', payload: BODY })).toBe(false);
+		expect(verifyZernioSignature({ secret: SECRET, signature: 'abc123', payload: BODY })).toBe(
+			false,
+		);
+	});
+
+	it('rejects a signature made with a different secret', () => {
+		const signature = signZernioPayload('other-secret', BODY);
+		expect(verifyZernioSignature({ secret: SECRET, signature, payload: BODY })).toBe(false);
 	});
 });
 

--- a/packages/api/test/agent-whatsapp-route.test.ts
+++ b/packages/api/test/agent-whatsapp-route.test.ts
@@ -5,11 +5,11 @@ import { buildApp } from '../src/app';
 import { loadConfig } from '../src/config';
 import { createInMemoryRepositories } from '../src/repositories/memory';
 import { NoopReceivedEmailReader } from '../src/services/agent/email/received';
-import { signWebhookPayload } from '../src/services/agent/webhook';
 import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
 import { NoopFaqAnswerService } from '../src/services/faq-answer';
 import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
 import { createNotificationService } from '../src/services/notifications';
+import { signZernioPayload } from '../src/services/zernio-whatsapp';
 import {
 	buildTestAppWithRepos,
 	RecordingMailer,
@@ -254,7 +254,7 @@ describe('POST /v1/channels/whatsapp/inbound', () => {
 
 // --- Signature + handshake (separate config) --------------------------------
 
-const SECRET = 'whsec_dGVzdHNlY3JldA==';
+const SECRET = 'zwh_test_secret';
 
 function buildWhatsappApp(extraConfig: Record<string, string> = {}): FastifyInstance {
 	const repos = createInMemoryRepositories();
@@ -286,14 +286,9 @@ describe('POST /v1/channels/whatsapp/inbound — signature + handshake', () => {
 	it('accepts a validly signed delivery and rejects a tampered one', async () => {
 		app = buildWhatsappApp({ ZERNIO_WEBHOOK_SECRET: SECRET });
 		const body = JSON.stringify(inbound({ to: '+19998887777' }));
-		const id = 'msg_1';
-		const timestamp = String(Math.floor(Date.now() / 1000));
-		const signature = signWebhookPayload({ secret: SECRET, id, timestamp, payload: body });
 		const headers = {
 			'content-type': 'application/json',
-			'zernio-id': id,
-			'zernio-timestamp': timestamp,
-			'zernio-signature': signature,
+			'x-zernio-signature': signZernioPayload(SECRET, body),
 		};
 		const ok = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: body, headers });
 		// Unknown account, but the signature passed (a 401 would mean it didn't).
@@ -306,6 +301,32 @@ describe('POST /v1/channels/whatsapp/inbound — signature + handshake', () => {
 			headers,
 		});
 		expect(tampered.statusCode).toBe(401);
+	});
+
+	it('accepts the legacy X-Late-Signature header', async () => {
+		app = buildWhatsappApp({ ZERNIO_WEBHOOK_SECRET: SECRET });
+		const body = JSON.stringify(inbound({ to: '+19998887777' }));
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: body,
+			headers: {
+				'content-type': 'application/json',
+				'x-late-signature': signZernioPayload(SECRET, body),
+			},
+		});
+		expect(res.json()).toEqual({ handled: false, outcome: 'unknown_account' });
+	});
+
+	it('rejects a delivery with no signature header (401)', async () => {
+		app = buildWhatsappApp({ ZERNIO_WEBHOOK_SECRET: SECRET });
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: JSON.stringify(inbound()),
+			headers: { 'content-type': 'application/json' },
+		});
+		expect(res.statusCode).toBe(401);
 	});
 
 	it('refuses to serve unsigned in production (503, fail closed)', async () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — _new verifier + route cases added; full api suite green, coverage above thresholds._

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix. Follow-up to #108/#109: reconciles the WhatsApp/zernio integration with zernio's **live** API for the two provider specifics its docs confirm precisely. (Codex flagged these on #109; verified against zernio's published docs.)

### The bugs (present since #108)

With a real `ZERNIO_WEBHOOK_SECRET` / `ZERNIO_API_KEY` set, the channel could not work:

1. **Webhook signature scheme was wrong.** The route verified a Svix-style `zernio-id`/`zernio-timestamp`/`zernio-signature` envelope, but zernio signs the **raw request body** with HMAC-SHA256 and sends the lowercase hex digest in `X-Zernio-Signature` (legacy alias `X-Late-Signature`) — no id/timestamp, no replay window. Every signed delivery would have returned `401`.
2. **API base URL was wrong.** Default was `https://api.zernio.com` with `/v1/…` paths appended; zernio documents the base as `https://zernio.com/api/v1`, so outbound send/provision calls hit an unsupported host.

### What changed

- **New `verifyZernioSignature` / `signZernioPayload`** in `services/zernio-whatsapp.ts` (the module that owns zernio's wire format), implemented on `node:crypto` with a constant-time compare. The Svix `verifyWebhookSignature` in `services/agent/webhook.ts` is untouched — the **email** channel still uses it.
- **WhatsApp route** now verifies `X-Zernio-Signature` (falling back to `X-Late-Signature`) over the raw body.
- **`ZERNIO_API_URL` default** → `https://zernio.com/api/v1`; adapter leaf paths drop the duplicated `/v1` (`/messages`, `/numbers`). `.env.example` updated to match.
- **README** reconciliation note updated: signature + base URL marked resolved; the remaining `TODO(zernio)` items called out precisely.

### Deliberately still `TODO(zernio)` (not guessed)

zernio's docs don't publish these, so guessing would be worse than an honest placeholder:

- **Inbound payload mapping** — `parseZernioInbound` still expects the canonical `whatsapp.message.*` shape; zernio's real events are `message.received`/`message.failed` with the message in a nested `message` object whose schema isn't documented.
- **Send/provision endpoints + provisioning model** — the leaf paths/payloads are still assumptions, and zernio's WhatsApp pages read as *connect credentials + select a number* rather than *provision a new number*, so `ZernioProvisioner` may need rethinking, not just endpoint tweaks. Flagged for a follow-up.

### Verification

`pnpm lint`, `pnpm type-check`, and `pnpm --filter @rivus/api test:coverage` all pass (799 tests; statements 95.5% / branches 87.3% / functions 97.2% / lines 95.6%, all above the 90/80/90/90 thresholds). Until the two open items above are resolved, the no-op path (no `ZERNIO_API_KEY`) remains the supported way to exercise the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E623EWd33DkMJbqN68w3PM

---
_Generated by [Claude Code](https://claude.ai/code/session_01E623EWd33DkMJbqN68w3PM)_