### PR TITLE
feat(api): add the voice channel on Plivo — the agent answers calls

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -288,8 +288,8 @@ Used when `ZERNIO_API_KEY` is set and the Plivo credentials are not.
 | `ZERNIO_WEBHOOK_SECRET` | _(unset)_                | zernio webhook signing secret; the route verifies the `X-Zernio-Signature` (raw-body HMAC-SHA256) header. Unset: dev/test accept unsigned deliveries; **production refuses the route (503)**. |
 | `ZERNIO_VERIFY_TOKEN`   | _(unset)_                | Verify token for the `GET` registration handshake. Unset: that handshake endpoint 404s.                               |
 
-Provisionable channels are **WhatsApp and SMS** (voice is schema-ready but not
-yet built), both **text only** (media/location/voice messages get no reply).
+Provisionable channels are **WhatsApp, SMS, and voice**; the messaging channels
+are **text only** (media/location messages get no reply).
 
 > **Note — the zernio provider is not yet fully wired to zernio's live API**
 > (the Plivo path above is built against Plivo's documented wire formats). The
@@ -339,3 +339,34 @@ reports flagging failures, and the no-op degradation without credentials.
    Plivo console before carriers accept application-originated texts — a
    one-time compliance step per brand/campaign, like the WABA registration for
    WhatsApp.
+
+### Voice channel (Plivo)
+
+The same scheduling agent also **answers phone calls** on the same number,
+turn-based on Plivo's Voice API: the call hits the answer webhook, Rivus greets
+and listens (`<GetInput inputType="speech">`), and each transcribed utterance
+runs through the identical channel-agnostic orchestrator — thread state, inbox
+mirroring (a `phone` conversation with a full transcript), booking — with the
+reply spoken back in the response XML. The call ends after a terminal outcome
+(booked, confirmed, or directed to self-signup); anything else loops the
+listen. Unknown callers are recognized by phone exactly like SMS/WhatsApp.
+
+1. Same credentials as the other channels (`PLIVO_AUTH_ID` + `PLIVO_AUTH_TOKEN`);
+   deliveries are verified with the same V2 signature scheme (no extra config —
+   the signed URL is reconstructed per request).
+2. In the Plivo console, create an **Application** with `answer_url` =
+   `POST /v1/channels/voice/plivo/answer` (public URL) and attach it to the
+   account's number. The same application's `message_url` can point at the SMS
+   webhook — one application wires both. TODO(plivo): automate the application
+   attach via the Numbers API when the channel is enabled.
+3. An owner enables the channel (app: Settings → Phone calls, or
+   `POST /v1/account/channels/voice/enable`). The account's existing
+   Plivo-owned WhatsApp/SMS number is adopted — calls, texts, and WhatsApp all
+   share one number — or a fresh voice+SMS number is rented.
+4. No extra registration: unlike WhatsApp (WABA) and US SMS (10DLC), inbound
+   voice works as soon as the application is attached to the number.
+
+Voice replies record in the inbox like every channel, but `phone`
+conversations have no reply-out transport (there is no live call to push a
+human reply into), so inbox replies on them record without sending — the
+pre-existing behavior for phone conversations.

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -1246,6 +1246,16 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -4668,6 +4678,104 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AgentChannelWebhookResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/voice/plivo/answer": {
+      "post": {
+        "summary": "Plivo voice webhook — answers an inbound call (answer_url)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Plivo requests this URL when someone calls the account’s provisioned number (the application’s answer_url, answer_method POST). The response XML greets the caller and listens for speech; each utterance is transcribed and posted to the input webhook. Deliveries are authenticated with Plivo’s V2 signature headers when PLIVO_AUTH_TOKEN is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/voice/plivo/input": {
+      "post": {
+        "summary": "Plivo voice webhook — one transcribed caller utterance (GetInput action)",
+        "tags": [
+          "channels"
+        ],
+        "description": "GetInput posts each transcribed utterance here. The utterance runs through the same channel-agnostic scheduling orchestrator as every other channel (threads, inbox mirroring as a phone conversation, booking); the response XML speaks the agent’s reply and either listens for the next turn or ends the call on a terminal outcome.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -16,6 +16,7 @@ import { accountChannelRoutes } from './routes/account-channels';
 import { adminRoutes } from './routes/admin';
 import { agentEmailRoutes } from './routes/agent-email';
 import { agentSmsPlivoRoutes } from './routes/agent-sms-plivo';
+import { agentVoicePlivoRoutes } from './routes/agent-voice-plivo';
 import { agentWhatsappRoutes } from './routes/agent-whatsapp';
 import { agentWhatsappPlivoRoutes } from './routes/agent-whatsapp-plivo';
 import { authRoutes } from './routes/auth';
@@ -202,6 +203,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	app.register(agentWhatsappRoutes, { prefix: '/v1/channels' });
 	app.register(agentWhatsappPlivoRoutes, { prefix: '/v1/channels' });
 	app.register(agentSmsPlivoRoutes, { prefix: '/v1/channels' });
+	app.register(agentVoicePlivoRoutes, { prefix: '/v1/channels' });
 
 	return app;
 }

--- a/packages/api/src/routes/account-channels.ts
+++ b/packages/api/src/routes/account-channels.ts
@@ -14,19 +14,18 @@ import { plivoOwnedIdentifier } from '../services/plivo';
  * assign a customer-facing number and stores it on the account (idempotent — a
  * re-enable never re-provisions); disabling turns the channel off but retains the
  * number so re-enabling restores the same one. Email isn't here (its address is
- * derived, always on); WhatsApp and SMS are provisionable, voice is reserved.
+ * derived, always on); WhatsApp, SMS, and voice are all provisionable.
  *
- * One number, every channel: when a channel is enabled and its sibling already
+ * One number, every channel: when a channel is enabled and a sibling already
  * holds a Plivo-owned number, that number is adopted instead of renting a
- * second one — Plivo fronts WhatsApp and SMS (and later voice) on the same
- * number. Numbers Plivo does not own (zernio's, the dev fakes) are never
+ * second one — Plivo fronts WhatsApp, SMS, and voice on the same number. Numbers Plivo does not own (zernio's, the dev fakes) are never
  * shared onto a channel Plivo would have to send from.
  */
 
 const channelParamsSchema = z.object({ channel: provisionedChannelSchema });
 
-/** The channels an owner can provision today (voice is schema-ready, not built). */
-const PROVISIONABLE = ['whatsapp', 'sms'] as const;
+/** The channels an owner can provision today. */
+const PROVISIONABLE = ['whatsapp', 'sms', 'voice'] as const;
 type ProvisionableChannel = (typeof PROVISIONABLE)[number];
 
 function isProvisionable(channel: string): channel is ProvisionableChannel {
@@ -39,10 +38,8 @@ function isProvisionable(channel: string): channel is ProvisionableChannel {
  */
 function providerConfigured(config: Config, channel: ProvisionableChannel): boolean {
 	const plivo = Boolean(config.PLIVO_AUTH_ID && config.PLIVO_AUTH_TOKEN);
-	if (channel === 'sms') {
-		return plivo;
-	}
-	return plivo || Boolean(config.ZERNIO_API_KEY);
+	// Only WhatsApp has an alternative provider (zernio); SMS and voice are Plivo-only.
+	return channel === 'whatsapp' ? plivo || Boolean(config.ZERNIO_API_KEY) : plivo;
 }
 
 /**
@@ -78,9 +75,12 @@ export const accountChannelRoutes: FastifyPluginAsync = async (fastify) => {
 	const app = fastify.withTypeProvider<ZodTypeProvider>();
 	const { accounts, config, whatsappProvisioner, smsProvisioner } = app.deps;
 
+	// Voice rides the same Plivo (or no-op) provisioner as SMS: both are
+	// plain rented numbers; only WhatsApp can route to an alternative provider.
 	const provisioners: Record<ProvisionableChannel, ChannelProvisioner> = {
 		whatsapp: whatsappProvisioner,
 		sms: smsProvisioner,
+		voice: smsProvisioner,
 	};
 
 	app.post(

--- a/packages/api/src/routes/agent-voice-plivo.ts
+++ b/packages/api/src/routes/agent-voice-plivo.ts
@@ -1,0 +1,223 @@
+import { type Account, normalizePhone } from '@rivus/core';
+import type { FastifyPluginAsync } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { errorResponseSchema } from '../http-schemas';
+import { defaultCapabilities } from '../services/agent/capabilities';
+import { handleInboundAgentMessage } from '../services/agent/orchestrator';
+import { createVoiceChannelAdapter } from '../services/agent/voice/adapter';
+import { plivoFormBodyParser, plivoWebhookAuthHook, requestOrigin } from './plivo-webhook-auth';
+
+/**
+ * The Plivo edge of the scheduling agent's voice channel — the one channel
+ * whose replies are SYNCHRONOUS: Plivo calls these webhooks and the call is
+ * driven by the XML each response returns. A call arrives at the number's
+ * `answer_url` (the answer route below), which greets the caller and listens
+ * with `<GetInput inputType="speech">`; each transcribed utterance then POSTs
+ * to the input route, which runs the same channel-agnostic orchestrator every
+ * other channel uses — thread state, inbox mirroring (a `phone` conversation),
+ * booking — and speaks the rendered reply back, looping the listen until the
+ * conversation reaches a terminal outcome (booked, confirmed, or sent to
+ * signup) and the call ends.
+ *
+ * v1 is turn-based (speak, listen, repeat) on the classic Voice API — a smart
+ * receptionist cadence, not barge-in realtime speech. The channel plumbing
+ * built here (provisioning, transcripts, guards) carries over unchanged if the
+ * conversation loop later moves to Plivo Audio Streaming.
+ */
+
+/** The absolute path of the input webhook (`GetInput action`), under the app's mount. */
+const INPUT_PATH = '/v1/channels/voice/plivo/input';
+
+/** Outcomes after which the call ends instead of listening for another turn. */
+const TERMINAL_OUTCOMES = new Set(['book', 'confirm_existing', 'send_signup_link']);
+
+const GOODBYE = 'Thanks for calling. Goodbye!';
+const NO_INPUT = "I didn't catch anything — call back anytime. Goodbye!";
+
+function xmlEscape(text: string): string {
+	return text
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&apos;');
+}
+
+/** A closing document: speak, then Plivo ends the call at the end of the XML. */
+function speakDocument(text: string): string {
+	return `<Response><Speak>${xmlEscape(text)}</Speak></Response>`;
+}
+
+/**
+ * A listening document: speak the prompt, capture one spoken utterance to the
+ * input route, and close politely if the caller says nothing. `hints` biases
+ * recognition toward the option numbers the agent offers.
+ */
+function listenDocument(prompt: string, actionUrl: string): string {
+	return (
+		'<Response>' +
+		`<GetInput action="${xmlEscape(actionUrl)}" method="POST" inputType="speech" language="en-US" hints="option,one,two,three,four,five,tomorrow,morning,afternoon">` +
+		`<Speak>${xmlEscape(prompt)}</Speak>` +
+		'</GetInput>' +
+		`<Speak>${xmlEscape(NO_INPUT)}</Speak>` +
+		'</Response>'
+	);
+}
+
+// Plivo delivers numbers bare ("14155551234"); normalize like the other routes.
+function callerNumber(value: string | undefined): string {
+	const trimmed = (value ?? '').trim();
+	if (trimmed === '') {
+		return '';
+	}
+	return normalizePhone(trimmed.startsWith('+') ? trimmed : `+${trimmed}`);
+}
+
+// The call fields both webhooks carry (answer_method/GetInput both POST forms).
+const callPayloadSchema = z.object({
+	From: z.string().optional(),
+	To: z.string().optional(),
+	CallUUID: z.string().optional(),
+	/** GetInput's transcription; absent on the answer webhook. */
+	Speech: z.string().optional(),
+});
+
+export const agentVoicePlivoRoutes: FastifyPluginAsync = async (fastify) => {
+	const app = fastify.withTypeProvider<ZodTypeProvider>();
+	const { config, accounts, customers, conversations, agentThreads, jobs } = app.deps;
+
+	const capabilities = defaultCapabilities();
+
+	app.addContentTypeParser(
+		'application/x-www-form-urlencoded',
+		{ parseAs: 'string' },
+		plivoFormBodyParser,
+	);
+	// Same V2 signature gate as the other Plivo webhooks. No pinned URL: the two
+	// voice endpoints have different paths, and nothing here doubles as a send-time
+	// callback, so verification reconstructs each request's own URL.
+	app.addHook('onRequest', plivoWebhookAuthHook(app, undefined));
+
+	/**
+	 * Resolve which account owns the called number, applying the same guards the
+	 * chat channels enforce — spoken, since a caller can't be answered with JSON.
+	 */
+	async function resolveAccount(to: string, from: string): Promise<Account | { speech: string }> {
+		const businessNumber = callerNumber(to);
+		const account = await accounts.findByChannelAddress('voice', businessNumber);
+		if (!account || account.status === 'canceled') {
+			return { speech: "Sorry, this number isn't in service. Goodbye!" };
+		}
+		if (!account.channels.voice.enabled) {
+			return { speech: `Sorry, ${account.name} isn't taking calls here right now. Goodbye!` };
+		}
+		// Loop guard: never converse with any account's own number.
+		if (await accounts.findByChannelAddress('voice', callerNumber(from))) {
+			return { speech: GOODBYE };
+		}
+		return account;
+	}
+
+	const voiceSchema = {
+		tags: ['channels'],
+		body: z.unknown(),
+		response: { 200: z.string(), 401: errorResponseSchema, 503: errorResponseSchema },
+	};
+
+	app.post(
+		'/voice/plivo/answer',
+		{
+			schema: {
+				...voiceSchema,
+				summary: 'Plivo voice webhook — answers an inbound call (answer_url)',
+				description:
+					'Plivo requests this URL when someone calls the account’s provisioned ' +
+					'number (the application’s answer_url, answer_method POST). The response ' +
+					'XML greets the caller and listens for speech; each utterance is ' +
+					'transcribed and posted to the input webhook. Deliveries are ' +
+					'authenticated with Plivo’s V2 signature headers when PLIVO_AUTH_TOKEN ' +
+					'is configured.',
+			},
+		},
+		async (request, reply) => {
+			const payload = callPayloadSchema.safeParse(request.body);
+			const { From = '', To = '' } = payload.success ? payload.data : {};
+			const resolved = await resolveAccount(To, From);
+			reply.type('text/xml');
+			if (!('id' in resolved)) {
+				return speakDocument(resolved.speech);
+			}
+			const greeting =
+				`Hi! You've reached ${resolved.name}. I'm Rivus, their scheduling assistant. ` +
+				'How can I help you today?';
+			return listenDocument(greeting, `${requestOrigin(request)}${INPUT_PATH}`);
+		},
+	);
+
+	app.post(
+		'/voice/plivo/input',
+		{
+			schema: {
+				...voiceSchema,
+				summary: 'Plivo voice webhook — one transcribed caller utterance (GetInput action)',
+				description:
+					'GetInput posts each transcribed utterance here. The utterance runs ' +
+					'through the same channel-agnostic scheduling orchestrator as every ' +
+					'other channel (threads, inbox mirroring as a phone conversation, ' +
+					'booking); the response XML speaks the agent’s reply and either listens ' +
+					'for the next turn or ends the call on a terminal outcome.',
+			},
+		},
+		async (request, reply) => {
+			const payload = callPayloadSchema.safeParse(request.body);
+			const {
+				From = '',
+				To = '',
+				Speech = '',
+				CallUUID = '',
+			} = payload.success ? payload.data : {};
+			const resolved = await resolveAccount(To, From);
+			reply.type('text/xml');
+			if (!('id' in resolved)) {
+				return speakDocument(resolved.speech);
+			}
+			const actionUrl = `${requestOrigin(request)}${INPUT_PATH}`;
+			const caller = callerNumber(From);
+			if (caller === '') {
+				return speakDocument(GOODBYE);
+			}
+			if (Speech.trim() === '') {
+				return listenDocument("Sorry, I didn't catch that. Could you say it again?", actionUrl);
+			}
+
+			// One spoken turn = one orchestrated agent turn, same as a chat message.
+			// The capture adapter hands back the rendered utterance to speak.
+			const capture = { text: '' };
+			const adapter = createVoiceChannelAdapter({ customers, capture });
+			const result = await handleInboundAgentMessage({
+				deps: { config, jobs, conversations, agentThreads },
+				adapter,
+				capabilities,
+				account: resolved,
+				message: {
+					sender: { address: caller, name: '' },
+					text: Speech,
+					subject: '',
+					// No per-utterance id from Plivo; '' skips redelivery dedup, which a
+					// synchronous webhook doesn't need. CallUUID stays in the logs.
+					externalMessageId: '',
+				},
+				logger: request.log.child({ callUuid: CallUUID }),
+			});
+
+			if (!result.handled || capture.text === '') {
+				return speakDocument(GOODBYE);
+			}
+			if (TERMINAL_OUTCOMES.has(result.outcome)) {
+				return speakDocument(`${capture.text} ${GOODBYE}`);
+			}
+			return listenDocument(capture.text, actionUrl);
+		},
+	);
+};

--- a/packages/api/src/routes/plivo-webhook-auth.ts
+++ b/packages/api/src/routes/plivo-webhook-auth.ts
@@ -20,6 +20,18 @@ function headerValue(value: string | string[] | undefined): string {
 }
 
 /**
+ * The public origin of a request (`https://api.rivus.ai`), honoring the
+ * forwarding headers the front-door proxy sets. Used to reconstruct signed
+ * webhook URLs and to build absolute callback URLs (the voice route's
+ * `GetInput action`).
+ */
+export function requestOrigin(request: FastifyRequest): string {
+	const proto = headerValue(request.headers['x-forwarded-proto']) || request.protocol;
+	const host = headerValue(request.headers['x-forwarded-host']) || request.headers.host || '';
+	return `${proto}://${host}`;
+}
+
+/**
  * The URL Plivo signed. The pinned URL (the exact URL configured in the Plivo
  * console for this channel) wins; otherwise it is derived from the request,
  * honoring the forwarding headers the front-door proxy sets.
@@ -28,9 +40,7 @@ function requestUrl(request: FastifyRequest, pinned: string | undefined): string
 	if (pinned) {
 		return pinned;
 	}
-	const proto = headerValue(request.headers['x-forwarded-proto']) || request.protocol;
-	const host = headerValue(request.headers['x-forwarded-host']) || request.headers.host || '';
-	return `${proto}://${host}${request.raw.url ?? request.url}`;
+	return `${requestOrigin(request)}${request.raw.url ?? request.url}`;
 }
 
 /**

--- a/packages/api/src/services/agent/response.ts
+++ b/packages/api/src/services/agent/response.ts
@@ -93,7 +93,17 @@ function reasonSentence(
 
 /** How a contact is told to reply, worded for the medium. */
 function replyHere(medium: ChannelMedium): string {
-	return medium === 'email' ? 'reply to this email' : 'reply here';
+	if (medium === 'email') {
+		return 'reply to this email';
+	}
+	return medium === 'voice' ? 'call back' : 'reply here';
+}
+
+/** How a contact picks an offered slot, worded for the medium. */
+function pickAnOption(medium: ChannelMedium): string {
+	return medium === 'voice'
+		? 'Say the number that works for you, or suggest another time.'
+		: 'Reply with the number that works for you, or suggest another time.';
 }
 
 /** The intermediate shape of a decision's content, before it becomes blocks. */
@@ -113,7 +123,10 @@ function contentFor(decision: AgentDecision, context: AgentReplyContext): Decisi
 			return {
 				lead: [
 					`Thanks for reaching out to ${context.accountName}! I'm Rivus, their scheduling assistant.`,
-					`I don't see this email address in ${context.accountName}'s customer list yet. Add yourself in a minute at the link below, then ${replyHere(context.medium)} and I'll get you booked in.`,
+					`I don't see this ${context.medium === 'email' ? 'email address' : 'phone number'} in ${context.accountName}'s customer list yet. ` +
+						(context.medium === 'voice'
+							? `Add yourself in a minute at the web link I'll read out, then call back and I'll get you booked in.`
+							: `Add yourself in a minute at the link below, then ${replyHere(context.medium)} and I'll get you booked in.`),
 				],
 				slots: [],
 				action: { label: `Join ${context.accountName} as a customer`, url: context.signupUrl },
@@ -124,7 +137,7 @@ function contentFor(decision: AgentDecision, context: AgentReplyContext): Decisi
 				lead: [`Great to hear from you! Here are ${context.accountName}'s next openings:`],
 				slots: decision.slots,
 				action: null,
-				trail: ['Reply with the number that works for you, or suggest another time.'],
+				trail: [pickAnOption(context.medium)],
 			};
 		case 'book':
 			return {
@@ -134,7 +147,9 @@ function contentFor(decision: AgentDecision, context: AgentReplyContext): Decisi
 				],
 				...none,
 				trail: [
-					`Need to change or cancel? Reply here and the ${context.accountName} team will take care of it.`,
+					context.medium === 'voice'
+						? `Need to change or cancel? Just call back and the ${context.accountName} team will take care of it.`
+						: `Need to change or cancel? Reply here and the ${context.accountName} team will take care of it.`,
 				],
 			};
 		case 'confirm_existing':
@@ -143,7 +158,11 @@ function contentFor(decision: AgentDecision, context: AgentReplyContext): Decisi
 					`You're all set — you're already booked for ${formatSlotLabel(decision.slot.startAt, context.timeZone, year)}.`,
 				],
 				...none,
-				trail: ['If you need to change or cancel, just reply and let me know.'],
+				trail: [
+					context.medium === 'voice'
+						? 'If you need to change or cancel, just call back anytime.'
+						: 'If you need to change or cancel, just reply and let me know.',
+				],
 			};
 		case 'propose_unavailable': {
 			const requestedLabel = formatSlotLabel(decision.requestedStartAt, context.timeZone, year);
@@ -152,7 +171,9 @@ function contentFor(decision: AgentDecision, context: AgentReplyContext): Decisi
 					lead: [reasonSentence(decision.reason, requestedLabel)],
 					...none,
 					trail: [
-						`I couldn't find another opening in the next two weeks — reply with a few times that work for you and I'll check them against ${context.accountName}'s calendar.`,
+						context.medium === 'voice'
+							? `I couldn't find another opening in the next two weeks. Tell me a few times that work for you and I'll check them against ${context.accountName}'s calendar.`
+							: `I couldn't find another opening in the next two weeks — reply with a few times that work for you and I'll check them against ${context.accountName}'s calendar.`,
 					],
 				};
 			}
@@ -160,7 +181,7 @@ function contentFor(decision: AgentDecision, context: AgentReplyContext): Decisi
 				lead: [reasonSentence(decision.reason, requestedLabel), 'Here is what we do have open:'],
 				slots: decision.alternatives,
 				action: null,
-				trail: ['Reply with the number that works for you, or suggest another time.'],
+				trail: [pickAnOption(context.medium)],
 			};
 		}
 		case 'no_availability':
