### PR TITLE
feat(api): add Plivo as the primary WhatsApp provider

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -204,35 +204,73 @@ flow with `curl` against a dev API. The scheduling policy itself is pure
 renderer renders — a new channel reuses everything but the renderer, which is
 exactly how the WhatsApp channel below is built.
 
-### WhatsApp channel (zernio)
+### WhatsApp channel
 
-The same scheduling agent also answers over **WhatsApp Business**, via the
-[zernio](https://zernio.com) provider. Rivus assigns the account a WhatsApp
-number when an owner enables the channel, then customers who message that number
-get the identical experience to email — sender validation against the account's
-customers (unknown senders get the self-signup link), open-slot offers in the
-account's timezone, booking a confirmed `Job`, multi-turn state on an
-`AgentThread`, FAQ drafts, and the exchange mirrored into the inbox as a
-`whatsapp` conversation. None of that is re-implemented per channel: the WhatsApp
-route only owns the provider edges (signature check, the zernio payload shape,
-resolving the account from the business number, and the loop/unsupported guards)
-and hands a normalized message to the same `handleInboundAgentMessage` the email
-channel uses. See the "unified across channels" note in
+The same scheduling agent also answers over **WhatsApp Business**. Rivus assigns
+the account a WhatsApp number when an owner enables the channel, then customers
+who message that number get the identical experience to email — sender
+validation against the account's customers (unknown senders get the self-signup
+link), open-slot offers in the account's timezone, booking a confirmed `Job`,
+multi-turn state on an `AgentThread`, FAQ drafts, and the exchange mirrored into
+the inbox as a `whatsapp` conversation. None of that is re-implemented per
+channel — or per provider: each provider route owns only its edges (signature
+check and payload shape) and hands a canonical event to the shared dispatch
+(`routes/agent-whatsapp-shared.ts`), which resolves the account, applies the
+loop/unsupported guards, and calls the same `handleInboundAgentMessage` the
+email channel uses. See the "unified across channels" note in
 [AGENTS.md](../../AGENTS.md) for the layering.
 
-The inbound webhook also handles **outbound delivery status**: when a message
+The inbound webhooks also handle **outbound delivery status**: when a message
 Rivus sent fails to reach the customer, the conversation is flagged
 `needs_attention` with an inline note, so it surfaces in the inbox's "Needs you"
 filter and a human can follow up another way — the same treatment as an email
 bounce.
 
-Wiring it up:
+Two providers are wired behind the same seams (`WhatsappSender`,
+`ChannelProvisioner`): **Plivo** is the primary — chosen whenever its
+credentials are set — and **zernio** the alternative, used when only its key is
+set. With neither configured, both degrade to no-ops (a deterministic fake
+number in dev, sends dropped), so the whole flow still runs locally with `curl`
+and no credentials.
 
