### PR TITLE
fix(api): harden the voice webhooks from review feedback

### DIFF
--- a/packages/api/src/routes/agent-voice-plivo.ts
+++ b/packages/api/src/routes/agent-voice-plivo.ts
@@ -34,6 +34,12 @@ const TERMINAL_OUTCOMES = new Set(['book', 'confirm_existing', 'send_signup_link
 
 const GOODBYE = 'Thanks for calling. Goodbye!';
 const NO_INPUT = "I didn't catch anything — call back anytime. Goodbye!";
+const NOT_IN_SERVICE = "Sorry, this number isn't in service. Goodbye!";
+const ANONYMOUS =
+	"Sorry, we can't take calls from restricted or anonymous numbers. Please call back with caller I D enabled. Goodbye!";
+// Spoken instead of a JSON 500: Plivo drops the call abruptly on non-XML.
+const APOLOGY =
+	'Sorry, something went wrong on our end. Please call back in a few minutes. Goodbye!';
 
 function xmlEscape(text: string): string {
 	return text
@@ -63,6 +69,35 @@ function listenDocument(prompt: string, actionUrl: string): string {
 		`<Speak>${xmlEscape(NO_INPUT)}</Speak>` +
 		'</Response>'
 	);
+}
+
+/** Word numbers ASR may emit where the menu says "Option 1". */
+const SPOKEN_NUMBERS: Record<string, string> = {
+	one: '1',
+	two: '2',
+	three: '3',
+	four: '4',
+	five: '5',
+	six: '6',
+	seven: '7',
+	eight: '8',
+	nine: '9',
+	ten: '10',
+};
+
+/**
+ * Voice-edge speech normalization: "option one" → "option 1" (also "number
+ * one"), so a spoken menu pick parses exactly like a typed one. Bare word
+ * numbers ("two") already parse in core; this only covers the phrasing the
+ * spoken menu itself invites.
+ */
+function normalizeSpeech(text: string): string {
+	return text
+		.trim()
+		.replace(
+			/\b(option|number)\s+(one|two|three|four|five|six|seven|eight|nine|ten)\b/gi,
+			(_, lead: string, word: string) => `${lead} ${SPOKEN_NUMBERS[word.toLowerCase()]}`,
+		);
 }
 
 // Plivo delivers numbers bare ("14155551234"); normalize like the other routes.
@@ -105,15 +140,22 @@ export const agentVoicePlivoRoutes: FastifyPluginAsync = async (fastify) => {
 	 */
 	async function resolveAccount(to: string, from: string): Promise<Account | { speech: string }> {
 		const businessNumber = callerNumber(to);
+		// Both repository implementations already return null for '', so an
+		// unparseable To can never match an unprovisioned account — these explicit
+		// guards just spare the lookups and keep the route safe on its own terms.
+		if (businessNumber === '') {
+			return { speech: NOT_IN_SERVICE };
+		}
 		const account = await accounts.findByChannelAddress('voice', businessNumber);
 		if (!account || account.status === 'canceled') {
-			return { speech: "Sorry, this number isn't in service. Goodbye!" };
+			return { speech: NOT_IN_SERVICE };
 		}
 		if (!account.channels.voice.enabled) {
 			return { speech: `Sorry, ${account.name} isn't taking calls here right now. Goodbye!` };
 		}
 		// Loop guard: never converse with any account's own number.
-		if (await accounts.findByChannelAddress('voice', callerNumber(from))) {
+		const caller = callerNumber(from);
+		if (caller !== '' && (await accounts.findByChannelAddress('voice', caller))) {
 			return { speech: GOODBYE };
 		}
 		return account;
@@ -141,17 +183,27 @@ export const agentVoicePlivoRoutes: FastifyPluginAsync = async (fastify) => {
 			},
 		},
 		async (request, reply) => {
-			const payload = callPayloadSchema.safeParse(request.body);
-			const { From = '', To = '' } = payload.success ? payload.data : {};
-			const resolved = await resolveAccount(To, From);
 			reply.type('text/xml');
-			if (!('id' in resolved)) {
-				return speakDocument(resolved.speech);
+			try {
+				const payload = callPayloadSchema.safeParse(request.body);
+				const { From = '', To = '' } = payload.success ? payload.data : {};
+				const resolved = await resolveAccount(To, From);
+				if (!('id' in resolved)) {
+					return speakDocument(resolved.speech);
+				}
+				// A caller with no presentable number can never be recognized or booked —
+				// decline up front instead of greeting and hanging up a turn later.
+				if (callerNumber(From) === '') {
+					return speakDocument(ANONYMOUS);
+				}
+				const greeting =
+					`Hi! You've reached ${resolved.name}. I'm Rivus, their scheduling assistant. ` +
+					'How can I help you today?';
+				return listenDocument(greeting, `${requestOrigin(request)}${INPUT_PATH}`);
+			} catch (error) {
+				request.log.error({ err: error }, 'voice answer webhook failed');
+				return speakDocument(APOLOGY);
 			}
-			const greeting =
-				`Hi! You've reached ${resolved.name}. I'm Rivus, their scheduling assistant. ` +
-				'How can I help you today?';
-			return listenDocument(greeting, `${requestOrigin(request)}${INPUT_PATH}`);
 		},
 	);
 
@@ -170,54 +222,63 @@ export const agentVoicePlivoRoutes: FastifyPluginAsync = async (fastify) => {
 			},
 		},
 		async (request, reply) => {
-			const payload = callPayloadSchema.safeParse(request.body);
-			const {
-				From = '',
-				To = '',
-				Speech = '',
-				CallUUID = '',
-			} = payload.success ? payload.data : {};
-			const resolved = await resolveAccount(To, From);
 			reply.type('text/xml');
-			if (!('id' in resolved)) {
-				return speakDocument(resolved.speech);
-			}
-			const actionUrl = `${requestOrigin(request)}${INPUT_PATH}`;
-			const caller = callerNumber(From);
-			if (caller === '') {
-				return speakDocument(GOODBYE);
-			}
-			if (Speech.trim() === '') {
-				return listenDocument("Sorry, I didn't catch that. Could you say it again?", actionUrl);
-			}
+			try {
+				const payload = callPayloadSchema.safeParse(request.body);
+				const {
+					From = '',
+					To = '',
+					Speech = '',
+					CallUUID = '',
+				} = payload.success ? payload.data : {};
+				const resolved = await resolveAccount(To, From);
+				if (!('id' in resolved)) {
+					return speakDocument(resolved.speech);
+				}
+				const actionUrl = `${requestOrigin(request)}${INPUT_PATH}`;
+				const caller = callerNumber(From);
+				if (caller === '') {
+					return speakDocument(ANONYMOUS);
+				}
+				const speech = normalizeSpeech(Speech);
+				if (speech === '') {
+					return listenDocument("Sorry, I didn't catch that. Could you say it again?", actionUrl);
+				}
 
-			// One spoken turn = one orchestrated agent turn, same as a chat message.
-			// The capture adapter hands back the rendered utterance to speak.
-			const capture = { text: '' };
-			const adapter = createVoiceChannelAdapter({ customers, capture });
-			const result = await handleInboundAgentMessage({
-				deps: { config, jobs, conversations, agentThreads },
-				adapter,
-				capabilities,
-				account: resolved,
-				message: {
-					sender: { address: caller, name: '' },
-					text: Speech,
-					subject: '',
-					// No per-utterance id from Plivo; '' skips redelivery dedup, which a
-					// synchronous webhook doesn't need. CallUUID stays in the logs.
-					externalMessageId: '',
-				},
-				logger: request.log.child({ callUuid: CallUUID }),
-			});
+				// One spoken turn = one orchestrated agent turn, same as a chat message.
+				// The capture adapter hands back the rendered utterance to speak.
+				const capture = { text: '' };
+				const adapter = createVoiceChannelAdapter({ customers, capture });
+				const result = await handleInboundAgentMessage({
+					deps: { config, jobs, conversations, agentThreads },
+					adapter,
+					capabilities,
+					account: resolved,
+					message: {
+						sender: { address: caller, name: '' },
+						text: speech,
+						subject: '',
+						// Plivo sends no per-utterance id, and a synthetic CallUUID+Speech key
+						// would dedupe a caller legitimately repeating themselves (same words,
+						// same call) into a goodbye — worse than the rare timeout-retry replay
+						// it would catch, which lands on the already-booked thread as
+						// confirm_existing rather than a double booking. So '' (dedup off).
+						externalMessageId: '',
+					},
+					logger: request.log.child({ callUuid: CallUUID }),
+				});
 
-			if (!result.handled || capture.text === '') {
-				return speakDocument(GOODBYE);
+				if (!result.handled || capture.text === '') {
+					return speakDocument(GOODBYE);
+				}
+				if (TERMINAL_OUTCOMES.has(result.outcome)) {
+					return speakDocument(`${capture.text} ${GOODBYE}`);
+				}
+				return listenDocument(capture.text, actionUrl);
+			} catch (error) {
+				request.log.error({ err: error }, 'voice input webhook failed');
+				return speakDocument(APOLOGY);
 			}
-			if (TERMINAL_OUTCOMES.has(result.outcome)) {
-				return speakDocument(`${capture.text} ${GOODBYE}`);
-			}
-			return listenDocument(capture.text, actionUrl);
 		},
 	);
 };

--- a/packages/api/src/routes/agent-voice-plivo.ts
+++ b/packages/api/src/routes/agent-voice-plivo.ts
@@ -37,7 +37,13 @@ const NO_INPUT = "I didn't catch anything — call back anytime. Goodbye!";
 const NOT_IN_SERVICE = "Sorry, this number isn't in service. Goodbye!";
 const ANONYMOUS =
 	"Sorry, we can't take calls from restricted or anonymous numbers. Please call back with caller I D enabled. Goodbye!";
-// Spoken instead of a JSON 500: Plivo drops the call abruptly on non-XML.
+// Spoken with HTTP 200 instead of erroring — deliberately. These webhooks are
+// call-flow ACTION URLs, not async status callbacks: the response XML drives a
+// live call, so a non-200 buys no durable retry (Plivo's retry-on-non-200
+// applies to status callbacks like hangup_url; a live caller can't be parked
+// while the service recovers). Erroring would replace this polite goodbye with
+// Plivo's generic mid-call failure handling; "call back in a few minutes" IS
+// the retry path for a human on the phone.
 const APOLOGY =
 	'Sorry, something went wrong on our end. Please call back in a few minutes. Goodbye!';
 

--- a/packages/api/test/agent-voice-plivo-route.test.ts
+++ b/packages/api/test/agent-voice-plivo-route.test.ts
@@ -1,6 +1,6 @@
 import type { AccountId } from '@rivus/core';
 import type { FastifyInstance } from 'fastify';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { buildApp } from '../src/app';
 import { loadConfig } from '../src/config';
 import { createInMemoryRepositories } from '../src/repositories/memory';
@@ -92,6 +92,29 @@ describe('POST /v1/channels/voice/plivo/answer', () => {
 		expect(res.body).not.toContain('<GetInput');
 	});
 
+	it('declines restricted/anonymous callers up front instead of greeting them', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: ANSWER_URL,
+			payload: call({ From: '' }),
+		});
+		expect(res.body).toContain('restricted or anonymous');
+		expect(res.body).not.toContain('<GetInput');
+	});
+
+	it('speaks an apology instead of JSON when a dependency fails (Plivo needs XML)', async () => {
+		const { app: built, repos } = await setup();
+		app = built;
+		vi.spyOn(repos.accounts, 'findByChannelAddress').mockRejectedValueOnce(new Error('db down'));
+		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(res.statusCode).toBe(200);
+		expect(res.headers['content-type']).toContain('xml');
+		expect(res.body).toContain('something went wrong');
+		expect(res.body).not.toContain('<GetInput');
+	});
+
 	it('declines the call when the channel is disabled', async () => {
 		const { app: built, repos, accountId } = await setup();
 		app = built;
@@ -156,7 +179,8 @@ describe('POST /v1/channels/voice/plivo/input', () => {
 		const res = await app.inject({
 			method: 'POST',
 			url: INPUT_URL,
-			payload: call({ Speech: 'option 1' }),
+			// ASR often writes the pick out in words; the route normalizes it.
+			payload: call({ Speech: 'option one' }),
 		});
 		expect(res.body).toContain('You&apos;re booked!');
 		expect(res.body).toContain('Goodbye');
@@ -197,6 +221,20 @@ describe('POST /v1/channels/voice/plivo/input', () => {
 		});
 		expect(res.body).toContain('didn&apos;t catch that');
 		expect(res.body).toContain('<GetInput');
+	});
+
+	it('speaks an apology when the orchestrator fails mid-turn', async () => {
+		const { app: built, repos } = await setup();
+		app = built;
+		vi.spyOn(repos.agentThreads, 'findByContact').mockRejectedValueOnce(new Error('db down'));
+		const res = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ Speech: 'When are you free?' }),
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.headers['content-type']).toContain('xml');
+		expect(res.body).toContain('something went wrong');
 	});
 
 	it('hangs up on calls for unknown numbers or from an account’s own number', async () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix / hardening — follow-up to the voice channel (#113), addressing the gemini and Codex review feedback that landed after the merge. All changes are confined to the voice route and its tests.

### Applied

- **Speak instead of erroring** (gemini): an unexpected failure (database, orchestrator) previously propagated to Fastify's JSON 500 handler, and Plivo drops the call abruptly on non-XML. Both webhooks now catch, log, and speak a brief apology so the call ends gracefully. Tested by injecting repository failures on both endpoints.
- **Decline restricted/anonymous callers at answer time** (gemini): a caller with no presentable number can never be recognized or booked — previously they were greeted, then hung up on a turn later.
- **Normalize spoken menu picks** (Codex): ASR often transcribes "option one" in words, which the core parser (digits after `option`) would re-offer instead of booking. The voice edge now maps `option/number + word` to digits, and the booking test exercises the spoken form end to end.
- **Explicit empty-number guards in `resolveAccount`**: defense in depth plus skipped lookups.

### Assessed, with notes

- gemini's **critical** finding (empty `To` matches unprovisioned accounts and leaks business names) doesn't reproduce in this codebase: both repository implementations already return `null` for empty-address lookups (`repositories/memory.ts:311`, `repositories/mongo.ts:488`), so no account match, name leak, or anonymous-caller blocking was possible through that path. The new explicit guards make the route safe on its own terms rather than relying on every implementation remembering that contract.
- Codex's **retry-key** suggestion (dedup key for voice turns) is deliberately not taken: Plivo sends no per-utterance id, and a synthetic `CallUUID+Speech` key would dedupe a caller legitimately repeating themselves (same words, same call) into a goodbye — worse than the rare timeout-retry replay it would catch, which lands on the already-booked thread as `confirm_existing` (`services/agent/engine.ts:115`), not a double booking. The rationale is now in the code.

`pnpm lint && pnpm type-check && pnpm test` pass — 899 API tests (3 new: dependency-failure apologies on both webhooks, anonymous-caller decline; the booking test now speaks "option one").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2)_