@@ -170,7 +191,9 @@ function contentFor(decision: AgentDecision, context: AgentReplyContext): Decisi
 				],
 				...none,
 				trail: [
-					"Reply with a few times that work for you and I'll check them against the calendar.",
+					context.medium === 'voice'
+						? "Tell me a few times that work for you and I'll check them against the calendar."
+						: "Reply with a few times that work for you and I'll check them against the calendar.",
 				],
 			};
 	}

--- a/packages/api/src/services/agent/voice/adapter.ts
+++ b/packages/api/src/services/agent/voice/adapter.ts
@@ -1,0 +1,63 @@
+import type { AccountId, Customer } from '@rivus/core';
+import type { CustomerRepository } from '../../../repositories/types';
+import type {
+	ChannelAdapter,
+	ChannelCapabilities,
+	OutboundContext,
+	SignupPrefill,
+} from '../channel';
+import type { AgentResponse } from '../response';
+import { renderVoiceResponse } from './renderer';
+
+/**
+ * The voice channel adapter. Voice is the one channel whose transport is
+ * SYNCHRONOUS: the reply is the XML the webhook answers with, not a message
+ * pushed through a provider API. So `deliver` renders the spoken utterance
+ * into a per-turn {@link VoiceTurnCapture} the route hands in, and the route
+ * speaks it in its HTTP response. Everything else is the standard adapter
+ * contract — recognize callers by phone, feature-blind rendering — so the
+ * orchestrator (thread state, inbox mirroring, dedup) is reused unchanged.
+ *
+ * Inbox conversations for calls use the existing `phone` channel, and have no
+ * entry in the reply-out registry: with no live call there is nothing to push
+ * a human reply through, so inbox replies on phone conversations record only.
+ */
+
+/** Where one turn's spoken reply lands (the route speaks it in the response). */
+export interface VoiceTurnCapture {
+	text: string;
+}
+
+const VOICE_CAPABILITIES: ChannelCapabilities = {
+	channel: 'phone',
+	medium: 'voice',
+	supportsRichText: false,
+	supportsInteractiveOptions: false,
+	supportsHyperlinkButtons: false,
+	maxTextLength: null,
+	hasSubjects: false,
+	threadingModel: 'session',
+	isRealtimeVoice: true,
+	supportsAttachments: false,
+};
+
+export function createVoiceChannelAdapter(deps: {
+	customers: CustomerRepository;
+	capture: VoiceTurnCapture;
+}): ChannelAdapter {
+	return {
+		channel: 'phone',
+		capabilities: VOICE_CAPABILITIES,
+		findCustomer(accountId: AccountId, contactAddress: string): Promise<Customer | null> {
+			return deps.customers.findByPhone(accountId, contactAddress);
+		},
+		signupPrefill(sender): SignupPrefill {
+			return { param: 'phone', value: sender.address };
+		},
+		async deliver(response: AgentResponse, _ctx: OutboundContext): Promise<string> {
+			const speech = renderVoiceResponse(response);
+			deps.capture.text = speech;
+			return speech;
+		},
+	};
+}