-1. Set `ZERNIO_API_KEY` (and `ZERNIO_API_URL` if it isn't the default). **Without
-   a key the channel still works end-to-end locally**: the sender and provisioner
-   degrade to no-ops, so enabling the channel assigns a deterministic fake number
-   and outbound messages are dropped — enough to drive the inbound flow with
-   `curl` and no credentials.
+#### Plivo (primary provider)
+
+Plivo fronts SMS, MMS, and WhatsApp through one Messages API and one rented
+number, which is why it's the primary: when the SMS and voice channels are
+built, the same Plivo account and the same per-account number will carry them.
+
+1. Set `PLIVO_AUTH_ID` + `PLIVO_AUTH_TOKEN` (Console → API keys), and
+   `PLIVO_API_URL` if it isn't the default.
+2. Point the WhatsApp webhook at `POST /v1/channels/whatsapp/plivo/inbound` in
+   the Plivo console. Deliveries are verified with Plivo's V2 signature scheme,
+   which signs **URL + nonce with the auth token** (there is no separate webhook
+   secret). Set `PLIVO_WEBHOOK_URL` to the exact public URL you configured so a
+   rewriting proxy can't break verification; the sender also attaches it to every
+   message as the delivery-status callback, which is what feeds the
+   `needs_attention` flow above.
+3. Numbers: enabling the channel rents a voice+SMS-capable number through
+   Plivo's Numbers API. Registering that number to the WhatsApp Business Account
+   (Meta's Embedded Signup in the Plivo console) is a one-time step per number
+   that Plivo does not yet expose over the API — see `TODO(plivo)` in
+   `src/services/plivo-whatsapp.ts`.
+4. An account **owner** enables the channel — in the app (Settings → WhatsApp
+   Business → On) or via `POST /v1/account/channels/whatsapp/enable`. Rivus
+   provisions the number and starts answering; `…/disable` turns it off but
+   retains the number, so re-enabling restores the same one. Both are idempotent.
+
+| Variable               | Default                    | Notes                                                                                                                 |
+| ---------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `PLIVO_AUTH_ID`        | _(unset)_                  | Plivo account auth ID. Both credentials set ⇒ Plivo is the active WhatsApp provider.                                   |
+| `PLIVO_AUTH_TOKEN`     | _(unset)_                  | Plivo auth token — API auth **and** the webhook signing key. Unset: dev/test accept unsigned deliveries; **production refuses the Plivo route (503)**. |
+| `PLIVO_API_URL`        | `https://api.plivo.com/v1` | Base URL of Plivo's REST API.                                                                                          |
+| `PLIVO_WEBHOOK_URL`    | _(unset)_                  | The public URL of the Plivo webhook route. Pins signature verification behind proxies and rides along on sends as the status callback. Unset: the URL is derived per-request and sends carry no callback. |
+| `PLIVO_NUMBER_COUNTRY` | `US`                       | ISO 3166-1 alpha-2 country whose numbers the provisioner rents.                                                        |
+
+#### zernio (alternative provider)
+
+Used when `ZERNIO_API_KEY` is set and the Plivo credentials are not.
+
+1. Set `ZERNIO_API_KEY` (and `ZERNIO_API_URL` if it isn't the default).
 2. In zernio, point an inbound webhook at `POST /v1/channels/whatsapp/inbound` and
    set its signing secret as `ZERNIO_WEBHOOK_SECRET`. Subscribe it to zernio's
    `message.received` (inbound customer messages) and `message.failed` (undelivered
@@ -240,23 +278,21 @@ Wiring it up:
    type. `ZERNIO_VERIFY_TOKEN` applies only if zernio requires a `GET` registration
    handshake (still unconfirmed — the handshake endpoint stays inert, 404, until
    the token is set).
-3. An account **owner** enables the channel — in the app (Settings → WhatsApp
-   Business → On) or via `POST /v1/account/channels/whatsapp/enable`. Rivus
-   provisions the number and starts answering; `…/disable` turns it off but
-   retains the number, so re-enabling restores the same one. Both are idempotent.
+3. Enable the channel exactly as in the Plivo step 4 above.
 
 | Variable                | Default                  | Notes                                                                                                                   |
 | ----------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | `ZERNIO_API_URL`        | `https://zernio.com/api/v1` | Base URL of the zernio API (per zernio's docs).                                                                     |
-| `ZERNIO_API_KEY`        | _(unset)_                | Unset: WhatsApp degrades to a no-op sender + provisioner (a deterministic fake number in dev) so the API runs without credentials. |
+| `ZERNIO_API_KEY`        | _(unset)_                | Unset: WhatsApp falls back as described above (Plivo when configured, else the no-ops).                                |
 | `ZERNIO_WEBHOOK_SECRET` | _(unset)_                | zernio webhook signing secret; the route verifies the `X-Zernio-Signature` (raw-body HMAC-SHA256) header. Unset: dev/test accept unsigned deliveries; **production refuses the route (503)**. |
 | `ZERNIO_VERIFY_TOKEN`   | _(unset)_                | Verify token for the `GET` registration handshake. Unset: that handshake endpoint 404s.                               |
 
 v1 is **WhatsApp only** (SMS and voice are schema-ready but not yet
 provisionable) and **text only** (media/location/voice messages get no reply).
 
-> **Note — the WhatsApp channel is not yet fully wired to zernio's live API.** The
-> remaining provider specifics are marked `TODO(zernio)` and confined to two files:
+> **Note — the zernio provider is not yet fully wired to zernio's live API**
+> (the Plivo path above is built against Plivo's documented wire formats). The
+> remaining zernio specifics are marked `TODO(zernio)` and confined to two files:
 >
 > - `src/services/zernio-whatsapp.ts` — send + provision leaf paths/payloads
 > - `src/services/agent/whatsapp/inbound.ts` — `parseZernioInbound`, the payload→event mapping
@@ -278,5 +314,4 @@ provisionable) and **text only** (media/location/voice messages get no reply).
 >   *connect credentials + select a number* rather than *provision a new number* —
 >   so `ZernioProvisioner` may need rethinking, not just endpoint tweaks.
 >
-> Until then, the no-op path (no `ZERNIO_API_KEY`) is the supported way to exercise
-> the flow.
+> Until then, use Plivo (or the no-op path) to exercise the flow end-to-end.

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -4596,6 +4596,55 @@
           }
         }
       }
+    },
+    "/v1/channels/whatsapp/plivo/inbound": {
+      "post": {
+        "summary": "Plivo WhatsApp webhook (inbound customer messages + delivery status)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Plivo delivers WhatsApp events for the account’s provisioned business number here: inbound customer messages, and delivery reports for messages Rivus sent (the sender passes this URL as the status callback). On an inbound message Rivus validates the sender against the account’s customers (by phone), keeps the multi-turn scheduling state on the thread, and replies over WhatsApp. On a failed delivery it flags the conversation for a human. Deliveries are authenticated with Plivo’s V2 signature headers when PLIVO_AUTH_TOKEN is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWhatsappWebhookResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -16,6 +16,7 @@ import { accountChannelRoutes } from './routes/account-channels';
 import { adminRoutes } from './routes/admin';
 import { agentEmailRoutes } from './routes/agent-email';
 import { agentWhatsappRoutes } from './routes/agent-whatsapp';
+import { agentWhatsappPlivoRoutes } from './routes/agent-whatsapp-plivo';
 import { authRoutes } from './routes/auth';
 import { billingRoutes } from './routes/billing';
 import { conversationRoutes } from './routes/conversations';
@@ -198,6 +199,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	app.register(publicRoutes, { prefix: '/v1/public' });
 	app.register(agentEmailRoutes, { prefix: '/v1/channels' });
 	app.register(agentWhatsappRoutes, { prefix: '/v1/channels' });
+	app.register(agentWhatsappPlivoRoutes, { prefix: '/v1/channels' });
 
 	return app;
 }

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -71,6 +71,26 @@ const envSchema = z
 		// Verify token for the GET webhook handshake some WhatsApp providers require
 		// to register a webhook URL. When unset, the handshake endpoint 404s.
 		ZERNIO_VERIFY_TOKEN: z.string().min(1).optional(),
+		// --- WhatsApp channel (Plivo, the primary provider) ---
+		// Plivo account credentials (Console → API keys). When both are set, Plivo is
+		// the active WhatsApp provider — sender and number provisioner — and the Plivo
+		// webhook verifies deliveries with the auth token (Plivo signs URL + nonce
+		// with it; there is no separate webhook secret). When unset, WhatsApp falls
+		// back to zernio (above), else to a no-op — mirroring the Resend gate.
+		PLIVO_AUTH_ID: z.string().min(1).optional(),
+		PLIVO_AUTH_TOKEN: z.string().min(1).optional(),
+		// Base URL of Plivo's REST API; the account-scoped resource paths hang off it.
+		PLIVO_API_URL: z.url().default('https://api.plivo.com/v1'),
+		// The public URL of this API's Plivo webhook (…/v1/channels/whatsapp/plivo/inbound
+		// as reachable from the internet), i.e. the exact URL configured in the Plivo
+		// console. Used two ways: it pins the URL signature validation recomputes
+		// (Plivo signs the URL it calls, so a rewriting proxy in front of the API
+		// would otherwise break verification), and it rides along on every send as
+		// the delivery-status callback so failures flag the conversation. When unset,
+		// verification derives the URL from the request and sends carry no callback.
+		PLIVO_WEBHOOK_URL: z.url().optional(),
+		// ISO 3166-1 alpha-2 country whose numbers the provisioner rents.
+		PLIVO_NUMBER_COUNTRY: z.string().length(2).default('US'),
 		// --- AI (duplicate-FAQ detection) ---
 		// The knowledge base's "is this a duplicate?" check runs through the AI SDK,
 		// so any provider whose key is set can serve it. OpenAI is the primary; the

--- a/packages/api/src/routes/agent-whatsapp-plivo.ts
+++ b/packages/api/src/routes/agent-whatsapp-plivo.ts
@@ -1,0 +1,155 @@
+import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { errorResponseSchema } from '../http-schemas';
+import { defaultCapabilities } from '../services/agent/capabilities';
+import { createWhatsappChannelAdapter } from '../services/agent/whatsapp/adapter';
+import { parsePlivoInbound } from '../services/agent/whatsapp/plivo-inbound';
+import { verifyPlivoSignature } from '../services/plivo-whatsapp';
+import { dispatchWhatsappEvent, whatsappWebhookResponseSchema } from './agent-whatsapp-shared';
+
+/**
+ * The Plivo edge of the scheduling agent's WhatsApp channel. Plivo posts two
+ * kinds of deliveries here: inbound customer messages (the webhook configured
+ * on the WhatsApp Business Account in the Plivo console) and delivery reports
+ * for Rivus's own sends (the callback URL the sender attaches to every
+ * message). This route owns only the Plivo-specific edges — V2 signature
+ * verification (URL + nonce, keyed by the auth token; there is no separate
+ * webhook secret) and the payload shape, including Plivo's form-encoded
+ * variant — then hands the canonical event to {@link dispatchWhatsappEvent},
+ * the same shared body the zernio route uses.
+ *
+ * Everything unactionable answers `200 {handled:false}` (never a non-2xx that
+ * would make Plivo redeliver something that will never become actionable).
+ */
+
+/** First value of a possibly-repeated header, as a string. */
+function headerValue(value: string | string[] | undefined): string {
+	if (Array.isArray(value)) {
+		return value[0] ?? '';
+	}
+	return value ?? '';
+}
+
+/**
+ * The URL Plivo signed. `PLIVO_WEBHOOK_URL` (the exact URL configured in the
+ * Plivo console) pins it; otherwise it is derived from the request, honoring
+ * the forwarding headers the front-door proxy sets.
+ */
+function requestUrl(request: FastifyRequest, configured: string | undefined): string {
+	if (configured) {
+		return configured;
+	}
+	const proto = headerValue(request.headers['x-forwarded-proto']) || request.protocol;
+	const host = headerValue(request.headers['x-forwarded-host']) || request.headers.host || '';
+	return `${proto}://${host}${request.raw.url ?? request.url}`;
+}
+
+export const agentWhatsappPlivoRoutes: FastifyPluginAsync = async (fastify) => {
+	const app = fastify.withTypeProvider<ZodTypeProvider>();
+	const {
+		config,
+		accounts,
+		customers,
+		conversations,
+		agentThreads,
+		memberships,
+		notifier,
+		whatsappSender,
+		jobs,
+	} = app.deps;
+
+	const adapter = createWhatsappChannelAdapter({ customers, sender: whatsappSender });
+	const capabilities = defaultCapabilities();
+	const dispatchDeps = {
+		config,
+		accounts,
+		conversations,
+		agentThreads,
+		memberships,
+		notifier,
+		jobs,
+	};
+
+	// Plivo's message callbacks arrive form-encoded; parse them to the same plain
+	// object shape as JSON so the payload mapper sees one input. Plugin-scoped, so
+	// no other route inherits it. TODO(plivo): confirm whether the WhatsApp hook
+	// also uses JSON in production — both are accepted here either way.
+	app.addContentTypeParser(
+		'application/x-www-form-urlencoded',
+		{ parseAs: 'string' },
+		(_request, payload, done) => {
+			done(null, Object.fromEntries(new URLSearchParams(payload as string)));
+		},
+	);
+
+	// Authenticity gate, before any parsing. Plivo V2 signs the webhook URL + a
+	// nonce with the account's auth token — the body is not part of the signature.
+	app.addHook('preValidation', async (request, reply) => {
+		if (request.method !== 'POST') {
+			return;
+		}
+		const authToken = config.PLIVO_AUTH_TOKEN;
+		if (!authToken) {
+			if (config.NODE_ENV === 'production') {
+				return reply.code(503).send({
+					error: 'Service Unavailable',
+					message: 'The WhatsApp channel is not configured (PLIVO_AUTH_TOKEN is unset).',
+					statusCode: 503,
+				});
+			}
+			return;
+		}
+		const verified = verifyPlivoSignature({
+			authToken,
+			url: requestUrl(request, config.PLIVO_WEBHOOK_URL),
+			nonce: headerValue(request.headers['x-plivo-signature-v2-nonce']),
+			signature: headerValue(request.headers['x-plivo-signature-v2']),
+			maSignature: headerValue(request.headers['x-plivo-signature-ma-v2']),
+		});
+		if (!verified) {
+			throw app.httpErrors.unauthorized('Invalid webhook signature');
+		}
+	});
+
+	app.post(
+		'/whatsapp/plivo/inbound',
+		{
+			schema: {
+				tags: ['channels'],
+				summary: 'Plivo WhatsApp webhook (inbound customer messages + delivery status)',
+				description:
+					'Plivo delivers WhatsApp events for the account’s provisioned business ' +
+					'number here: inbound customer messages, and delivery reports for messages ' +
+					'Rivus sent (the sender passes this URL as the status callback). On an ' +
+					'inbound message Rivus validates the sender against the account’s customers ' +
+					'(by phone), keeps the multi-turn scheduling state on the thread, and replies ' +
+					'over WhatsApp. On a failed delivery it flags the conversation for a human. ' +
+					'Deliveries are authenticated with Plivo’s V2 signature headers when ' +
+					'PLIVO_AUTH_TOKEN is configured.',
+				body: z.unknown(),
+				response: {
+					200: whatsappWebhookResponseSchema,
+					401: errorResponseSchema,
+					503: errorResponseSchema,
+				},
+			},
+		},
+		async (request) => {
+			const result = parsePlivoInbound(request.body);
+			if (result.kind === 'unrecognized') {
+				return { handled: false, outcome: 'unrecognized_payload' };
+			}
+			if (result.kind === 'ignored') {
+				return { handled: false, outcome: 'ignored_event_type' };
+			}
+			return dispatchWhatsappEvent({
+				deps: dispatchDeps,
+				adapter,
+				capabilities,
+				event: result.event,
+				logger: request.log,
+			});
+		},
+	);
+};

--- a/packages/api/src/routes/agent-whatsapp-shared.ts
+++ b/packages/api/src/routes/agent-whatsapp-shared.ts
@@ -1,0 +1,110 @@
+import { normalizePhone } from '@rivus/core';
+import type { FastifyBaseLogger } from 'fastify';
+import { z } from 'zod';
+import type { AgentCapability } from '../services/agent/capabilities';
+import type { ChannelAdapter, InboundAgentMessage } from '../services/agent/channel';
+import {
+	flagDeliveryFailure,
+	handleInboundAgentMessage,
+	type InboundHandleResult,
+} from '../services/agent/orchestrator';
+import {
+	WHATSAPP_FAILED_EVENT,
+	type WhatsappInboundEvent,
+} from '../services/agent/whatsapp/inbound';
+import type { AppDeps } from '../types';
+
+/**
+ * The provider-agnostic body shared by the WhatsApp webhook routes. Each
+ * provider route (zernio, Plivo) owns only its edges — signature verification
+ * and payload parsing into the canonical {@link WhatsappInboundEvent} — then
+ * hands the event here, so account resolution, the loop/unsupported guards,
+ * and the orchestrator hand-off can never drift between providers.
+ */
+
+/** What the webhook routes need from {@link AppDeps} to dispatch an event. */
+export type WhatsappWebhookDeps = Pick<
+	AppDeps,
+	'config' | 'accounts' | 'conversations' | 'agentThreads' | 'memberships' | 'notifier' | 'jobs'
+>;
+
+/** The 200 body both provider webhooks answer with (one shared OpenAPI id). */
+export const whatsappWebhookResponseSchema = z
+	.object({
+		handled: z.boolean(),
+		outcome: z.string(),
+	})
+	.meta({ id: 'AgentWhatsappWebhookResult' });
+
+export async function dispatchWhatsappEvent(options: {
+	deps: WhatsappWebhookDeps;
+	adapter: ChannelAdapter;
+	capabilities: AgentCapability[];
+	event: WhatsappInboundEvent;
+	logger: FastifyBaseLogger;
+}): Promise<InboundHandleResult> {
+	const { deps, adapter, capabilities, event, logger } = options;
+	const { accounts, conversations, agentThreads, memberships, notifier, config, jobs } = deps;
+
+	// Delivery failure: a message Rivus sent never reached the customer.
+	if (event.type === WHATSAPP_FAILED_EVENT) {
+		const businessNumber = normalizePhone(event.data.from);
+		const account = await accounts.findByChannelAddress('whatsapp', businessNumber);
+		if (!account || account.status === 'canceled') {
+			return { handled: false, outcome: 'unknown_account' };
+		}
+		const customerNumber = normalizePhone(event.data.to);
+		if (customerNumber === '') {
+			return { handled: false, outcome: 'unparseable_recipient' };
+		}
+		return flagDeliveryFailure({
+			deps: { conversations, agentThreads, memberships, notifier },
+			account,
+			channel: 'whatsapp',
+			contactAddress: customerNumber,
+			noteBody: `Rivus's last WhatsApp message to ${customerNumber} couldn't be delivered — follow up another way.`,
+			outcome: 'delivery_failed',
+			logger,
+		});
+	}
+
+	// Which account owns the business number this was sent to?
+	const businessNumber = normalizePhone(event.data.to);
+	const account = await accounts.findByChannelAddress('whatsapp', businessNumber);
+	if (!account || account.status === 'canceled') {
+		return { handled: false, outcome: 'unknown_account' };
+	}
+	// A disabled channel is off: acknowledge without replying (never a retry).
+	if (!account.channels.whatsapp.enabled) {
+		return { handled: false, outcome: 'channel_disabled' };
+	}
+
+	const senderNumber = normalizePhone(event.data.from);
+	if (senderNumber === '') {
+		return { handled: false, outcome: 'unparseable_sender' };
+	}
+	// Loop guard: never converse with any account's own business number, so two
+	// Rivus accounts can't schedule each other forever.
+	if (await accounts.findByChannelAddress('whatsapp', senderNumber)) {
+		return { handled: false, outcome: 'own_number' };
+	}
+	// v1 handles text only; a media/location/voice message gets no reply.
+	if (event.data.text.trim() === '') {
+		return { handled: false, outcome: 'unsupported_message_type' };
+	}
+
+	const message: InboundAgentMessage = {
+		sender: { address: senderNumber, name: event.data.profileName },
+		text: event.data.text,
+		subject: '',
+		externalMessageId: event.data.messageId,
+	};
+	return handleInboundAgentMessage({
+		deps: { config, jobs, conversations, agentThreads },
+		adapter,
+		capabilities,
+		account,
+		message,
+		logger,
+	});
+}

--- a/packages/api/src/routes/agent-whatsapp.ts
+++ b/packages/api/src/routes/agent-whatsapp.ts
@@ -1,39 +1,25 @@
-import { normalizePhone } from '@rivus/core';
 import type { FastifyError, FastifyPluginAsync, FastifyRequest } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { errorResponseSchema } from '../http-schemas';
 import { defaultCapabilities } from '../services/agent/capabilities';
-import type { InboundAgentMessage } from '../services/agent/channel';
-import { flagDeliveryFailure, handleInboundAgentMessage } from '../services/agent/orchestrator';
 import { createWhatsappChannelAdapter } from '../services/agent/whatsapp/adapter';
-import {
-	parseZernioInbound,
-	WHATSAPP_FAILED_EVENT,
-	WHATSAPP_MESSAGE_EVENT,
-} from '../services/agent/whatsapp/inbound';
+import { parseZernioInbound } from '../services/agent/whatsapp/inbound';
 import { verifyZernioSignature } from '../services/zernio-whatsapp';
+import { dispatchWhatsappEvent, whatsappWebhookResponseSchema } from './agent-whatsapp-shared';
 
 /**
- * The WhatsApp channel of the scheduling agent: zernio posts every message to the
- * account's provisioned business number here. This route owns only the WhatsApp
- * edges — signature verification, the verify-token handshake, the zernio payload
- * shape, resolving the account from the business number, and the loop/unsupported
- * guards — then hands a normalized {@link InboundAgentMessage} to the same
- * channel-agnostic {@link handleInboundAgentMessage} the email channel uses, so
+ * The zernio edge of the scheduling agent's WhatsApp channel: zernio posts every
+ * message to the account's provisioned business number here. This route owns
+ * only the zernio-specific edges — signature verification, the verify-token
+ * handshake, and the zernio payload shape — then hands the canonical event to
+ * {@link dispatchWhatsappEvent}, the same shared body the Plivo route uses, so
  * WhatsApp inherits scheduling, the inbox, FAQ drafts, and delivery-failure
  * handling with no channel-specific feature code.
  *
  * Everything unactionable answers `200 {handled:false}` (never a non-2xx that
  * would make zernio redeliver something that will never become actionable).
  */
-
-const webhookResponseSchema = z
-	.object({
-		handled: z.boolean(),
-		outcome: z.string(),
-	})
-	.meta({ id: 'AgentWhatsappWebhookResult' });
 
 const verifyQuerySchema = z.object({
 	'hub.mode': z.string().optional(),
@@ -65,7 +51,15 @@ export const agentWhatsappRoutes: FastifyPluginAsync = async (fastify) => {
 
 	const adapter = createWhatsappChannelAdapter({ customers, sender: whatsappSender });
 	const capabilities = defaultCapabilities();
-	const orchestratorDeps = { config, jobs, conversations, agentThreads };
+	const dispatchDeps = {
+		config,
+		accounts,
+		conversations,
+		agentThreads,
+		memberships,
+		notifier,
+		jobs,
+	};
 
 	// Raw body kept byte-for-byte for signature verification (see the email route).
 	const rawBodies = new WeakMap<FastifyRequest, string>();
@@ -149,7 +143,7 @@ export const agentWhatsappRoutes: FastifyPluginAsync = async (fastify) => {
 					'header when ZERNIO_WEBHOOK_SECRET is configured.',
 				body: z.unknown(),
 				response: {
-					200: webhookResponseSchema,
+					200: whatsappWebhookResponseSchema,
 					401: errorResponseSchema,
 					503: errorResponseSchema,
 				},
@@ -160,70 +154,11 @@ export const agentWhatsappRoutes: FastifyPluginAsync = async (fastify) => {
 			if (!event) {
 				return { handled: false, outcome: 'unrecognized_payload' };
 			}
-
-			// Delivery failure: a message Rivus sent never reached the customer.
-			if (event.type === WHATSAPP_FAILED_EVENT) {
-				const businessNumber = normalizePhone(event.data.from);
-				const account = await accounts.findByChannelAddress('whatsapp', businessNumber);
-				if (!account || account.status === 'canceled') {
-					return { handled: false, outcome: 'unknown_account' };
-				}
-				const customerNumber = normalizePhone(event.data.to);
-				if (customerNumber === '') {
-					return { handled: false, outcome: 'unparseable_recipient' };
-				}
-				return flagDeliveryFailure({
-					deps: { conversations, agentThreads, memberships, notifier },
-					account,
-					channel: 'whatsapp',
-					contactAddress: customerNumber,
-					noteBody: `Rivus's last WhatsApp message to ${customerNumber} couldn't be delivered — follow up another way.`,
-					outcome: 'delivery_failed',
-					logger: request.log,
-				});
-			}
-
-			if (event.type !== WHATSAPP_MESSAGE_EVENT) {
-				return { handled: false, outcome: 'ignored_event_type' };
-			}
-
-			// Which account owns the business number this was sent to?
-			const businessNumber = normalizePhone(event.data.to);
-			const account = await accounts.findByChannelAddress('whatsapp', businessNumber);
-			if (!account || account.status === 'canceled') {
-				return { handled: false, outcome: 'unknown_account' };
-			}
-			// A disabled channel is off: acknowledge without replying (never a retry).
-			if (!account.channels.whatsapp.enabled) {
-				return { handled: false, outcome: 'channel_disabled' };
-			}
-
-			const senderNumber = normalizePhone(event.data.from);
-			if (senderNumber === '') {
-				return { handled: false, outcome: 'unparseable_sender' };
-			}
-			// Loop guard: never converse with any account's own business number, so two
-			// Rivus accounts can't schedule each other forever.
-			if (await accounts.findByChannelAddress('whatsapp', senderNumber)) {
-				return { handled: false, outcome: 'own_number' };
-			}
-			// v1 handles text only; a media/location/voice message gets no reply.
-			if (event.data.text.trim() === '') {
-				return { handled: false, outcome: 'unsupported_message_type' };
-			}
-
-			const message: InboundAgentMessage = {
-				sender: { address: senderNumber, name: event.data.profileName },
-				text: event.data.text,
-				subject: '',
-				externalMessageId: event.data.messageId,
-			};
-			return handleInboundAgentMessage({
-				deps: orchestratorDeps,
+			return dispatchWhatsappEvent({
+				deps: dispatchDeps,
 				adapter,
 				capabilities,
-				account,
-				message,
+				event,
 				logger: request.log,
 			});
 		},

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -22,7 +22,7 @@ import { createFaqAnswerService } from './services/faq-answer';
 import { createFaqSimilarityService } from './services/faq-similarity';
 import { createNotificationService } from './services/notifications';
 import { createMailer } from './services/resend-mailer';
-import { createWhatsappProvisioner, createWhatsappSender } from './services/zernio-whatsapp';
+import { createWhatsappProvisioner, createWhatsappSender } from './services/whatsapp-provider';
 
 /** Connect to Mongo, build the app with Mongo-backed repositories, and listen. */
 export async function start(): Promise<void> {

--- a/packages/api/src/services/agent/whatsapp/plivo-inbound.ts
+++ b/packages/api/src/services/agent/whatsapp/plivo-inbound.ts
@@ -1,0 +1,123 @@
+import { normalizePhone } from '@rivus/core';
+import { z } from 'zod';
+import {
+	WHATSAPP_FAILED_EVENT,
+	WHATSAPP_MESSAGE_EVENT,
+	type WhatsappInboundEvent,
+} from './inbound';
+
+/**
+ * Parsing of Plivo's WhatsApp webhook into the same canonical channel event the
+ * zernio parser produces, so the two provider routes share every downstream
+ * step. All knowledge of Plivo's field names lives here. Plivo posts two kinds
+ * of deliveries to the webhook: inbound customer messages (`From`/`To`/
+ * `MessageUUID` plus `Text`, or `ContentType` + `Body` on WhatsApp-flavored
+ * payloads) and delivery reports for our own sends (`Status`), which arrive on
+ * the callback URL the sender attaches to every message.
+ */
+
+/** How a Plivo delivery was classified. */
+export type PlivoInboundResult =
+	/** An event Rivus acts on (inbound message, or a failed delivery). */
+	| { kind: 'event'; event: WhatsappInboundEvent }
+	/** A recognized delivery Rivus deliberately ignores (e.g. Status=delivered). */
+	| { kind: 'ignored' }
+	/** Not a Plivo delivery we understand. */
+	| { kind: 'unrecognized' };
+
+// Every field optional: real deliveries vary by message kind, and the form-
+// encoded variants carry only strings. Unknown keys are stripped, not rejected.
+const plivoPayloadSchema = z.object({
+	From: z.string().optional(),
+	To: z.string().optional(),
+	/** Channel discriminator on inbound messages: sms | mms | whatsapp. */
+	Type: z.string().optional(),
+	/** WhatsApp payload kind: text | media | location | button | ... */
+	ContentType: z.string().optional(),
+	/** Message text on SMS-shaped payloads. */
+	Text: z.string().optional(),
+	/** Message text on WhatsApp-shaped payloads. */
+	Body: z.string().optional(),
+	MessageUUID: z.union([z.string(), z.number()]).optional(),
+	/** The customer's WhatsApp profile name, when Plivo forwards it. */
+	ProfileName: z.string().optional(),
+	/** Present only on delivery reports: queued|sent|delivered|undelivered|failed|read. */
+	Status: z.string().optional(),
+	ErrorCode: z.union([z.string(), z.number()]).optional(),
+});
+
+/**
+ * Plivo delivers numbers as bare E.164 digits ("14155551234"); the canonical
+ * event (and the account's stored address) uses the `+` form. A value that
+ * already carries `+` passes through; anything unparseable becomes `''`.
+ */
+function plivoNumber(value: string | undefined): string {
+	const trimmed = (value ?? '').trim();
+	if (trimmed === '') {
+		return '';
+	}
+	return normalizePhone(trimmed.startsWith('+') ? trimmed : `+${trimmed}`);
+}
+
+/**
+ * Map a Plivo webhook payload (JSON- or form-encoded, already parsed to an
+ * object) into a canonical {@link WhatsappInboundEvent}. Delivery reports for
+ * still-in-flight or successful sends are recognized-but-ignored; only
+ * `failed`/`undelivered` become the canonical failure event.
+ */
+export function parsePlivoInbound(body: unknown): PlivoInboundResult {
+	const parsed = plivoPayloadSchema.safeParse(body);
+	if (!parsed.success) {
+		return { kind: 'unrecognized' };
+	}
+	const payload = parsed.data;
+
+	// A delivery report for a message Rivus sent. `From` is the account's
+	// business number (the outbound sender), `To` the customer it failed to reach.
+	if (payload.Status !== undefined) {
+		const status = payload.Status.trim().toLowerCase();
+		if (status !== 'failed' && status !== 'undelivered') {
+			return { kind: 'ignored' };
+		}
+		return {
+			kind: 'event',
+			event: {
+				type: WHATSAPP_FAILED_EVENT,
+				data: {
+					from: plivoNumber(payload.From),
+					to: plivoNumber(payload.To),
+					reason: payload.ErrorCode !== undefined ? String(payload.ErrorCode) : status,
+				},
+			},
+		};
+	}
+
+	// An inbound message. The same Plivo application can also front SMS; a
+	// non-WhatsApp message on this hook is recognized and ignored, not an error.
+	if (payload.Type !== undefined && payload.Type.trim().toLowerCase() !== 'whatsapp') {
+		return { kind: 'ignored' };
+	}
+	const from = plivoNumber(payload.From);
+	const to = plivoNumber(payload.To);
+	if (from === '' || to === '') {
+		return { kind: 'unrecognized' };
+	}
+	// Text lives in `Body` on WhatsApp-shaped payloads and `Text` on SMS-shaped
+	// ones; a non-text ContentType (media/location/button) yields '' so the route
+	// declines it as unsupported, exactly like the zernio path.
+	const contentType = (payload.ContentType ?? 'text').trim().toLowerCase();
+	const text = contentType === 'text' ? (payload.Body ?? payload.Text ?? '') : '';
+	return {
+		kind: 'event',
+		event: {
+			type: WHATSAPP_MESSAGE_EVENT,
+			data: {
+				to,
+				from,
+				text,
+				messageId: payload.MessageUUID !== undefined ? String(payload.MessageUUID) : '',
+				profileName: payload.ProfileName ?? '',
+			},
+		},
+	};
+}

--- a/packages/api/src/services/plivo-whatsapp.ts
+++ b/packages/api/src/services/plivo-whatsapp.ts
@@ -1,0 +1,290 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { type AccountId, normalizePhone } from '@rivus/core';
+import { z } from 'zod';
+import type { Config } from '../config';
+import {
+	type ChannelProvisioner,
+	NoopChannelProvisioner,
+	type ProvisionedIdentifier,
+} from './channel-provisioning';
+import type { FetchLike } from './resend-mailer';
+import { NoopWhatsappSender, type WhatsappMessage, type WhatsappSender } from './whatsapp';
+
+/**
+ * The Plivo adapter for the WhatsApp seams — the only module that knows Plivo's
+ * wire format. Plivo fronts the same Messages API for SMS, MMS, and WhatsApp
+ * (`type` selects the channel), which is why it's Rivus's primary provider: the
+ * SMS and voice channels can later ride the same account, the same rented
+ * number, and near-identical adapters. Like `ZernioWhatsappSender` (kept as an
+ * alternative provider) and `ResendMailer`, it calls the documented REST
+ * endpoints with `fetch`, so it adds no dependency and is trivially faked in
+ * tests.
+ *
+ * Wire format sources: Plivo's Messages API and Numbers API references, and the
+ * signature algorithm from Plivo's published node SDK (`validateSignature`).
+ */
+
+// Leaf resources under `${PLIVO_API_URL}/Account/{authId}`.
+const MESSAGE_PATH = '/Message/';
+const NUMBER_SEARCH_PATH = '/PhoneNumber/';
+
+interface PlivoOptions {
+	authId: string;
+	authToken: string;
+	apiUrl: string;
+	fetchImpl?: FetchLike;
+}
+
+function basicAuth(authId: string, authToken: string): Record<string, string> {
+	const credentials = Buffer.from(`${authId}:${authToken}`).toString('base64');
+	return { authorization: `Basic ${credentials}`, 'content-type': 'application/json' };
+}
+
+function accountUrl(apiUrl: string, authId: string, leaf: string): string {
+	return `${apiUrl.replace(/\/+$/, '')}/Account/${authId}${leaf}`;
+}
+
+/** A webhook URL as Plivo signs it: query string (and fragment) stripped. */
+function stripQuery(url: string): string {
+	const withoutFragment = url.split('#', 1)[0] ?? '';
+	return withoutFragment.split('?', 1)[0] ?? '';
+}
+
+/**
+ * Compute the `X-Plivo-Signature-V2` value for a webhook delivery — the base64
+ * HMAC-SHA256 of the webhook URL (without its query string) concatenated with
+ * the `X-Plivo-Signature-V2-Nonce`, keyed by the account's auth token. Matches
+ * Plivo's SDK `validateSignature`. The counterpart of
+ * {@link verifyPlivoSignature}, used by tests (and handy for local `curl`s).
+ */
+export function signPlivoUrl(options: { authToken: string; url: string; nonce: string }): string {
+	return createHmac('sha256', options.authToken)
+		.update(stripQuery(options.url) + options.nonce)
+		.digest('base64');
+}
+
+/**
+ * Verify a Plivo webhook delivery. Unlike zernio's scheme (which signs the raw
+ * body), Plivo V2 signs only the **URL + nonce** — the URL exactly as Plivo
+ * called it. `X-Plivo-Signature-V2` carries the signature computed with the
+ * (sub)account's auth token and `X-Plivo-Signature-Ma-V2` the one computed with
+ * the main account's; either may hold several comma-separated candidates during
+ * a token rotation, so any single match passes.
+ */
+export function verifyPlivoSignature(options: {
+	/** The account auth token (the signing key). */
+	authToken: string;
+	/** The URL Plivo called, byte-for-byte as configured (query is ignored). */
+	url: string;
+	/** The `X-Plivo-Signature-V2-Nonce` header value. */
+	nonce: string;
+	/** The `X-Plivo-Signature-V2` header value. */
+	signature: string;
+	/** The `X-Plivo-Signature-Ma-V2` header value, when present. */
+	maSignature?: string;
+}): boolean {
+	if (!options.authToken || options.nonce === '') {
+		return false;
+	}
+	const candidates = [options.signature, options.maSignature ?? '']
+		.flatMap((header) => header.split(','))
+		.map((value) => value.trim())
+		.filter((value) => value !== '');
+	if (candidates.length === 0) {
+		return false;
+	}
+	const expected = Buffer.from(
+		signPlivoUrl({ authToken: options.authToken, url: options.url, nonce: options.nonce }),
+		'utf8',
+	);
+	return candidates.some((candidate) => {
+		const provided = Buffer.from(candidate, 'utf8');
+		return provided.length === expected.length && timingSafeEqual(provided, expected);
+	});
+}
+
+export class PlivoWhatsappSender implements WhatsappSender {
+	private readonly endpoint: string;
+	private readonly headers: Record<string, string>;
+	private readonly statusCallbackUrl: string;
+	private readonly fetchImpl: FetchLike;
+
+	constructor(options: PlivoOptions & { statusCallbackUrl?: string }) {
+		this.endpoint = accountUrl(options.apiUrl, options.authId, MESSAGE_PATH);
+		this.headers = basicAuth(options.authId, options.authToken);
+		this.statusCallbackUrl = options.statusCallbackUrl ?? '';
+		this.fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+	}
+
+	/**
+	 * Send a free-form WhatsApp text. Meta only allows free-form messages inside
+	 * the 24-hour customer-service window, which every agent send satisfies (the
+	 * customer always messages first, and inbox reply-out answers an open
+	 * conversation). TODO(plivo): add templated sends when Rivus initiates
+	 * conversations (reminders, review requests) outside the window.
+	 */
+	async sendMessage(message: WhatsappMessage): Promise<void> {
+		const body: Record<string, string> = {
+			src: message.from,
+			dst: message.to,
+			type: 'whatsapp',
+			text: message.text,
+		};
+		// Delivery reports come back to the webhook so failures flag the inbox.
+		if (this.statusCallbackUrl !== '') {
+			body.url = this.statusCallbackUrl;
+		}
+		const response = await this.fetchImpl(this.endpoint, {
+			method: 'POST',
+			headers: this.headers,
+			body: JSON.stringify(body),
+		});
+		if (!response.ok) {
+			const detail = await response.text().catch(() => '');
+			throw new Error(
+				`Plivo rejected the WhatsApp message (status ${response.status})${detail ? `: ${detail}` : ''}`,
+			);
+		}
+	}
+}
+
+const searchResponseSchema = z.object({
+	objects: z.array(z.object({ number: z.string() })).default([]),
+});
+
+const buyResponseSchema = z.object({
+	numbers: z
+		.array(z.object({ number: z.string().default(''), status: z.string().default('') }))
+		.default([]),
+});
+
+/**
+ * Rents an SMS+voice-capable number from Plivo's Numbers API when an owner
+ * enables the channel. One rented number is the account's identity across
+ * WhatsApp today and SMS/voice later — that single-number story is the point of
+ * standardizing on Plivo.
+ *
+ * Renting alone does not make the number WhatsApp-ready: it must then be
+ * registered to Rivus's WhatsApp Business Account via Meta's Embedded Signup in
+ * the Plivo console (a one-time, human step per number today).
+ * TODO(plivo): automate WABA registration if/when Plivo exposes its Tech
+ * Provider onboarding over the API.
+ */
+export class PlivoProvisioner implements ChannelProvisioner {
+	private readonly searchUrl: string;
+	private readonly apiUrl: string;
+	private readonly authId: string;
+	private readonly headers: Record<string, string>;
+	private readonly country: string;
+	private readonly fetchImpl: FetchLike;
+
+	constructor(options: PlivoOptions & { numberCountry: string }) {
+		this.apiUrl = options.apiUrl;
+		this.authId = options.authId;
+		this.searchUrl = accountUrl(options.apiUrl, options.authId, NUMBER_SEARCH_PATH);
+		this.headers = basicAuth(options.authId, options.authToken);
+		this.country = options.numberCountry.toUpperCase();
+		this.fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+	}
+
+	async provision(input: {
+		accountId: AccountId;
+		accountName: string;
+		existing: ProvisionedIdentifier;
+	}): Promise<ProvisionedIdentifier> {
+		// Idempotent: never re-provision an account that already holds a number.
+		if (input.existing.address !== '') {
+			return input.existing;
+		}
+		const number = await this.findAvailableNumber();
+		await this.rent(number);
+		// Plivo returns bare E.164 digits ("14154009186"); the account stores `+`-form.
+		const address = normalizePhone(`+${number.replace(/^\+/, '')}`);
+		if (address === '') {
+			throw new Error(`Plivo offered a number that is not valid E.164: ${number}`);
+		}
+		return { address, providerRef: number };
+	}
+
+	/** Search for a rentable number that supports voice + SMS (one number, every channel). */
+	private async findAvailableNumber(): Promise<string> {
+		const query = new URLSearchParams({
+			country_iso: this.country,
+			services: 'voice,sms',
+			limit: '5',
+		});
+		const response = await this.fetchImpl(`${this.searchUrl}?${query}`, {
+			method: 'GET',
+			headers: this.headers,
+		});
+		if (!response.ok) {
+			const detail = await response.text().catch(() => '');
+			throw new Error(
+				`Plivo number search failed (status ${response.status})${detail ? `: ${detail}` : ''}`,
+			);
+		}
+		const parsed = searchResponseSchema.safeParse(JSON.parse(await response.text()));
+		const number = parsed.success ? parsed.data.objects[0]?.number : undefined;
+		if (!number) {
+			throw new Error(`Plivo has no ${this.country} numbers with voice+SMS available to rent.`);
+		}
+		return number;
+	}
+
+	private async rent(number: string): Promise<void> {
+		const response = await this.fetchImpl(
+			accountUrl(this.apiUrl, this.authId, `${NUMBER_SEARCH_PATH}${number}/`),
+			{ method: 'POST', headers: this.headers, body: JSON.stringify({}) },
+		);
+		if (!response.ok) {
+			const detail = await response.text().catch(() => '');
+			throw new Error(
+				`Plivo refused to rent ${number} (status ${response.status})${detail ? `: ${detail}` : ''}`,
+			);
+		}
+		const parsed = buyResponseSchema.safeParse(JSON.parse(await response.text()));
+		const status = parsed.success ? (parsed.data.numbers[0]?.status ?? '') : '';
+		if (status.toLowerCase() !== 'success') {
+			throw new Error(`Plivo did not confirm the rental of ${number} (status "${status}").`);
+		}
+	}
+}
+
+type PlivoConfig = Pick<
+	Config,
+	'PLIVO_AUTH_ID' | 'PLIVO_AUTH_TOKEN' | 'PLIVO_API_URL' | 'PLIVO_WEBHOOK_URL'
+>;
+
+/** A WhatsApp sender for the config: real Plivo when credentials are present, else a no-op. */
+export function createPlivoWhatsappSender(
+	config: PlivoConfig,
+	fetchImpl?: FetchLike,
+): WhatsappSender {
+	if (!config.PLIVO_AUTH_ID || !config.PLIVO_AUTH_TOKEN) {
+		return new NoopWhatsappSender();
+	}
+	return new PlivoWhatsappSender({
+		authId: config.PLIVO_AUTH_ID,
+		authToken: config.PLIVO_AUTH_TOKEN,
+		apiUrl: config.PLIVO_API_URL,
+		statusCallbackUrl: config.PLIVO_WEBHOOK_URL,
+		fetchImpl,
+	});
+}
+
+/** A channel provisioner for the config: real Plivo when credentials are present, else a no-op. */
+export function createPlivoProvisioner(
+	config: PlivoConfig & Pick<Config, 'PLIVO_NUMBER_COUNTRY'>,
+	fetchImpl?: FetchLike,
+): ChannelProvisioner {
+	if (!config.PLIVO_AUTH_ID || !config.PLIVO_AUTH_TOKEN) {
+		return new NoopChannelProvisioner();
+	}
+	return new PlivoProvisioner({
+		authId: config.PLIVO_AUTH_ID,
+		authToken: config.PLIVO_AUTH_TOKEN,
+		apiUrl: config.PLIVO_API_URL,
+		numberCountry: config.PLIVO_NUMBER_COUNTRY,
+		fetchImpl,
+	});
+}

--- a/packages/api/src/services/whatsapp-provider.ts
+++ b/packages/api/src/services/whatsapp-provider.ts
@@ -1,0 +1,56 @@
+import type { Config } from '../config';
+import type { ChannelProvisioner } from './channel-provisioning';
+import { createPlivoProvisioner, createPlivoWhatsappSender } from './plivo-whatsapp';
+import type { FetchLike } from './resend-mailer';
+import type { WhatsappSender } from './whatsapp';
+import {
+	createWhatsappProvisioner as createZernioProvisioner,
+	createWhatsappSender as createZernioWhatsappSender,
+} from './zernio-whatsapp';
+
+/**
+ * Selection of the active WhatsApp provider from the config. Plivo is the
+ * primary (its account will also carry the SMS and voice channels later, so
+ * one rented number serves every channel); zernio remains wired as the
+ * alternative provider and is chosen when only its key is set. With neither
+ * configured both factories degrade to no-ops, so the API still boots and
+ * tests run without provider credentials. Each provider's webhook route is
+ * always registered — inbound is gated by that route's own config, not here.
+ */
+
+type WhatsappProviderConfig = Pick<
+	Config,
+	| 'PLIVO_AUTH_ID'
+	| 'PLIVO_AUTH_TOKEN'
+	| 'PLIVO_API_URL'
+	| 'PLIVO_WEBHOOK_URL'
+	| 'PLIVO_NUMBER_COUNTRY'
+	| 'ZERNIO_API_KEY'
+	| 'ZERNIO_API_URL'
+>;
+
+function plivoConfigured(config: WhatsappProviderConfig): boolean {
+	return Boolean(config.PLIVO_AUTH_ID && config.PLIVO_AUTH_TOKEN);
+}
+
+/** The active provider's WhatsApp sender: Plivo, else zernio, else a no-op. */
+export function createWhatsappSender(
+	config: WhatsappProviderConfig,
+	fetchImpl?: FetchLike,
+): WhatsappSender {
+	if (plivoConfigured(config)) {
+		return createPlivoWhatsappSender(config, fetchImpl);
+	}
+	return createZernioWhatsappSender(config, fetchImpl);
+}
+
+/** The active provider's number provisioner: Plivo, else zernio, else a no-op. */
+export function createWhatsappProvisioner(
+	config: WhatsappProviderConfig,
+	fetchImpl?: FetchLike,
+): ChannelProvisioner {
+	if (plivoConfigured(config)) {
+		return createPlivoProvisioner(config, fetchImpl);
+	}
+	return createZernioProvisioner(config, fetchImpl);
+}

--- a/packages/api/test/agent-whatsapp-plivo-route.test.ts
+++ b/packages/api/test/agent-whatsapp-plivo-route.test.ts
@@ -1,0 +1,416 @@
+import type { AccountId } from '@rivus/core';
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { loadConfig } from '../src/config';
+import { createInMemoryRepositories } from '../src/repositories/memory';
+import { NoopReceivedEmailReader } from '../src/services/agent/email/received';
+import {
+	type PlivoInboundResult,
+	parsePlivoInbound,
+} from '../src/services/agent/whatsapp/plivo-inbound';
+import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
+import { NoopFaqAnswerService } from '../src/services/faq-answer';
+import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
+import { createNotificationService } from '../src/services/notifications';
+import { signPlivoUrl } from '../src/services/plivo-whatsapp';
+import {
+	buildTestAppWithRepos,
+	RecordingMailer,
+	RecordingWhatsappSender,
+	signupOwner,
+} from './helpers';
+
+const WEBHOOK_URL = '/v1/channels/whatsapp/plivo/inbound';
+// The account's business number is stored `+`-formed; Plivo delivers bare digits.
+const BIZ = '+15550001111';
+const BIZ_PLIVO = '15550001111';
+const SENDER = '+15559990000';
+const SENDER_PLIVO = '15559990000';
+
+/** A Plivo-shaped inbound WhatsApp text delivery. */
+function inbound(overrides: Record<string, string> = {}) {
+	return {
+		From: SENDER_PLIVO,
+		To: BIZ_PLIVO,
+		Type: 'whatsapp',
+		ContentType: 'text',
+		Body: 'Hi there',
+		MessageUUID: 'plivo-msg-001',
+		ProfileName: 'Dana',
+		...overrides,
+	};
+}
+
+function sender(app: FastifyInstance): RecordingWhatsappSender {
+	return app.deps.whatsappSender as RecordingWhatsappSender;
+}
+
+/** Build an app + repos and enable WhatsApp on the signed-up owner's account. */
+async function setup() {
+	const { app, repos } = await buildTestAppWithRepos();
+	const owner = await signupOwner(app);
+	const accountId = owner.account.id as AccountId;
+	await repos.accounts.setChannelConfig(accountId, 'whatsapp', {
+		enabled: true,
+		address: BIZ,
+		providerRef: BIZ_PLIVO,
+	});
+	return { app, repos, accountId, owner };
+}
+
+describe('POST /v1/channels/whatsapp/plivo/inbound', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('ignores a message to a number no account has provisioned', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ To: '15557778888' }),
+		});
+		expect(res.json()).toEqual({ handled: false, outcome: 'unknown_account' });
+	});
+
+	it('acknowledges without replying when the channel is disabled', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.accounts.setChannelConfig(accountId, 'whatsapp', {
+			enabled: false,
+			address: BIZ,
+			providerRef: BIZ_PLIVO,
+		});
+		const res = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(res.json()).toEqual({ handled: false, outcome: 'channel_disabled' });
+		expect(sender(app).messages).toHaveLength(0);
+	});
+
+	it('sends an unknown sender a signup link prefilled with their phone', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(res.json()).toEqual({ handled: true, outcome: 'send_signup_link' });
+		const sent = sender(app).messages.at(-1);
+		expect(sent?.from).toBe(BIZ);
+		expect(sent?.to).toBe(SENDER);
+		expect(sent?.text).toContain(`phone=${encodeURIComponent(SENDER)}`);
+	});
+
+	it('books a slot for a recognized customer over two Plivo turns', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.customers.create(accountId, {
+			name: 'Dana Fox',
+			email: '',
+			phone: '(555) 999-0000',
+			address: '12 Pine St',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+		const offer = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ Body: 'When are you free?', MessageUUID: 'plivo-msg-a' }),
+		});
+		expect(offer.json()).toEqual({ handled: true, outcome: 'offer_slots' });
+		expect(sender(app).messages.at(-1)?.text).toContain('1.');
+		const book = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ Body: '1', MessageUUID: 'plivo-msg-b' }),
+		});
+		expect(book.json()).toEqual({ handled: true, outcome: 'book' });
+		const { total } = await repos.jobs.list({ accountId, page: 1, pageSize: 10 });
+		expect(total).toBe(1);
+	});
+
+	it('accepts Plivo’s form-encoded variant (SMS-shaped Text field)', async () => {
+		const built = await setup();
+		app = built.app;
+		const body = new URLSearchParams({
+			From: SENDER_PLIVO,
+			To: BIZ_PLIVO,
+			Type: 'whatsapp',
+			Text: 'Hi there',
+			MessageUUID: 'plivo-msg-form',
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: body.toString(),
+			headers: { 'content-type': 'application/x-www-form-urlencoded' },
+		});
+		expect(res.json()).toEqual({ handled: true, outcome: 'send_signup_link' });
+		expect(sender(app).messages.at(-1)?.to).toBe(SENDER);
+	});
+
+	it('ignores an exact redelivery of an already-processed message', async () => {
+		const built = await setup();
+		app = built.app;
+		const first = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(first.json()).toEqual({ handled: true, outcome: 'send_signup_link' });
+		const second = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(second.json()).toEqual({ handled: false, outcome: 'duplicate_delivery' });
+	});
+
+	it('refuses to converse with any account’s own business number (loop guard)', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ From: BIZ_PLIVO }),
+		});
+		expect(res.json()).toEqual({ handled: false, outcome: 'own_number' });
+	});
+
+	it('declines media, location, and button deliveries (text only)', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ ContentType: 'media', Body: '' }),
+		});
+		expect(res.json()).toEqual({ handled: false, outcome: 'unsupported_message_type' });
+	});
+
+	it('ignores a non-WhatsApp (SMS) message on the hook', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound({ Type: 'sms' }),
+		});
+		expect(res.json()).toEqual({ handled: false, outcome: 'ignored_event_type' });
+	});
+
+	it('answers unrecognized payloads with 200 (never a retry storm)', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: { hello: 'world' },
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.json()).toEqual({ handled: false, outcome: 'unrecognized_payload' });
+	});
+
+	it('flags the conversation when a delivery report says failed, ignores the rest', async () => {
+		const built = await setup();
+		app = built.app;
+		// Open a thread first (an unknown sender gets a signup link).
+		await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		const delivered = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: { From: BIZ_PLIVO, To: SENDER_PLIVO, Status: 'delivered', MessageUUID: 'm-out-1' },
+		});
+		expect(delivered.json()).toEqual({ handled: false, outcome: 'ignored_event_type' });
+		const failed = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: {
+				From: BIZ_PLIVO,
+				To: SENDER_PLIVO,
+				Status: 'failed',
+				ErrorCode: 30008,
+				MessageUUID: 'm-out-1',
+			},
+		});
+		expect(failed.json()).toEqual({ handled: true, outcome: 'delivery_failed' });
+	});
+});
+
+// --- Signature (separate config) ---------------------------------------------
+
+const AUTH_TOKEN = 'plivo-test-auth-token';
+const PINNED_URL = 'https://api.rivus.ai/v1/channels/whatsapp/plivo/inbound';
+
+function buildPlivoApp(extraConfig: Record<string, string> = {}): FastifyInstance {
+	const repos = createInMemoryRepositories();
+	return buildApp({
+		config: loadConfig({
+			NODE_ENV: 'test',
+			JWT_SECRET: 'test-secret-value-1234',
+			...extraConfig,
+		} as NodeJS.ProcessEnv),
+		...repos,
+		mailer: new RecordingMailer(),
+		receivedEmails: new NoopReceivedEmailReader(),
+		whatsappSender: new RecordingWhatsappSender(),
+		whatsappProvisioner: new NoopChannelProvisioner(),
+		notifier: createNotificationService({ notifications: repos.notifications }),
+		faqSimilarity: new NoopFaqSimilarityService(),
+		faqAnswer: new NoopFaqAnswerService(),
+		ping: async () => ({ ready: true }),
+	});
+}
+
+describe('POST /v1/channels/whatsapp/plivo/inbound — signature', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('accepts a delivery signed for the pinned webhook URL and rejects the rest', async () => {
+		app = buildPlivoApp({ PLIVO_AUTH_TOKEN: AUTH_TOKEN, PLIVO_WEBHOOK_URL: PINNED_URL });
+		const nonce = '12345678901234567890';
+		const headers = {
+			'x-plivo-signature-v2-nonce': nonce,
+			'x-plivo-signature-v2': signPlivoUrl({ authToken: AUTH_TOKEN, url: PINNED_URL, nonce }),
+		};
+		const ok = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound(), headers });
+		// Unknown account, but the signature passed (a 401 would mean it didn't).
+		expect(ok.json()).toEqual({ handled: false, outcome: 'unknown_account' });
+
+		const wrongNonce = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound(),
+			headers: { ...headers, 'x-plivo-signature-v2-nonce': 'different-nonce' },
+		});
+		expect(wrongNonce.statusCode).toBe(401);
+
+		const unsigned = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(unsigned.statusCode).toBe(401);
+	});
+
+	it('accepts the main-account signature header', async () => {
+		app = buildPlivoApp({ PLIVO_AUTH_TOKEN: AUTH_TOKEN, PLIVO_WEBHOOK_URL: PINNED_URL });
+		const nonce = '888777666555';
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound(),
+			headers: {
+				'x-plivo-signature-v2-nonce': nonce,
+				'x-plivo-signature-ma-v2': signPlivoUrl({ authToken: AUTH_TOKEN, url: PINNED_URL, nonce }),
+			},
+		});
+		expect(res.json()).toEqual({ handled: false, outcome: 'unknown_account' });
+	});
+
+	it('derives the signed URL from forwarding headers when none is pinned', async () => {
+		app = buildPlivoApp({ PLIVO_AUTH_TOKEN: AUTH_TOKEN });
+		const nonce = '424242424242';
+		const res = await app.inject({
+			method: 'POST',
+			url: WEBHOOK_URL,
+			payload: inbound(),
+			headers: {
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'api.rivus.ai',
+				'x-plivo-signature-v2-nonce': nonce,
+				'x-plivo-signature-v2': signPlivoUrl({ authToken: AUTH_TOKEN, url: PINNED_URL, nonce }),
+			},
+		});
+		expect(res.json()).toEqual({ handled: false, outcome: 'unknown_account' });
+	});
+
+	it('ignores the query string when verifying (Plivo signs the base URL)', async () => {
+		app = buildPlivoApp({ PLIVO_AUTH_TOKEN: AUTH_TOKEN });
+		const nonce = '10101010';
+		const res = await app.inject({
+			method: 'POST',
+			url: `${WEBHOOK_URL}?utm=plivo`,
+			payload: inbound(),
+			headers: {
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'api.rivus.ai',
+				'x-plivo-signature-v2-nonce': nonce,
+				'x-plivo-signature-v2': signPlivoUrl({ authToken: AUTH_TOKEN, url: PINNED_URL, nonce }),
+			},
+		});
+		expect(res.json()).toEqual({ handled: false, outcome: 'unknown_account' });
+	});
+
+	it('stays open when unconfigured outside production, and 503s in production', async () => {
+		app = buildPlivoApp();
+		const open = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(open.json()).toEqual({ handled: false, outcome: 'unknown_account' });
+		await app.close();
+
+		app = buildPlivoApp({
+			NODE_ENV: 'production',
+			JWT_SECRET: 'x'.repeat(32),
+			RESEND_API_KEY: 're_test_key',
+			LOG_LEVEL: 'silent',
+			CORS_ORIGIN: 'https://app.rivus.ai',
+		});
+		const res = await app.inject({ method: 'POST', url: WEBHOOK_URL, payload: inbound() });
+		expect(res.statusCode).toBe(503);
+	});
+});
+
+// --- Payload mapping edges the route tests don't reach ------------------------
+
+describe('parsePlivoInbound', () => {
+	function kind(result: PlivoInboundResult): string {
+		return result.kind;
+	}
+
+	it('maps SMS-shaped payloads (Text, no ContentType) to a text message', () => {
+		const result = parsePlivoInbound({ From: SENDER_PLIVO, To: BIZ_PLIVO, Text: 'hello' });
+		expect(result).toEqual({
+			kind: 'event',
+			event: {
+				type: 'whatsapp.message.received',
+				data: { to: BIZ, from: SENDER, text: 'hello', messageId: '', profileName: '' },
+			},
+		});
+	});
+
+	it('keeps `+`-formed numbers and stringifies numeric MessageUUIDs', () => {
+		const result = parsePlivoInbound({
+			From: SENDER,
+			To: BIZ,
+			Body: 'hi',
+			MessageUUID: 12345,
+		});
+		expect(result).toEqual({
+			kind: 'event',
+			event: {
+				type: 'whatsapp.message.received',
+				data: { to: BIZ, from: SENDER, text: 'hi', messageId: '12345', profileName: '' },
+			},
+		});
+	});
+
+	it('uses the status as the failure reason when there is no error code', () => {
+		const result = parsePlivoInbound({ From: BIZ_PLIVO, To: SENDER_PLIVO, Status: 'undelivered' });
+		expect(result).toEqual({
+			kind: 'event',
+			event: {
+				type: 'whatsapp.message.failed',
+				data: { from: BIZ, to: SENDER, reason: 'undelivered' },
+			},
+		});
+	});
+
+	it('ignores in-flight and successful delivery reports', () => {
+		for (const status of ['queued', 'sent', 'delivered', 'read', 'SENT']) {
+			expect(kind(parsePlivoInbound({ From: BIZ_PLIVO, To: SENDER_PLIVO, Status: status }))).toBe(
+				'ignored',
+			);
+		}
+	});
+
+	it('rejects non-object and number-less payloads', () => {
+		expect(kind(parsePlivoInbound('a string'))).toBe('unrecognized');
+		expect(kind(parsePlivoInbound(null))).toBe('unrecognized');
+		expect(kind(parsePlivoInbound({ From: 'garbage', To: BIZ_PLIVO, Body: 'x' }))).toBe(
+			'unrecognized',
+		);
+		expect(kind(parsePlivoInbound({ From: SENDER_PLIVO, Body: 'x' }))).toBe('unrecognized');
+	});
+});