--- a/packages/api/src/services/agent/voice/renderer.ts
+++ b/packages/api/src/services/agent/voice/renderer.ts
@@ -1,0 +1,47 @@
+import type { AgentResponse, AgentResponseBlock } from '../response';
+
+/**
+ * The voice renderer: any {@link AgentResponse} → one spoken utterance for a
+ * `<Speak>` element. Where the chat renderer keeps line structure, speech wants
+ * flowing sentences: options become "Option 1: …", the action link becomes a
+ * read-out web address (protocol and query stripped — nobody dictates
+ * `?email=…`), and newlines become sentence breaks. XML escaping is the XML
+ * layer's job, not this renderer's.
+ */
+
+/** A URL as a human would read it out: no scheme, no query, no trailing slash. */
+function spokenUrl(url: string): string {
+	const withoutScheme = url.replace(/^https?:\/\//, '');
+	const withoutQuery = withoutScheme.split('?', 1)[0] ?? '';
+	return withoutQuery.replace(/\/+$/, '');
+}
+
+/** Newlines → sentence-ish breaks, so multi-line paragraphs read naturally. */
+function flowing(text: string): string {
+	return text
+		.split('\n')
+		.map((line) => line.trim())
+		.filter((line) => line !== '')
+		.join(' ');
+}
+
+function blockSpeech(block: AgentResponseBlock): string {
+	switch (block.kind) {
+		case 'greeting':
+		case 'paragraph':
+		case 'notice':
+		case 'freeText':
+			return flowing(block.text);
+		case 'options':
+			return block.items.map((item) => `Option ${item.value}: ${item.label}.`).join(' ');
+		case 'action':
+			return `${block.label}: ${spokenUrl(block.url)}.`;
+	}
+}
+
+export function renderVoiceResponse(response: AgentResponse): string {
+	return response.blocks
+		.map(blockSpeech)
+		.filter((speech) => speech !== '')
+		.join(' ');
+}

--- a/packages/api/test/account-channels-route.test.ts
+++ b/packages/api/test/account-channels-route.test.ts
@@ -104,7 +104,7 @@ describe('account channel provisioning', () => {
 		expect(me.json().account.channels.whatsapp.enabled).toBe(false);
 	});
 
-	it('rejects an unknown channel (400) and a not-yet-available one (400)', async () => {
+	it('rejects an unknown channel (400)', async () => {
 		app = await buildTestApp();
 		const owner = await signupOwner(app);
 		const unknown = await app.inject({
@@ -113,12 +113,19 @@ describe('account channel provisioning', () => {
 			headers: authHeader(owner.token),
 		});
 		expect(unknown.statusCode).toBe(400);
-		const notYet = await app.inject({
+	});
+
+	it('provisions voice like the other channels', async () => {
+		app = await buildTestApp();
+		const owner = await signupOwner(app);
+		const enabled = await app.inject({
 			method: 'POST',
 			url: '/v1/account/channels/voice/enable',
 			headers: authHeader(owner.token),
 		});
-		expect(notYet.statusCode).toBe(400);
+		expect(enabled.statusCode).toBe(200);
+		expect(enabled.json().channels.voice.enabled).toBe(true);
+		expect(enabled.json().channels.voice.address).toMatch(/^\+1555\d{7}$/);
 	});
 
 	it('provisions, disables, and restores an SMS number like WhatsApp', async () => {
@@ -221,6 +228,24 @@ describe('one Plivo number shared across channels', () => {
 			headers: authHeader(accountB.token),
 		});
 		expect(me.json().account.channels.sms.enabled).toBe(false);
+	});
+
+	it('enabling voice adopts the account’s Plivo-owned messaging number', async () => {
+		const { app: built, repos } = await buildTestAppWithRepos();
+		app = built;
+		const owner = await signupOwner(app);
+		await repos.accounts.setChannelConfig(owner.account.id as AccountId, 'sms', {
+			enabled: true,
+			address: '+14155550103',
+			providerRef: '14155550103',
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: '/v1/account/channels/voice/enable',
+			headers: authHeader(owner.token),
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.json().channels.voice).toMatchObject({ enabled: true, address: '+14155550103' });
 	});
 
 	it('never shares a number Plivo does not own (zernio ids, dev fakes)', async () => {

--- a/packages/api/test/agent-response-matrix.test.ts
+++ b/packages/api/test/agent-response-matrix.test.ts
@@ -7,6 +7,7 @@ import { createEmailChannelAdapter } from '../src/services/agent/email/adapter';
 import type { AgentDecision } from '../src/services/agent/engine';
 import { type AgentReplyContext, composeAgentResponse } from '../src/services/agent/response';
 import { createSmsChannelAdapter } from '../src/services/agent/sms/adapter';
+import { createVoiceChannelAdapter } from '../src/services/agent/voice/adapter';
 import { createWhatsappChannelAdapter } from '../src/services/agent/whatsapp/adapter';
 import type { AgentEmail, Mailer } from '../src/services/email';
 import { RecordingSmsSender, RecordingWhatsappSender } from './helpers';
@@ -137,8 +138,20 @@ function smsChannel(): ChannelUnderTest {
 	return { name: 'sms', adapter, lastRendered: () => sender.messages.at(-1)?.text ?? '' };
 }
 
+function voiceChannel(): ChannelUnderTest {
+	const capture = { text: '' };
+	const { customers } = createInMemoryRepositories();
+	const adapter = createVoiceChannelAdapter({ customers, capture });
+	return { name: 'voice', adapter, lastRendered: () => capture.text };
+}
+
 // Every channel with an outbound transport. Adding one here covers it for all decisions.
-const CHANNELS: Array<() => ChannelUnderTest> = [emailChannel, whatsappChannel, smsChannel];
+const CHANNELS: Array<() => ChannelUnderTest> = [
+	emailChannel,
+	whatsappChannel,
+	smsChannel,
+	voiceChannel,
+];
 
 describe('agent response render matrix (channels × decisions)', () => {
 	for (const makeChannel of CHANNELS) {

--- a/packages/api/test/agent-voice-plivo-route.test.ts
+++ b/packages/api/test/agent-voice-plivo-route.test.ts
@@ -1,0 +1,362 @@
+import type { AccountId } from '@rivus/core';
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../src/app';
+import { loadConfig } from '../src/config';
+import { createInMemoryRepositories } from '../src/repositories/memory';
+import { NoopReceivedEmailReader } from '../src/services/agent/email/received';
+import { composeAgentResponse } from '../src/services/agent/response';
+import { renderVoiceResponse } from '../src/services/agent/voice/renderer';
+import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
+import { NoopFaqAnswerService } from '../src/services/faq-answer';
+import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
+import { createNotificationService } from '../src/services/notifications';
+import { signPlivoUrl } from '../src/services/plivo';
+import {
+	buildTestAppWithRepos,
+	RecordingMailer,
+	RecordingSmsSender,
+	RecordingWhatsappSender,
+	signupOwner,
+} from './helpers';
+
+const ANSWER_URL = '/v1/channels/voice/plivo/answer';
+const INPUT_URL = '/v1/channels/voice/plivo/input';
+// The account's number is stored `+`-formed; Plivo delivers bare digits.
+const BIZ = '+15550003333';
+const BIZ_PLIVO = '15550003333';
+const CALLER = '+15559990000';
+const CALLER_PLIVO = '15559990000';
+
+function call(overrides: Record<string, string> = {}) {
+	return {
+		From: CALLER_PLIVO,
+		To: BIZ_PLIVO,
+		CallUUID: 'call-0001',
+		...overrides,
+	};
+}
+
+/** Build an app + repos and enable voice on the signed-up owner's account. */
+async function setup() {
+	const { app, repos } = await buildTestAppWithRepos();
+	const owner = await signupOwner(app);
+	const accountId = owner.account.id as AccountId;
+	await repos.accounts.setChannelConfig(accountId, 'voice', {
+		enabled: true,
+		address: BIZ,
+		providerRef: BIZ_PLIVO,
+	});
+	return { app, repos, accountId, owner };
+}
+
+describe('POST /v1/channels/voice/plivo/answer', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('greets the caller by business name and listens for speech', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(res.statusCode).toBe(200);
+		expect(res.headers['content-type']).toContain('xml');
+		expect(res.body).toContain('<GetInput');
+		expect(res.body).toContain('inputType="speech"');
+		expect(res.body).toContain(`action="http://localhost:80${INPUT_URL}"`);
+		expect(res.body).toContain('scheduling assistant');
+	});
+
+	it('escapes XML-significant characters in the spoken account name', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		const account = await repos.accounts.findById(accountId);
+		if (account) {
+			await repos.accounts.update(accountId, { name: 'Smith & Sons <Plumbing>' });
+		}
+		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(res.body).toContain('Smith &amp; Sons &lt;Plumbing&gt;');
+	});
+
+	it('speaks a not-in-service message for a number no account holds', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: ANSWER_URL,
+			payload: call({ To: '15557778888' }),
+		});
+		expect(res.body).toContain('isn&apos;t in service');
+		expect(res.body).not.toContain('<GetInput');
+	});
+
+	it('declines the call when the channel is disabled', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.accounts.setChannelConfig(accountId, 'voice', {
+			enabled: false,
+			address: BIZ,
+			providerRef: BIZ_PLIVO,
+		});
+		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(res.body).toContain('isn&apos;t taking calls');
+		expect(res.body).not.toContain('<GetInput');
+	});
+});
+
+describe('POST /v1/channels/voice/plivo/input', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('offers slots to a recognized caller and keeps listening', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.customers.create(accountId, {
+			name: 'Dana Fox',
+			email: '',
+			phone: '(555) 999-0000',
+			address: '12 Pine St',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ Speech: 'When are you free?' }),
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.body).toContain('Option 1:');
+		expect(res.body).toContain('Say the number that works for you');
+		expect(res.body).toContain('<GetInput');
+	});
+
+	it('books when the caller picks a slot, then ends the call', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.customers.create(accountId, {
+			name: 'Dana Fox',
+			email: '',
+			phone: '+1 (555) 999-0000',
+			address: '12 Pine St',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+		await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ Speech: 'When are you free?' }),
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ Speech: 'option 1' }),
+		});
+		expect(res.body).toContain('You&apos;re booked!');
+		expect(res.body).toContain('Goodbye');
+		expect(res.body).not.toContain('<GetInput');
+		const { total } = await repos.jobs.list({ accountId, page: 1, pageSize: 10 });
+		expect(total).toBe(1);
+		// The call landed in the inbox as a phone conversation with a transcript.
+		const thread = await repos.agentThreads.findByContact(accountId, 'phone', CALLER);
+		expect(thread).not.toBeNull();
+		const messages = thread
+			? await repos.conversations.listMessages(accountId, thread.conversationId)
+			: [];
+		expect(messages?.some((m) => m.author === 'customer' && m.body === 'option 1')).toBe(true);
+	});
+
+	it('sends an unknown caller to signup and ends the call with the spoken link', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ Speech: 'Can I book something?' }),
+		});
+		// Terminal: the URL is read out (no scheme/query) and the call ends.
+		expect(res.body).toContain('rivus.ai/customers/join/');
+		expect(res.body).not.toContain('https://');
+		expect(res.body).not.toContain('<GetInput');
+		expect(res.body).toContain('Goodbye');
+	});
+
+	it('re-prompts when nothing was transcribed', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ Speech: '   ' }),
+		});
+		expect(res.body).toContain('didn&apos;t catch that');
+		expect(res.body).toContain('<GetInput');
+	});
+
+	it('hangs up on calls for unknown numbers or from an account’s own number', async () => {
+		const { app: built, repos } = await setup();
+		app = built;
+		const unknown = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ To: '15557778888', Speech: 'hello' }),
+		});
+		expect(unknown.body).toContain('isn&apos;t in service');
+
+		// A second account whose voice number calls the first (loop guard).
+		const other = await signupOwner(app);
+		await repos.accounts.setChannelConfig(other.account.id as AccountId, 'voice', {
+			enabled: true,
+			address: '+15552224444',
+			providerRef: '15552224444',
+		});
+		const loop = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ From: '15552224444', Speech: 'hello' }),
+		});
+		expect(loop.body).toContain('Goodbye');
+		expect(loop.body).not.toContain('<GetInput');
+	});
+});
+
+// --- Signature (separate config) ---------------------------------------------
+
+const AUTH_TOKEN = 'plivo-test-auth-token';
+
+function buildVoiceApp(extraConfig: Record<string, string> = {}): FastifyInstance {
+	const repos = createInMemoryRepositories();
+	return buildApp({
+		config: loadConfig({
+			NODE_ENV: 'test',
+			JWT_SECRET: 'test-secret-value-1234',
+			...extraConfig,
+		} as NodeJS.ProcessEnv),
+		...repos,
+		mailer: new RecordingMailer(),
+		receivedEmails: new NoopReceivedEmailReader(),
+		whatsappSender: new RecordingWhatsappSender(),
+		whatsappProvisioner: new NoopChannelProvisioner(),
+		smsSender: new RecordingSmsSender(),
+		smsProvisioner: new NoopChannelProvisioner(),
+		notifier: createNotificationService({ notifications: repos.notifications }),
+		faqSimilarity: new NoopFaqSimilarityService(),
+		faqAnswer: new NoopFaqAnswerService(),
+		ping: async () => ({ ready: true }),
+	});
+}
+
+describe('POST /v1/channels/voice/plivo/* — signature', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('verifies against each endpoint’s own reconstructed URL', async () => {
+		app = buildVoiceApp({ PLIVO_AUTH_TOKEN: AUTH_TOKEN });
+		const nonce = '77665544';
+		const signed = await app.inject({
+			method: 'POST',
+			url: ANSWER_URL,
+			payload: call(),
+			headers: {
+				'x-plivo-signature-v2-nonce': nonce,
+				'x-plivo-signature-v2': signPlivoUrl({
+					authToken: AUTH_TOKEN,
+					url: `http://localhost:80${ANSWER_URL}`,
+					nonce,
+				}),
+			},
+		});
+		// Unknown account, but spoken politely — the signature passed.
+		expect(signed.statusCode).toBe(200);
+		expect(signed.body).toContain('isn&apos;t in service');
+
+		const unsigned = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(unsigned.statusCode).toBe(401);
+
+		// A signature minted for the answer URL never opens the input URL.
+		const crossPath = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ Speech: 'hi' }),
+			headers: {
+				'x-plivo-signature-v2-nonce': nonce,
+				'x-plivo-signature-v2': signPlivoUrl({
+					authToken: AUTH_TOKEN,
+					url: `http://localhost:80${ANSWER_URL}`,
+					nonce,
+				}),
+			},
+		});
+		expect(crossPath.statusCode).toBe(401);
+	});
+
+	it('stays open when unconfigured outside production, and 503s in production', async () => {
+		app = buildVoiceApp();
+		const open = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(open.statusCode).toBe(200);
+		await app.close();
+
+		app = buildVoiceApp({
+			NODE_ENV: 'production',
+			JWT_SECRET: 'x'.repeat(32),
+			RESEND_API_KEY: 're_test_key',
+			LOG_LEVEL: 'silent',
+			CORS_ORIGIN: 'https://app.rivus.ai',
+		});
+		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(res.statusCode).toBe(503);
+	});
+});
+
+// --- Spoken rendering ----------------------------------------------------------
+
+describe('renderVoiceResponse', () => {
+	const context = {
+		accountName: 'Cascade Plumbing',
+		customerName: 'Dana Fox',
+		timeZone: 'America/Los_Angeles',
+		signupUrl: 'https://www.rivus.ai/customers/join/cascade?phone=%2B15559990000',
+		jobTitle: 'Water heater',
+		now: new Date('2026-07-03T17:00:00.000Z'),
+		medium: 'voice' as const,
+	};
+
+	it('speaks options as "Option N", not a numbered list', () => {
+		const speech = renderVoiceResponse(
+			composeAgentResponse(
+				{
+					kind: 'offer_slots',
+					slots: [
+						{ startAt: '2026-07-07T16:00:00.000Z', durationMinutes: 60 },
+						{ startAt: '2026-07-09T21:00:00.000Z', durationMinutes: 60 },
+					],
+				},
+				context,
+			),
+		);
+		expect(speech).toContain('Option 1:');
+		expect(speech).toContain('Option 2:');
+		expect(speech).not.toContain('\n');
+		expect(speech).toContain('Say the number that works for you');
+	});
+
+	it('reads links without scheme or query, and flows multi-line text', () => {
+		const speech = renderVoiceResponse(
+			composeAgentResponse({ kind: 'send_signup_link' }, { ...context, customerName: '' }),
+		);
+		expect(speech).toContain('www.rivus.ai/customers/join/cascade');
+		expect(speech).not.toContain('https://');
+		expect(speech).not.toContain('?phone=');
+		expect(speech).not.toContain('\n');
+		expect(speech).toContain('phone number');
+	});
+});