--- a/packages/api/test/plivo-whatsapp.test.ts
+++ b/packages/api/test/plivo-whatsapp.test.ts
@@ -1,0 +1,310 @@
+import { createHmac } from 'node:crypto';
+import type { AccountId } from '@rivus/core';
+import { describe, expect, it } from 'vitest';
+import { loadConfig } from '../src/config';
+import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
+import {
+	createPlivoProvisioner,
+	createPlivoWhatsappSender,
+	PlivoProvisioner,
+	PlivoWhatsappSender,
+	signPlivoUrl,
+	verifyPlivoSignature,
+} from '../src/services/plivo-whatsapp';
+import type { FetchLike } from '../src/services/resend-mailer';
+import { NoopWhatsappSender } from '../src/services/whatsapp';
+import { createWhatsappProvisioner, createWhatsappSender } from '../src/services/whatsapp-provider';
+import { ZernioProvisioner, ZernioWhatsappSender } from '../src/services/zernio-whatsapp';
+
+const AUTH_ID = 'MA_TEST_AUTH_ID';
+const AUTH_TOKEN = 'test-auth-token';
+const API_URL = 'https://api.plivo.example/v1';
+
+interface RecordedCall {
+	url: string;
+	init: { method: string; headers: Record<string, string>; body?: string };
+}
+
+interface CannedResponse {
+	ok: boolean;
+	status: number;
+	body: string;
+}
+
+/** A FetchLike that replays canned responses in order and records every call. */
+function fakeFetch(responses: CannedResponse[]): { fetchImpl: FetchLike; calls: RecordedCall[] } {
+	const calls: RecordedCall[] = [];
+	const fetchImpl: FetchLike = async (url, init) => {
+		calls.push({ url, init });
+		const canned = responses[calls.length - 1];
+		if (!canned) {
+			throw new Error(`unexpected fetch #${calls.length} to ${url}`);
+		}
+		return { ok: canned.ok, status: canned.status, text: async () => canned.body };
+	};
+	return { fetchImpl, calls };
+}
+
+function testConfig(env: Record<string, string> = {}) {
+	return loadConfig({
+		NODE_ENV: 'test',
+		JWT_SECRET: 'test-secret-value-1234',
+		...env,
+	} as NodeJS.ProcessEnv);
+}
+
+describe('signPlivoUrl / verifyPlivoSignature', () => {
+	const URL_SIGNED = 'https://api.rivus.ai/v1/channels/whatsapp/plivo/inbound';
+	const NONCE = '05429567804466091622';
+
+	it('computes the base64 HMAC-SHA256 of url+nonce keyed by the auth token', () => {
+		const expected = createHmac('sha256', AUTH_TOKEN)
+			.update(URL_SIGNED + NONCE)
+			.digest('base64');
+		expect(signPlivoUrl({ authToken: AUTH_TOKEN, url: URL_SIGNED, nonce: NONCE })).toBe(expected);
+	});
+
+	it('ignores the query string (and fragment), like Plivo does', () => {
+		const bare = signPlivoUrl({ authToken: AUTH_TOKEN, url: URL_SIGNED, nonce: NONCE });
+		expect(
+			signPlivoUrl({ authToken: AUTH_TOKEN, url: `${URL_SIGNED}?a=1&b=2`, nonce: NONCE }),
+		).toBe(bare);
+		expect(signPlivoUrl({ authToken: AUTH_TOKEN, url: `${URL_SIGNED}#frag`, nonce: NONCE })).toBe(
+			bare,
+		);
+	});
+
+	it('accepts a valid signature and rejects a tampered one', () => {
+		const signature = signPlivoUrl({ authToken: AUTH_TOKEN, url: URL_SIGNED, nonce: NONCE });
+		expect(
+			verifyPlivoSignature({ authToken: AUTH_TOKEN, url: URL_SIGNED, nonce: NONCE, signature }),
+		).toBe(true);
+		expect(
+			verifyPlivoSignature({
+				authToken: AUTH_TOKEN,
+				url: URL_SIGNED,
+				nonce: '99999999',
+				signature,
+			}),
+		).toBe(false);
+		expect(
+			verifyPlivoSignature({
+				authToken: 'other-token',
+				url: URL_SIGNED,
+				nonce: NONCE,
+				signature,
+			}),
+		).toBe(false);
+		expect(
+			verifyPlivoSignature({
+				authToken: AUTH_TOKEN,
+				url: 'https://elsewhere.example/hook',
+				nonce: NONCE,
+				signature,
+			}),
+		).toBe(false);
+	});
+
+	it('accepts the signature from the main-account header or a comma-separated list', () => {
+		const signature = signPlivoUrl({ authToken: AUTH_TOKEN, url: URL_SIGNED, nonce: NONCE });
+		expect(
+			verifyPlivoSignature({
+				authToken: AUTH_TOKEN,
+				url: URL_SIGNED,
+				nonce: NONCE,
+				signature: '',
+				maSignature: signature,
+			}),
+		).toBe(true);
+		expect(
+			verifyPlivoSignature({
+				authToken: AUTH_TOKEN,
+				url: URL_SIGNED,
+				nonce: NONCE,
+				signature: `bogus-one, ${signature}`,
+			}),
+		).toBe(true);
+	});
+
+	it('rejects when the token, nonce, or every signature is missing', () => {
+		const signature = signPlivoUrl({ authToken: AUTH_TOKEN, url: URL_SIGNED, nonce: NONCE });
+		expect(verifyPlivoSignature({ authToken: '', url: URL_SIGNED, nonce: NONCE, signature })).toBe(
+			false,
+		);
+		expect(
+			verifyPlivoSignature({ authToken: AUTH_TOKEN, url: URL_SIGNED, nonce: '', signature }),
+		).toBe(false);
+		expect(
+			verifyPlivoSignature({ authToken: AUTH_TOKEN, url: URL_SIGNED, nonce: NONCE, signature: '' }),
+		).toBe(false);
+	});
+});
+
+describe('PlivoWhatsappSender', () => {
+	const MESSAGE = { from: '+15550001111', to: '+15559990000', text: 'Your slot is booked.' };
+
+	it('POSTs a whatsapp-typed message to the account Message resource with Basic auth', async () => {
+		const { fetchImpl, calls } = fakeFetch([
+			{ ok: true, status: 202, body: '{"message":"message(s) queued"}' },
+		]);
+		const sender = new PlivoWhatsappSender({
+			authId: AUTH_ID,
+			authToken: AUTH_TOKEN,
+			apiUrl: API_URL,
+			fetchImpl,
+		});
+		await sender.sendMessage(MESSAGE);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe(`${API_URL}/Account/${AUTH_ID}/Message/`);
+		expect(calls[0]?.init.method).toBe('POST');
+		const credentials = Buffer.from(`${AUTH_ID}:${AUTH_TOKEN}`).toString('base64');
+		expect(calls[0]?.init.headers.authorization).toBe(`Basic ${credentials}`);
+		expect(JSON.parse(calls[0]?.init.body ?? '{}')).toEqual({
+			src: MESSAGE.from,
+			dst: MESSAGE.to,
+			type: 'whatsapp',
+			text: MESSAGE.text,
+		});
+	});
+
+	it('attaches the delivery-status callback URL when configured', async () => {
+		const { fetchImpl, calls } = fakeFetch([{ ok: true, status: 202, body: '{}' }]);
+		const sender = new PlivoWhatsappSender({
+			authId: AUTH_ID,
+			authToken: AUTH_TOKEN,
+			apiUrl: API_URL,
+			statusCallbackUrl: 'https://api.rivus.ai/v1/channels/whatsapp/plivo/inbound',
+			fetchImpl,
+		});
+		await sender.sendMessage(MESSAGE);
+		expect(JSON.parse(calls[0]?.init.body ?? '{}').url).toBe(
+			'https://api.rivus.ai/v1/channels/whatsapp/plivo/inbound',
+		);
+	});
+
+	it('rejects with the status and response detail when Plivo refuses the send', async () => {
+		const { fetchImpl } = fakeFetch([
+			{ ok: false, status: 400, body: '{"error":"src is not whatsapp-enabled"}' },
+		]);
+		const sender = new PlivoWhatsappSender({
+			authId: AUTH_ID,
+			authToken: AUTH_TOKEN,
+			apiUrl: API_URL,
+			fetchImpl,
+		});
+		await expect(sender.sendMessage(MESSAGE)).rejects.toThrow(
+			/status 400.*src is not whatsapp-enabled/,
+		);
+	});
+});
+
+describe('PlivoProvisioner', () => {
+	const INPUT = {
+		accountId: 'acc_1' as AccountId,
+		accountName: 'Cascade Plumbing',
+		existing: { address: '', providerRef: '' },
+	};
+
+	function provisioner(fetchImpl: FetchLike, country = 'us') {
+		return new PlivoProvisioner({
+			authId: AUTH_ID,
+			authToken: AUTH_TOKEN,
+			apiUrl: API_URL,
+			numberCountry: country,
+			fetchImpl,
+		});
+	}
+
+	it('returns the existing identifier untouched (idempotent re-enable)', async () => {
+		const { fetchImpl, calls } = fakeFetch([]);
+		const existing = { address: '+15551234567', providerRef: '15551234567' };
+		await expect(provisioner(fetchImpl).provision({ ...INPUT, existing })).resolves.toEqual(
+			existing,
+		);
+		expect(calls).toHaveLength(0);
+	});
+
+	it('searches for a voice+SMS number, rents it, and returns it as +E.164', async () => {
+		const { fetchImpl, calls } = fakeFetch([
+			{ ok: true, status: 200, body: '{"objects":[{"number":"14154009186"}]}' },
+			{ ok: true, status: 201, body: '{"numbers":[{"number":"14154009186","status":"Success"}]}' },
+		]);
+		const provisioned = await provisioner(fetchImpl).provision(INPUT);
+		expect(provisioned).toEqual({ address: '+14154009186', providerRef: '14154009186' });
+		const searchUrl = new URL(calls[0]?.url ?? '');
+		expect(searchUrl.pathname).toBe(`/v1/Account/${AUTH_ID}/PhoneNumber/`);
+		expect(searchUrl.searchParams.get('country_iso')).toBe('US');
+		expect(searchUrl.searchParams.get('services')).toBe('voice,sms');
+		expect(calls[0]?.init.method).toBe('GET');
+		expect(calls[0]?.init.body).toBeUndefined();
+		expect(calls[1]?.url).toBe(`${API_URL}/Account/${AUTH_ID}/PhoneNumber/14154009186/`);
+		expect(calls[1]?.init.method).toBe('POST');
+	});
+
+	it('fails when the search errors or returns no numbers', async () => {
+		const errored = fakeFetch([{ ok: false, status: 500, body: 'upstream sad' }]);
+		await expect(provisioner(errored.fetchImpl).provision(INPUT)).rejects.toThrow(
+			/search failed \(status 500\)/,
+		);
+		const empty = fakeFetch([{ ok: true, status: 200, body: '{"objects":[]}' }]);
+		await expect(provisioner(empty.fetchImpl).provision(INPUT)).rejects.toThrow(
+			/no US numbers with voice\+SMS/,
+		);
+	});
+
+	it('fails when the rental errors or is not confirmed', async () => {
+		const search = { ok: true, status: 200, body: '{"objects":[{"number":"14154009186"}]}' };
+		const refused = fakeFetch([search, { ok: false, status: 403, body: 'insufficient funds' }]);
+		await expect(provisioner(refused.fetchImpl).provision(INPUT)).rejects.toThrow(
+			/refused to rent 14154009186 \(status 403\)/,
+		);
+		const pending = fakeFetch([
+			search,
+			{ ok: true, status: 201, body: '{"numbers":[{"number":"14154009186","status":"pending"}]}' },
+		]);
+		await expect(provisioner(pending.fetchImpl).provision(INPUT)).rejects.toThrow(
+			/did not confirm the rental/,
+		);
+	});
+
+	it('fails when Plivo offers a number that is not valid E.164', async () => {
+		const { fetchImpl } = fakeFetch([
+			{ ok: true, status: 200, body: '{"objects":[{"number":"not-a-number"}]}' },
+			{ ok: true, status: 201, body: '{"numbers":[{"number":"not-a-number","status":"Success"}]}' },
+		]);
+		await expect(provisioner(fetchImpl).provision(INPUT)).rejects.toThrow(/not valid E\.164/);
+	});
+});
+
+describe('provider factories', () => {
+	it('Plivo factories degrade to no-ops without credentials', () => {
+		const config = testConfig();
+		expect(createPlivoWhatsappSender(config)).toBeInstanceOf(NoopWhatsappSender);
+		expect(createPlivoProvisioner(config)).toBeInstanceOf(NoopChannelProvisioner);
+	});
+
+	it('Plivo factories build real adapters when credentials are set', () => {
+		const config = testConfig({ PLIVO_AUTH_ID: AUTH_ID, PLIVO_AUTH_TOKEN: AUTH_TOKEN });
+		expect(createPlivoWhatsappSender(config)).toBeInstanceOf(PlivoWhatsappSender);
+		expect(createPlivoProvisioner(config)).toBeInstanceOf(PlivoProvisioner);
+	});
+
+	it('selects Plivo first, then zernio, then the no-ops', () => {
+		const plivo = testConfig({
+			PLIVO_AUTH_ID: AUTH_ID,
+			PLIVO_AUTH_TOKEN: AUTH_TOKEN,
+			ZERNIO_API_KEY: 'zk_1',
+		});
+		expect(createWhatsappSender(plivo)).toBeInstanceOf(PlivoWhatsappSender);
+		expect(createWhatsappProvisioner(plivo)).toBeInstanceOf(PlivoProvisioner);
+
+		const zernio = testConfig({ ZERNIO_API_KEY: 'zk_1' });
+		expect(createWhatsappSender(zernio)).toBeInstanceOf(ZernioWhatsappSender);
+		expect(createWhatsappProvisioner(zernio)).toBeInstanceOf(ZernioProvisioner);
+
+		// One Plivo credential alone is not a configured provider — fall through.
+		const partial = testConfig({ PLIVO_AUTH_ID: AUTH_ID });
+		expect(createWhatsappSender(partial)).toBeInstanceOf(NoopWhatsappSender);
+		expect(createWhatsappProvisioner(partial)).toBeInstanceOf(NoopChannelProvisioner);
+	});
+});

--- a/packages/docs/site/openapi.json
+++ b/packages/docs/site/openapi.json
@@ -1150,6 +1150,186 @@
         }
       }
     },
+    "/v1/account/channels/{channel}/enable": {
+      "post": {
+        "summary": "Enable a messaging channel — provisions a number (owner only)",
+        "tags": [
+          "account"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "whatsapp",
+                "sms",
+                "voice"
+              ]
+            },
+            "in": "path",
+            "name": "channel",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/account/channels/{channel}/disable": {
+      "post": {
+        "summary": "Disable a messaging channel — retains the number (owner only)",
+        "tags": [
+          "account"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "whatsapp",
+                "sms",
+                "voice"
+              ]
+            },
+            "in": "path",
+            "name": "channel",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/admin/companies": {
       "get": {
         "summary": "List/search every company (Rivus staff only)",
@@ -4126,6 +4306,334 @@
             }
           },
           "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/public/accounts/{slug}": {
+      "get": {
+        "summary": "Look up an account for the customer self-signup page",
+        "tags": [
+          "public"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "slug",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicAccount"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/public/accounts/{slug}/customers": {
+      "post": {
+        "summary": "Add yourself as a customer of an account",
+        "tags": [
+          "public"
+        ],
+        "description": "Backs the self-signup view the scheduling agent links unrecognized senders to. Idempotent by email: if the address already belongs to one of the account’s customers the call succeeds without creating a duplicate — and without revealing that the record already existed.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120
+                  },
+                  "email": {
+                    "type": "string"
+                  },
+                  "phone": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 40
+                  },
+                  "address": {
+                    "default": "",
+                    "type": "string",
+                    "maxLength": 300
+                  }
+                },
+                "required": [
+                  "name",
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "slug",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicCustomerSignupResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/email/inbound": {
+      "post": {
+        "summary": "Resend email webhook (inbound customer mail + delivery status)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Resend delivers email events for the account’s agent address (`<account-slug>-<hex>@riv.us`) here. On `email.received` Rivus validates the sender against the account’s customers, keeps the multi-turn scheduling state on the thread, and replies by email — offering open times and booking the job once a time is agreed. On `email.bounced`/`email.complained` (a reply that never reached the customer) it flags the conversation for a human. Deliveries are authenticated with the Svix signature headers when `RESEND_WEBHOOK_SECRET` is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentEmailWebhookResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/whatsapp/inbound": {
+      "get": {
+        "summary": "zernio WhatsApp webhook verification handshake",
+        "tags": [
+          "channels"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "hub.mode",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "hub.verify_token",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "hub.challenge",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "zernio WhatsApp webhook (inbound customer messages + delivery status)",
+        "tags": [
+          "channels"
+        ],
+        "description": "zernio delivers WhatsApp events for the account’s provisioned business number here. On an inbound message Rivus validates the sender against the account’s customers (by phone), keeps the multi-turn scheduling state on the thread, and replies over WhatsApp. On a delivery failure it flags the conversation for a human. Deliveries are authenticated with the signature header when ZERNIO_WEBHOOK_SECRET is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWhatsappWebhookResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/whatsapp/plivo/inbound": {
+      "post": {
+        "summary": "Plivo WhatsApp webhook (inbound customer messages + delivery status)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Plivo delivers WhatsApp events for the account’s provisioned business number here: inbound customer messages, and delivery reports for messages Rivus sent (the sender passes this URL as the status callback). On an inbound message Rivus validates the sender against the account’s customers (by phone), keeps the multi-turn scheduling state on the thread, and replies over WhatsApp. On a failed delivery it flags the conversation for a human. Deliveries are authenticated with Plivo’s V2 signature headers when PLIVO_AUTH_TOKEN is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWhatsappWebhookResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
             "description": "Default Response",
             "content": {
               "application/json": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — builds the WhatsApp channel end to end on **Plivo** as the primary provider, keeping the zernio services wired as the alternative (they'll be expanded separately).

Plivo fronts SMS, MMS, and WhatsApp through one Messages API and one rented number per account, so standardizing on it means the same account and the same per-account number will carry the SMS and voice channels later.

### What's in the change

- **`services/plivo-whatsapp.ts`** — the Plivo adapter behind the existing seams: `PlivoWhatsappSender` (`POST /Account/{id}/Message/` with `type=whatsapp`, Basic auth, optional delivery-status callback URL), `PlivoProvisioner` (Numbers API: search then rent a voice+SMS-capable number), and Plivo's V2 webhook signature scheme (base64 HMAC-SHA256 of *URL + nonce* keyed by the auth token — verified against Plivo's docs and their published SDK).
- **`services/agent/whatsapp/plivo-inbound.ts`** — maps Plivo's inbound-message and delivery-report payloads (JSON or form-encoded) onto the existing canonical WhatsApp event; delivery reports in flight (`queued/sent/delivered/read`) are recognized-and-ignored, `failed/undelivered` flag the conversation.
- **`routes/agent-whatsapp-shared.ts`** — the provider-agnostic webhook body (account resolution, loop/disabled/unsupported guards, orchestrator hand-off) extracted from the zernio route so the two provider edges can't drift. The zernio route behaves identically (its tests are unchanged and pass).
- **`routes/agent-whatsapp-plivo.ts`** — `POST /v1/channels/whatsapp/plivo/inbound` with the V2 signature gate (fails closed with 503 in production until `PLIVO_AUTH_TOKEN` is set, mirroring the zernio gate) and a plugin-scoped `x-www-form-urlencoded` parser.
- **`services/whatsapp-provider.ts`** — provider selection: Plivo when its credentials are set, else zernio, else the no-ops (API still boots and tests run with no credentials).
- **Config** — `PLIVO_AUTH_ID`, `PLIVO_AUTH_TOKEN`, `PLIVO_API_URL`, `PLIVO_WEBHOOK_URL` (pins signature verification behind proxies and doubles as the status callback on sends), `PLIVO_NUMBER_COUNTRY`.
- **Docs** — API README restructured into Plivo (primary) + zernio (alternative) sections; OpenAPI regenerated (API + docs-site copies).

### Tests

- `test/plivo-whatsapp.test.ts` — signature sign/verify (query stripping, Ma header, comma-separated candidates, tampering), sender wire format and failure, provisioner idempotency/search/rent/error paths, provider-selection factories.
- `test/agent-whatsapp-plivo-route.test.ts` — the full webhook flow with Plivo-shaped payloads (JSON and form-encoded): signup link, two-turn booking, dedup, loop guard, disabled channel, non-text and non-WhatsApp deliveries, delivery reports, the signature gate (pinned URL, forwarded-header derivation, query-string handling), and the production 503.

`pnpm lint && pnpm type-check && pnpm test` pass (API coverage 95.6% lines / 87.3% branches, above the enforced thresholds).

### Notes for reviewers

- One WABA step stays manual for now: after the provisioner rents a number, registering it to the WhatsApp Business Account happens via Meta's Embedded Signup in the Plivo console — Plivo doesn't expose that over the API yet (marked `TODO(plivo)`).
- Free-form sends are valid because the customer always messages first (24-hour session window); templated sends for business-initiated messages are a marked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2)_