--- a/packages/app/app/settings.tsx
+++ b/packages/app/app/settings.tsx
@@ -130,6 +130,9 @@ export default function SettingsScreen() {
 	const [smsBusy, setSmsBusy] = useState(false);
 	const [smsError, setSmsError] = useState<string | null>(null);
 
+	const [voiceBusy, setVoiceBusy] = useState(false);
+	const [voiceError, setVoiceError] = useState<string | null>(null);
+
 	const [confirmingCancel, setConfirmingCancel] = useState(false);
 	const [canceling, setCanceling] = useState(false);
 	const [cancelError, setCancelError] = useState<string | null>(null);
@@ -246,6 +249,7 @@ export default function SettingsScreen() {
 
 	const whatsapp = session.account.channels.whatsapp;
 	const sms = session.account.channels.sms;
+	const voice = session.account.channels.voice;
 
 	async function onToggleWhatsapp(next: string) {
 		const enabled = next === 'on';
@@ -279,6 +283,24 @@ export default function SettingsScreen() {
 			setSmsError(messageFor(caught, `Could not ${enabled ? 'enable' : 'disable'} texting.`));
 		} finally {
 			setSmsBusy(false);
+		}
+	}
+
+	async function onToggleVoice(next: string) {
+		const enabled = next === 'on';
+		if (voiceBusy || enabled === voice.enabled) {
+			return;
+		}
+		setVoiceError(null);
+		setVoiceBusy(true);
+		try {
+			// Enabling provisions a number on the first call (reusing the WhatsApp/SMS
+			// number when the channels share one); the session updates in place.
+			await setChannelEnabled('voice', enabled);
+		} catch (caught) {
+			setVoiceError(messageFor(caught, `Could not ${enabled ? 'enable' : 'disable'} phone calls.`));
+		} finally {
+			setVoiceBusy(false);
 		}
 	}
 
@@ -402,6 +424,29 @@ export default function SettingsScreen() {
 					<CopyField label="Your SMS number" value={sms.address} />
 				) : null}
 				{smsError ? <Txt style={styles.errorTxt}>{smsError}</Txt> : null}
+			</Card>
+
+			<Card style={styles.card}>
+				<SectionLabel>Phone calls</SectionLabel>
+				<Txt style={styles.agentEmailHint}>
+					Customers can call this number — Rivus answers, offers open times, and books them. Turn it
+					on to get a number; calls share one number with WhatsApp and texting.
+				</Txt>
+				<View style={styles.whatsappRow}>
+					<Segmented
+						options={[
+							{ label: 'Off', value: 'off' },
+							{ label: 'On', value: 'on' },
+						]}
+						value={voice.enabled ? 'on' : 'off'}
+						onChange={onToggleVoice}
+					/>
+					{voiceBusy ? <ActivityIndicator color={colors.brandPurple} /> : null}
+				</View>
+				{voice.enabled && voice.address ? (
+					<CopyField label="Your phone number" value={voice.address} />
+				) : null}
+				{voiceError ? <Txt style={styles.errorTxt}>{voiceError}</Txt> : null}
 			</Card>
 
 			<Card style={styles.card}>

--- a/packages/docs/site/openapi.json
+++ b/packages/docs/site/openapi.json
@@ -1246,6 +1246,16 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -4668,6 +4678,104 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AgentChannelWebhookResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/voice/plivo/answer": {
+      "post": {
+        "summary": "Plivo voice webhook — answers an inbound call (answer_url)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Plivo requests this URL when someone calls the account’s provisioned number (the application’s answer_url, answer_method POST). The response XML greets the caller and listens for speech; each utterance is transcribed and posted to the input webhook. Deliveries are authenticated with Plivo’s V2 signature headers when PLIVO_AUTH_TOKEN is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/voice/plivo/input": {
+      "post": {
+        "summary": "Plivo voice webhook — one transcribed caller utterance (GetInput action)",
+        "tags": [
+          "channels"
+        ],
+        "description": "GetInput posts each transcribed utterance here. The utterance runs through the same channel-agnostic scheduling orchestrator as every other channel (threads, inbox mirroring as a phone conversation, booking); the response XML speaks the agent’s reply and either listens for the next turn or ends the call on a terminal outcome.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — the scheduling agent now **answers phone calls** on the same Plivo number that carries WhatsApp (#111) and SMS (#112), completing the one-number-every-channel story. Path A from the voice discussion: turn-based on Plivo's classic Voice API, with the architecture positioned to swap the conversation loop for Audio Streaming later without touching the channel plumbing.

### How a call flows

Plivo requests the number's `answer_url` (`POST /v1/channels/voice/plivo/answer`) → Rivus greets by business name and listens with `<GetInput inputType="speech">` → each transcribed utterance POSTs to `/v1/channels/voice/plivo/input` → the utterance runs through the **identical channel-agnostic orchestrator** as email/WhatsApp/SMS (thread state, customer recognition by phone, booking, inbox mirroring as a `phone` conversation with a full transcript) → the reply is spoken back in the response XML. Terminal outcomes (booked, confirmed, sent to signup) end the call; anything else loops the listen. Unknown numbers, disabled channels, and account-to-account calls get spoken declines mirroring the chat-channel guards.

### What's in the change

- **`services/agent/voice/renderer.ts`** — spoken rendering: options become "Option N: …", links are read out without scheme/query (nobody dictates `?email=…`), newlines flow into sentences.
- **`services/agent/voice/adapter.ts`** — the capture-transport adapter. Voice is the one channel whose reply is synchronous (the webhook's own XML), so `deliver` renders into a per-turn capture the route speaks. Conversation channel is the existing `phone`; it stays out of the reply-out registry since there's no live call to push an inbox reply into (replies on phone conversations record only — pre-existing behavior, now documented).
- **`routes/agent-voice-plivo.ts`** — both webhooks behind the shared V2 signature gate (per-request URL reconstruction; the two endpoints have different paths and nothing doubles as a send-time callback, so no pinned-URL config is needed), XML building with escaping, `hints` biasing recognition toward option numbers.
- **`response.ts`** — the reserved `'voice'` medium gets its wording ("Say the number…", "call back…") with email/chat strings byte-identical to before; also fixes a pre-existing copy bug where phone-matched channels told callers "I don't see this **email address**".
- **Provisioning** — `voice` joins the provisionable channels: enabling adopts the account's Plivo-owned WhatsApp/SMS number (either direction) or rents a voice+SMS-capable one; Plivo-only provider gate in production (503 when unconfigured, like SMS); cross-account uniqueness sweep covers all three channels.
- **App** — a "Phone calls" settings section mirroring the other channel toggles.
- **Docs** — README voice section including the console setup (create a Plivo Application with `answer_url` pointed at the answer webhook, attach it to the number — the same application's `message_url` wires SMS; automating the attach via the Numbers API is a marked follow-up); OpenAPI regenerated (API + docs copies).

### Tests

`agent-voice-plivo-route.test.ts` — greeting XML (business name, GetInput action URL, XML escaping of `&`/`<`), full two-turn booking over speech ending in hangup + job + inbox transcript, unknown-caller signup with the spoken link, re-prompt on empty transcription, not-in-service/disabled/loop-guard declines, per-endpoint signature verification (a signature minted for the answer URL doesn't open the input URL), production 503; spoken-renderer unit tests; the response matrix now covers **voice × every agent decision**; account-channels tests extended for voice provisioning and number adoption.

`pnpm lint && pnpm type-check && pnpm test` pass — 1,521 tests across packages (896 API); API coverage 95.7% lines / 87.6% branches (thresholds 90/80).

### Notes for reviewers

- v1 cadence is speak-listen-repeat (a smart receptionist, not barge-in realtime). Upgrading to human-like conversation is a conversation-loop swap to Plivo Audio Streaming (Pipecat + STT/LLM/TTS or speech-to-speech); provisioning, transcripts, and guards built here carry over unchanged.
- No extra registration for voice (unlike WABA/10DLC) — calls work once the application is attached to the number in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2)_