### PR TITLE
feat(api): migrate messaging to Twilio with per-number provider routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,14 +35,40 @@ AGENT_EMAIL_DOMAIN=riv.us
 # Base URL of the marketing website; used to build the customer self-signup link
 # (/customers/join/<slug>) the agent emails to unrecognized senders.
 WEBSITE_URL=https://rivus.ai
-# --- WhatsApp channel (zernio) ------------------------------------------------
-# Rivus assigns a WhatsApp Business number (via zernio) when an owner enables the
-# channel in settings, then answers over WhatsApp with the same scheduling agent
-# as email. zernio posts inbound messages to POST /v1/channels/whatsapp/inbound.
+# --- Phone-number channels: WhatsApp, SMS, voice -------------------------------
+# Rivus rents the account one number when an owner enables a channel in settings,
+# then answers over WhatsApp, SMS, and phone calls with the same scheduling agent
+# as email. Twilio is the primary provider; Plivo stays wired during the migration
+# for numbers it still owns (each outbound message routes through the number's
+# owner); zernio is the WhatsApp-only alternative. With nothing set, everything
+# degrades to no-ops (a deterministic fake number in development) so the API runs
+# without credentials. Full details per variable: packages/api/README.md.
+# Twilio (primary) — credentials from Console → Account Info. The auth token is
+# also the webhook signing key (X-Twilio-Signature): unset, dev/test accept
+# unsigned deliveries; production refuses the Twilio routes (503).
+# TWILIO_ACCOUNT_SID=ACxxxxxxxx
+# TWILIO_AUTH_TOKEN=xxxxxxxx
+# TWILIO_API_URL=https://api.twilio.com
+# Public URLs of the Twilio webhooks (pin signature verification behind proxies;
+# ride along on sends as the delivery-status callback; the SMS/voice ones are
+# attached to newly rented numbers at purchase).
+# TWILIO_WHATSAPP_WEBHOOK_URL=https://api.example.com/v1/channels/whatsapp/twilio/inbound
+# TWILIO_SMS_WEBHOOK_URL=https://api.example.com/v1/channels/sms/twilio/inbound
+# TWILIO_VOICE_WEBHOOK_URL=https://api.example.com/v1/channels/voice/twilio/answer
+# TWILIO_NUMBER_COUNTRY=US
+# Plivo (retained during the Twilio migration) — the auth token doubles as the
+# webhook signing key, like Twilio's.
+# PLIVO_AUTH_ID=MAxxxxxxxx
+# PLIVO_AUTH_TOKEN=xxxxxxxx
+# PLIVO_API_URL=https://api.plivo.com/v1
+# PLIVO_WEBHOOK_URL=https://api.example.com/v1/channels/whatsapp/plivo/inbound
+# PLIVO_SMS_WEBHOOK_URL=https://api.example.com/v1/channels/sms/plivo/inbound
+# PLIVO_NUMBER_COUNTRY=US
+# zernio (alternative WhatsApp provider; used when only its key is set). Inbound
+# webhook: POST /v1/channels/whatsapp/inbound.
 # Base URL of the zernio API (per zernio's docs).
 ZERNIO_API_URL=https://zernio.com/api/v1
-# zernio API key. When unset, WhatsApp degrades to a no-op sender + provisioner
-# (a deterministic fake number in development) so the API runs without credentials.
+# zernio API key.
 # ZERNIO_API_KEY=zk_xxxxxxxx
 # Signing secret for zernio's inbound webhook. When unset, dev/test accept unsigned
 # deliveries so you can drive the flow with curl; production refuses the webhook

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -381,7 +381,9 @@ reports flagging failures, and the no-op degradation without credentials.
    provider-owned WhatsApp number, SMS adopts that same number** instead of
    renting a second one (and vice versa — whichever channel is enabled first
    rents, the other shares); outbound texts leave through that number's owner.
-   Numbers neither phone provider owns (zernio's, dev fakes) are never shared.
+   Numbers neither phone provider owns (zernio's, dev fakes) are never shared,
+   and neither is a number whose owning provider is no longer configured — a
+   fresh number through the configured primary beats extending a dead one.
 4. US A2P traffic requires the number to be registered for **10DLC** in the
    provider's console before carriers accept application-originated texts — a
    one-time compliance step per brand/campaign, like the WABA registration for

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -294,7 +294,7 @@ numbers no longer provision through it while Twilio's credentials are set.
    Plivo's Numbers API. Registering that number to the WhatsApp Business Account
    (Meta's Embedded Signup in the Plivo console) is a one-time step per number
    that Plivo does not yet expose over the API — see `TODO(plivo)` in
-   `src/services/plivo-whatsapp.ts`.
+   `src/services/plivo.ts`.
 4. An account **owner** enables the channel — in the app (Settings → WhatsApp
    Business → On) or via `POST /v1/account/channels/whatsapp/enable`. Rivus
    provisions the number and starts answering; `…/disable` turns it off but

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -215,7 +215,7 @@ multi-turn state on an `AgentThread`, FAQ drafts, and the exchange mirrored into
 the inbox as a `whatsapp` conversation. None of that is re-implemented per
 channel — or per provider: each provider route owns only its edges (signature
 check and payload shape) and hands a canonical event to the shared dispatch
-(`routes/agent-whatsapp-shared.ts`), which resolves the account, applies the
+(`routes/agent-phone-shared.ts`), which resolves the account, applies the
 loop/unsupported guards, and calls the same `handleInboundAgentMessage` the
 email channel uses. See the "unified across channels" note in
 [AGENTS.md](../../AGENTS.md) for the layering.
@@ -226,18 +226,60 @@ Rivus sent fails to reach the customer, the conversation is flagged
 filter and a human can follow up another way — the same treatment as an email
 bounce.
 
-Two providers are wired behind the same seams (`WhatsappSender`,
-`ChannelProvisioner`): **Plivo** is the primary — chosen whenever its
-credentials are set — and **zernio** the alternative, used when only its key is
-set. With neither configured, both degrade to no-ops (a deterministic fake
+Three providers are wired behind the same seams (`WhatsappSender`, `SmsSender`,
+`ChannelProvisioner`): **Twilio** is the primary — new numbers provision through
+it whenever its credentials are set — **Plivo** stays fully wired during the
+migration off it (numbers it still owns keep working), and **zernio** is the
+WhatsApp-only alternative, used when only its key is set. Outbound sends are
+routed per message by the sending number's stored fingerprint (`providerRef`),
+so a mixed fleet of Twilio and Plivo numbers coexists safely mid-migration: a
+reply always leaves through the provider that owns the number it is sent from.
+With nothing configured, everything degrades to no-ops (a deterministic fake
 number in dev, sends dropped), so the whole flow still runs locally with `curl`
 and no credentials.
 
-#### Plivo (primary provider)
+#### Twilio (primary provider)
+
+Twilio fronts SMS and WhatsApp through one Messages API and one rented number
+(the `whatsapp:` address prefix selects the channel), and voice rides the same
+number via TwiML — one number per account carries all three channels.
+
+1. Set `TWILIO_ACCOUNT_SID` + `TWILIO_AUTH_TOKEN` (Console → Account Info), and
+   `TWILIO_API_URL` if it isn't the default.
+2. Webhooks: deliveries are verified with Twilio's `X-Twilio-Signature` scheme,
+   which signs **the exact request URL plus every form parameter** with the
+   auth token (no separate webhook secret). Set each channel's public URL so a
+   rewriting proxy can't break verification, and so sends carry a delivery
+   status callback:
+   - `TWILIO_WHATSAPP_WEBHOOK_URL` → `POST /v1/channels/whatsapp/twilio/inbound`
+   - `TWILIO_SMS_WEBHOOK_URL` → `POST /v1/channels/sms/twilio/inbound`
+   - `TWILIO_VOICE_WEBHOOK_URL` → `POST /v1/channels/voice/twilio/answer`
+3. Numbers: enabling a channel rents a voice+SMS-capable local number through
+   the IncomingPhoneNumbers API and — unlike Plivo — attaches the SMS and voice
+   webhooks **in the same purchase call** (`SmsUrl`, `VoiceUrl`), so no console
+   step is needed before texts and calls flow. WhatsApp still needs the number
+   registered as a WhatsApp sender against a WhatsApp Business Account;
+   Twilio's Senders API can do that programmatically, but it requires a WABA
+   link and an OTP round-trip — see `TODO(twilio)` in `src/services/twilio.ts`.
+4. An account **owner** enables each channel as described in its section;
+   `…/disable` turns it off but retains the number.
+
+| Variable                      | Default                   | Notes                                                                                                                 |
+| ----------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `TWILIO_ACCOUNT_SID`          | _(unset)_                 | Twilio account SID. Both credentials set ⇒ Twilio is the primary provider for every phone-number channel.              |
+| `TWILIO_AUTH_TOKEN`           | _(unset)_                 | Auth token — API auth **and** the webhook signing key. Unset: dev/test accept unsigned deliveries; **production refuses the Twilio routes (503)**. |
+| `TWILIO_API_URL`              | `https://api.twilio.com`  | Base URL of Twilio's REST API.                                                                                         |
+| `TWILIO_WHATSAPP_WEBHOOK_URL` | _(unset)_                 | Public URL of the Twilio WhatsApp webhook. Pins signature verification behind proxies and rides along on sends as the status callback. Unset: the URL is derived per-request and sends carry no callback. |
+| `TWILIO_SMS_WEBHOOK_URL`      | _(unset)_                 | The SMS counterpart, with the same two roles — and attached to newly rented numbers as their inbound `SmsUrl`.         |
+| `TWILIO_VOICE_WEBHOOK_URL`    | _(unset)_                 | Public URL of the voice **answer** webhook — attached to newly rented numbers as their `VoiceUrl`. The input webhook's URL (the `<Gather action>`) is derived from it. |
+| `TWILIO_NUMBER_COUNTRY`       | `US`                      | ISO 3166-1 alpha-2 country whose numbers the provisioner rents.                                                        |
+
+#### Plivo (retained during the Twilio migration)
 
 Plivo fronts SMS, MMS, and WhatsApp through one Messages API and one rented
-number, which is why it's the primary: when the SMS and voice channels are
-built, the same Plivo account and the same per-account number will carry them.
+number. It was the original primary; during the migration it stays fully wired
+so accounts still holding Plivo numbers keep sending and receiving — but new
+numbers no longer provision through it while Twilio's credentials are set.
 
 1. Set `PLIVO_AUTH_ID` + `PLIVO_AUTH_TOKEN` (Console → API keys), and
    `PLIVO_API_URL` if it isn't the default.
@@ -260,7 +302,7 @@ built, the same Plivo account and the same per-account number will carry them.
 
 | Variable               | Default                    | Notes                                                                                                                 |
 | ---------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `PLIVO_AUTH_ID`        | _(unset)_                  | Plivo account auth ID. Both credentials set ⇒ Plivo is the active WhatsApp provider.                                   |
+| `PLIVO_AUTH_ID`        | _(unset)_                  | Plivo account auth ID. Both credentials set ⇒ Plivo serves the numbers it owns (and is the primary when Twilio is unconfigured). |
 | `PLIVO_AUTH_TOKEN`     | _(unset)_                  | Plivo auth token — API auth **and** the webhook signing key. Unset: dev/test accept unsigned deliveries; **production refuses the Plivo route (503)**. |
 | `PLIVO_API_URL`        | `https://api.plivo.com/v1` | Base URL of Plivo's REST API.                                                                                          |
 | `PLIVO_WEBHOOK_URL`    | _(unset)_                  | The public URL of the Plivo WhatsApp webhook route. Pins signature verification behind proxies and rides along on sends as the status callback. Unset: the URL is derived per-request and sends carry no callback. |
@@ -269,7 +311,8 @@ built, the same Plivo account and the same per-account number will carry them.
 
 #### zernio (alternative provider)
 
-Used when `ZERNIO_API_KEY` is set and the Plivo credentials are not.
+Used when `ZERNIO_API_KEY` is set and neither Twilio's nor Plivo's credentials
+are.
 
 1. Set `ZERNIO_API_KEY` (and `ZERNIO_API_URL` if it isn't the default).
 2. In zernio, point an inbound webhook at `POST /v1/channels/whatsapp/inbound` and
@@ -284,7 +327,7 @@ Used when `ZERNIO_API_KEY` is set and the Plivo credentials are not.
 | Variable                | Default                  | Notes                                                                                                                   |
 | ----------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
 | `ZERNIO_API_URL`        | `https://zernio.com/api/v1` | Base URL of the zernio API (per zernio's docs).                                                                     |
-| `ZERNIO_API_KEY`        | _(unset)_                | Unset: WhatsApp falls back as described above (Plivo when configured, else the no-ops).                                |
+| `ZERNIO_API_KEY`        | _(unset)_                | Unset: WhatsApp falls back as described above (Twilio/Plivo when configured, else the no-ops).                         |
 | `ZERNIO_WEBHOOK_SECRET` | _(unset)_                | zernio webhook signing secret; the route verifies the `X-Zernio-Signature` (raw-body HMAC-SHA256) header. Unset: dev/test accept unsigned deliveries; **production refuses the route (503)**. |
 | `ZERNIO_VERIFY_TOKEN`   | _(unset)_                | Verify token for the `GET` registration handshake. Unset: that handshake endpoint 404s.                               |
 
@@ -315,56 +358,65 @@ are **text only** (media/location messages get no reply).
 >   *connect credentials + select a number* rather than *provision a new number* —
 >   so `ZernioProvisioner` may need rethinking, not just endpoint tweaks.
 >
-> Until then, use Plivo (or the no-op path) to exercise the flow end-to-end.
+> Until then, use Twilio or Plivo (or the no-op path) to exercise the flow
+> end-to-end.
 
-### SMS channel (Plivo)
+### SMS channel
 
-The same scheduling agent also answers over **SMS**, through the same Plivo
+The same scheduling agent also answers over **SMS**, through the same provider
 account, adapters, and — when both channels are on — the same number as
 WhatsApp. Everything about the WhatsApp channel above applies unchanged: the
 shared webhook dispatch, the inbox mirroring (an `sms` conversation), delivery
 reports flagging failures, and the no-op degradation without credentials.
 
-1. Same credentials as WhatsApp (`PLIVO_AUTH_ID` + `PLIVO_AUTH_TOKEN`).
-2. Point the number's message webhook at `POST /v1/channels/sms/plivo/inbound`
-   (in the Plivo console, the application attached to the number) and set
-   `PLIVO_SMS_WEBHOOK_URL` to that exact public URL.
+1. Same credentials as WhatsApp (Twilio is the primary; Plivo serves the
+   numbers it still owns).
+2. Inbound webhook: Twilio numbers are wired at purchase — the provisioner
+   attaches `TWILIO_SMS_WEBHOOK_URL` (→ `POST /v1/channels/sms/twilio/inbound`)
+   as the number's `SmsUrl`. Plivo numbers point their application's message
+   webhook at `POST /v1/channels/sms/plivo/inbound` in the console, pinned with
+   `PLIVO_SMS_WEBHOOK_URL`.
 3. An owner enables the channel (app: Settings → Text messages, or
    `POST /v1/account/channels/sms/enable`). **If the account already holds a
-   Plivo-owned WhatsApp number, SMS adopts that same number** instead of
+   provider-owned WhatsApp number, SMS adopts that same number** instead of
    renting a second one (and vice versa — whichever channel is enabled first
-   rents, the other shares). Numbers Plivo doesn't own (zernio's, dev fakes)
-   are never shared.
+   rents, the other shares); outbound texts leave through that number's owner.
+   Numbers neither phone provider owns (zernio's, dev fakes) are never shared.
 4. US A2P traffic requires the number to be registered for **10DLC** in the
-   Plivo console before carriers accept application-originated texts — a
+   provider's console before carriers accept application-originated texts — a
    one-time compliance step per brand/campaign, like the WABA registration for
    WhatsApp.
 
-### Voice channel (Plivo)
+### Voice channel
 
 The same scheduling agent also **answers phone calls** on the same number,
-turn-based on Plivo's Voice API: the call hits the answer webhook, Rivus greets
-and listens (`<GetInput inputType="speech">`), and each transcribed utterance
-runs through the identical channel-agnostic orchestrator — thread state, inbox
-mirroring (a `phone` conversation with a full transcript), booking — with the
-reply spoken back in the response XML. The call ends after a terminal outcome
-(booked, confirmed, or directed to self-signup); anything else loops the
-listen. Unknown callers are recognized by phone exactly like SMS/WhatsApp.
+turn-based: the call hits the answer webhook, Rivus greets and listens (Twilio
+`<Gather input="speech">`, Plivo `<GetInput inputType="speech">`), and each
+transcribed utterance runs through the identical channel-agnostic
+orchestrator — thread state, inbox mirroring (a `phone` conversation with a
+full transcript), booking — with the reply spoken back in the response
+document. Both provider routes share one voice core
+(`routes/agent-voice-shared.ts`) — account resolution, guards, spoken wording,
+and turn policy can't drift between dialects. The call ends after a terminal
+outcome (booked, confirmed, or directed to self-signup); anything else loops
+the listen. Unknown callers are recognized by phone exactly like SMS/WhatsApp.
 
-1. Same credentials as the other channels (`PLIVO_AUTH_ID` + `PLIVO_AUTH_TOKEN`);
-   deliveries are verified with the same V2 signature scheme (no extra config —
-   the signed URL is reconstructed per request).
-2. In the Plivo console, create an **Application** with `answer_url` =
-   `POST /v1/channels/voice/plivo/answer` (public URL) and attach it to the
-   account's number. The same application's `message_url` can point at the SMS
-   webhook — one application wires both. TODO(plivo): automate the application
-   attach via the Numbers API when the channel is enabled.
+1. Same credentials as the other channels; deliveries are verified with each
+   provider's signature scheme. Twilio pins the answer endpoint with
+   `TWILIO_VOICE_WEBHOOK_URL` and derives the input endpoint's URL (the
+   `<Gather action>`) from it; Plivo reconstructs each signed URL per request.
+2. Wiring: Twilio numbers get `TWILIO_VOICE_WEBHOOK_URL` (→
+   `POST /v1/channels/voice/twilio/answer`) attached as their `VoiceUrl` at
+   purchase — no console step. Plivo numbers need an **Application** with
+   `answer_url` = `POST /v1/channels/voice/plivo/answer` attached in the
+   console (its `message_url` can point at the SMS webhook — one application
+   wires both; TODO(plivo): automate the attach via the Numbers API).
 3. An owner enables the channel (app: Settings → Phone calls, or
    `POST /v1/account/channels/voice/enable`). The account's existing
-   Plivo-owned WhatsApp/SMS number is adopted — calls, texts, and WhatsApp all
-   share one number — or a fresh voice+SMS number is rented.
+   provider-owned WhatsApp/SMS number is adopted — calls, texts, and WhatsApp
+   all share one number — or a fresh voice+SMS number is rented.
 4. No extra registration: unlike WhatsApp (WABA) and US SMS (10DLC), inbound
-   voice works as soon as the application is attached to the number.
+   voice works as soon as the webhook is attached to the number.
 
 Voice replies record in the inbox like every channel, but `phone`
 conversations have no reply-out transport (there is no live call to push a

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -4607,6 +4607,202 @@
         }
       }
     },
+    "/v1/channels/whatsapp/twilio/inbound": {
+      "post": {
+        "summary": "Twilio WhatsApp webhook (inbound customer messages + delivery status)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Twilio delivers events for the account’s provisioned number here: inbound customer messages, and status callbacks for messages Rivus sent. The agent handles the message exactly like the other provider edges; the response is always the empty TwiML acknowledgment Twilio expects, with the handling outcome recorded in the logs. Deliveries are authenticated with the X-Twilio-Signature header when TWILIO_AUTH_TOKEN is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/sms/twilio/inbound": {
+      "post": {
+        "summary": "Twilio SMS webhook (inbound customer texts + delivery status)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Twilio delivers events for the account’s provisioned number here: inbound customer messages, and status callbacks for messages Rivus sent. The agent handles the message exactly like the other provider edges; the response is always the empty TwiML acknowledgment Twilio expects, with the handling outcome recorded in the logs. Deliveries are authenticated with the X-Twilio-Signature header when TWILIO_AUTH_TOKEN is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/voice/twilio/answer": {
+      "post": {
+        "summary": "Twilio voice webhook — answers an inbound call (VoiceUrl)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Twilio requests this URL when someone calls the account’s provisioned number (the number’s VoiceUrl, attached at purchase). The response TwiML greets the caller and listens for speech; each utterance is transcribed and posted to the input webhook. Deliveries are authenticated with the X-Twilio-Signature header when TWILIO_AUTH_TOKEN is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/voice/twilio/input": {
+      "post": {
+        "summary": "Twilio voice webhook — one transcribed caller utterance (Gather action)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Gather posts each transcribed utterance here. The utterance runs through the same channel-agnostic scheduling orchestrator as every other channel (threads, inbox mirroring as a phone conversation, booking); the response TwiML speaks the agent’s reply and either listens for the next turn or ends the call on a terminal outcome.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/channels/whatsapp/plivo/inbound": {
       "post": {
         "summary": "Plivo WhatsApp webhook (inbound customer messages + delivery status)",

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -15,8 +15,10 @@ import { accountRoutes } from './routes/account';
 import { accountChannelRoutes } from './routes/account-channels';
 import { adminRoutes } from './routes/admin';
 import { agentEmailRoutes } from './routes/agent-email';
+import { agentSmsTwilioRoutes, agentWhatsappTwilioRoutes } from './routes/agent-messaging-twilio';
 import { agentSmsPlivoRoutes } from './routes/agent-sms-plivo';
 import { agentVoicePlivoRoutes } from './routes/agent-voice-plivo';
+import { agentVoiceTwilioRoutes } from './routes/agent-voice-twilio';
 import { agentWhatsappRoutes } from './routes/agent-whatsapp';
 import { agentWhatsappPlivoRoutes } from './routes/agent-whatsapp-plivo';
 import { authRoutes } from './routes/auth';
@@ -201,6 +203,12 @@ export function buildApp(deps: AppDeps): FastifyInstance {
 	app.register(publicRoutes, { prefix: '/v1/public' });
 	app.register(agentEmailRoutes, { prefix: '/v1/channels' });
 	app.register(agentWhatsappRoutes, { prefix: '/v1/channels' });
+	// Every provider's webhook edge stays registered side by side — Twilio (the
+	// primary), Plivo (numbers it still owns during the migration), zernio — so
+	// a mixed number fleet keeps every inbound path live.
+	app.register(agentWhatsappTwilioRoutes, { prefix: '/v1/channels' });
+	app.register(agentSmsTwilioRoutes, { prefix: '/v1/channels' });
+	app.register(agentVoiceTwilioRoutes, { prefix: '/v1/channels' });
 	app.register(agentWhatsappPlivoRoutes, { prefix: '/v1/channels' });
 	app.register(agentSmsPlivoRoutes, { prefix: '/v1/channels' });
 	app.register(agentVoicePlivoRoutes, { prefix: '/v1/channels' });

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -71,7 +71,30 @@ const envSchema = z
 		// Verify token for the GET webhook handshake some WhatsApp providers require
 		// to register a webhook URL. When unset, the handshake endpoint 404s.
 		ZERNIO_VERIFY_TOKEN: z.string().min(1).optional(),
-		// --- WhatsApp channel (Plivo, the primary provider) ---
+		// --- Messaging channels (Twilio, the primary provider) ---
+		// Twilio account credentials (Console → Account Info). When both are set,
+		// Twilio is the primary provider for WhatsApp, SMS, and voice: new numbers
+		// are provisioned there and its webhooks verify with the auth token
+		// (X-Twilio-Signature). Numbers other providers still own keep sending
+		// through their owner — outbound routes per account by providerRef — so a
+		// Plivo fleet keeps working mid-migration.
+		TWILIO_ACCOUNT_SID: z.string().min(1).optional(),
+		TWILIO_AUTH_TOKEN: z.string().min(1).optional(),
+		// Base URL of Twilio's REST API; the account-scoped resource paths hang off it.
+		TWILIO_API_URL: z.url().default('https://api.twilio.com'),
+		// The public URLs of this API's Twilio webhooks, i.e. exactly what is
+		// configured in Twilio (per number / per WhatsApp sender). Same two roles as
+		// the Plivo equivalents: they pin the URL signature validation recomputes,
+		// and they ride along on sends as the delivery-status callback. When unset,
+		// verification derives the URL from the request and sends carry no callback.
+		TWILIO_WHATSAPP_WEBHOOK_URL: z.url().optional(),
+		TWILIO_SMS_WEBHOOK_URL: z.url().optional(),
+		// The voice webhook's public URL (the number's VoiceUrl); pins signature
+		// validation for the answer/input endpoints' shared origin.
+		TWILIO_VOICE_WEBHOOK_URL: z.url().optional(),
+		// ISO 3166-1 alpha-2 country whose numbers the Twilio provisioner rents.
+		TWILIO_NUMBER_COUNTRY: z.string().length(2).default('US'),
+		// --- WhatsApp channel (Plivo, retained during the Twilio migration) ---
 		// Plivo account credentials (Console → API keys). When both are set, Plivo is
 		// the active WhatsApp provider — sender and number provisioner — and the Plivo
 		// webhook verifies deliveries with the auth token (Plivo signs URL + nonce

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -76,8 +76,8 @@ const envSchema = z
 		// Twilio is the primary provider for WhatsApp, SMS, and voice: new numbers
 		// are provisioned there and its webhooks verify with the auth token
 		// (X-Twilio-Signature). Numbers other providers still own keep sending
-		// through their owner — outbound routes per account by providerRef — so a
-		// Plivo fleet keeps working mid-migration.
+		// through their owner — each outbound message routes by its sending
+		// number's providerRef — so a Plivo fleet keeps working mid-migration.
 		TWILIO_ACCOUNT_SID: z.string().min(1).optional(),
 		TWILIO_AUTH_TOKEN: z.string().min(1).optional(),
 		// Base URL of Twilio's REST API; the account-scoped resource paths hang off it.
@@ -95,11 +95,12 @@ const envSchema = z
 		// ISO 3166-1 alpha-2 country whose numbers the Twilio provisioner rents.
 		TWILIO_NUMBER_COUNTRY: z.string().length(2).default('US'),
 		// --- WhatsApp channel (Plivo, retained during the Twilio migration) ---
-		// Plivo account credentials (Console → API keys). When both are set, Plivo is
-		// the active WhatsApp provider — sender and number provisioner — and the Plivo
-		// webhook verifies deliveries with the auth token (Plivo signs URL + nonce
-		// with it; there is no separate webhook secret). When unset, WhatsApp falls
-		// back to zernio (above), else to a no-op — mirroring the Resend gate.
+		// Plivo account credentials (Console → API keys). When both are set, Plivo
+		// serves the numbers it still owns (and is the primary provider only while
+		// Twilio is unconfigured), and the Plivo webhooks verify deliveries with the
+		// auth token (Plivo signs URL + nonce with it; there is no separate webhook
+		// secret). When unset, WhatsApp falls back to zernio (above), else to a
+		// no-op — mirroring the Resend gate.
 		PLIVO_AUTH_ID: z.string().min(1).optional(),
 		PLIVO_AUTH_TOKEN: z.string().min(1).optional(),
 		// Base URL of Plivo's REST API; the account-scoped resource paths hang off it.

--- a/packages/api/src/routes/account-channels.ts
+++ b/packages/api/src/routes/account-channels.ts
@@ -8,6 +8,7 @@ import { toPublicAccount } from '../presenters';
 import { ConflictError } from '../repositories/errors';
 import type { ChannelProvisioner, ProvisionedIdentifier } from '../services/channel-provisioning';
 import { plivoOwnedIdentifier } from '../services/plivo';
+import { twilioOwnedIdentifier } from '../services/twilio';
 
 /**
  * Owner-only provisioning of a messaging channel. Enabling calls the provider to
@@ -17,9 +18,11 @@ import { plivoOwnedIdentifier } from '../services/plivo';
  * derived, always on); WhatsApp, SMS, and voice are all provisionable.
  *
  * One number, every channel: when a channel is enabled and a sibling already
- * holds a Plivo-owned number, that number is adopted instead of renting a
- * second one — Plivo fronts WhatsApp, SMS, and voice on the same number. Numbers Plivo does not own (zernio's, the dev fakes) are never
- * shared onto a channel Plivo would have to send from.
+ * holds a number the phone providers own (Twilio's, or Plivo's during the
+ * migration), that number is adopted instead of renting a second one — both
+ * providers front WhatsApp, SMS, and voice on the same number, and outbound
+ * sends route by the number's owner. Numbers neither owns (zernio's, the dev
+ * fakes) are never shared onto a channel they would have to send from.
  */
 
 const channelParamsSchema = z.object({ channel: provisionedChannelSchema });
@@ -37,22 +40,27 @@ function isProvisionable(channel: string): channel is ProvisionableChannel {
  * predicates the sender/provisioner factories use (`messaging-provider.ts`).
  */
 function providerConfigured(config: Config, channel: ProvisionableChannel): boolean {
+	const twilio = Boolean(config.TWILIO_ACCOUNT_SID && config.TWILIO_AUTH_TOKEN);
 	const plivo = Boolean(config.PLIVO_AUTH_ID && config.PLIVO_AUTH_TOKEN);
-	// Only WhatsApp has an alternative provider (zernio); SMS and voice are Plivo-only.
-	return channel === 'whatsapp' ? plivo || Boolean(config.ZERNIO_API_KEY) : plivo;
+	// Only WhatsApp has an alternative provider (zernio); SMS and voice need a
+	// phone-number provider (Twilio, or Plivo during the migration).
+	return channel === 'whatsapp'
+		? twilio || plivo || Boolean(config.ZERNIO_API_KEY)
+		: twilio || plivo;
 }
 
 /**
  * The identifier to hand the provisioner: the channel's own (idempotent
- * re-enable), else a sibling channel's Plivo-owned number (adopted, so both
- * channels share one number), else empty (a fresh rental).
+ * re-enable), else a sibling channel's provider-owned number (adopted, so both
+ * channels share one number — outbound routing sends through whichever
+ * provider the fingerprint names), else empty (a fresh rental).
  *
  * Known race, accepted: two enables for the same account arriving together can
  * each read empty siblings and rent two numbers. The app serializes its
  * toggles (one busy request at a time), so the residual window is a deliberate
- * double-submit; recovery is releasing the extra number in the Plivo console.
- * Closing it fully needs a per-account claim/lock this API deliberately
- * doesn't have.
+ * double-submit; recovery is releasing the extra number in the provider's
+ * console. Closing it fully needs a per-account claim/lock this API
+ * deliberately doesn't have.
  */
 function existingOrShared(account: Account, channel: ProvisionableChannel): ProvisionedIdentifier {
 	const own = account.channels[channel];
@@ -63,7 +71,9 @@ function existingOrShared(account: Account, channel: ProvisionableChannel): Prov
 		if (sibling === channel) {
 			continue;
 		}
-		const shared = plivoOwnedIdentifier(account.channels[sibling]);
+		const shared =
+			twilioOwnedIdentifier(account.channels[sibling]) ??
+			plivoOwnedIdentifier(account.channels[sibling]);
 		if (shared) {
 			return shared;
 		}

--- a/packages/api/src/routes/account-channels.ts
+++ b/packages/api/src/routes/account-channels.ts
@@ -55,6 +55,15 @@ function providerConfigured(config: Config, channel: ProvisionableChannel): bool
  * channels share one number — outbound routing sends through whichever
  * provider the fingerprint names), else empty (a fresh rental).
  *
+ * A sibling's number is adopted only while its owning provider is configured.
+ * With the owner's credentials gone (Plivo's, say, after the migration
+ * finishes), that number can neither send (outbound would fall to the primary
+ * and be rejected as not the primary's number) nor receive (the owner's
+ * webhook gate refuses deliveries it can't answer) — adopting it would 200
+ * the enable onto a dead channel. Renting fresh through the configured
+ * primary keeps the new channel working; the sibling's number splits off
+ * until it too is migrated.
+ *
  * Known race, accepted: two enables for the same account arriving together can
  * each read empty siblings and rent two numbers. The app serializes its
  * toggles (one busy request at a time), so the residual window is a deliberate
@@ -62,18 +71,24 @@ function providerConfigured(config: Config, channel: ProvisionableChannel): bool
  * console. Closing it fully needs a per-account claim/lock this API
  * deliberately doesn't have.
  */
-function existingOrShared(account: Account, channel: ProvisionableChannel): ProvisionedIdentifier {
+function existingOrShared(
+	config: Config,
+	account: Account,
+	channel: ProvisionableChannel,
+): ProvisionedIdentifier {
 	const own = account.channels[channel];
 	if (own.address !== '') {
 		return { address: own.address, providerRef: own.providerRef };
 	}
+	const twilio = Boolean(config.TWILIO_ACCOUNT_SID && config.TWILIO_AUTH_TOKEN);
+	const plivo = Boolean(config.PLIVO_AUTH_ID && config.PLIVO_AUTH_TOKEN);
 	for (const sibling of PROVISIONABLE) {
 		if (sibling === channel) {
 			continue;
 		}
 		const shared =
-			twilioOwnedIdentifier(account.channels[sibling]) ??
-			plivoOwnedIdentifier(account.channels[sibling]);
+			(twilio ? twilioOwnedIdentifier(account.channels[sibling]) : null) ??
+			(plivo ? plivoOwnedIdentifier(account.channels[sibling]) : null);
 		if (shared) {
 			return shared;
 		}
@@ -145,7 +160,7 @@ export const accountChannelRoutes: FastifyPluginAsync = async (fastify) => {
 				provisioned = await provisioners[channel].provision({
 					accountId,
 					accountName: account.name,
-					existing: existingOrShared(account, channel),
+					existing: existingOrShared(config, account, channel),
 				});
 			} catch (error) {
 				request.log.error({ err: error, channel }, 'channel provisioning failed');

--- a/packages/api/src/routes/agent-messaging-twilio.ts
+++ b/packages/api/src/routes/agent-messaging-twilio.ts
@@ -1,0 +1,151 @@
+import type { FastifyPluginAsync } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import type { Config } from '../config';
+import { errorResponseSchema } from '../http-schemas';
+import { defaultCapabilities } from '../services/agent/capabilities';
+import type { ChannelAdapter } from '../services/agent/channel';
+import { createSmsChannelAdapter } from '../services/agent/sms/adapter';
+import { parseTwilioInbound, type TwilioChannel } from '../services/agent/twilio-inbound';
+import { createWhatsappChannelAdapter } from '../services/agent/whatsapp/adapter';
+import type { AppDeps } from '../types';
+import { dispatchPhoneChannelEvent } from './agent-phone-shared';
+import { twilioWebhookAuthHook } from './twilio-webhook-auth';
+import { formUrlencodedParser } from './webhook-http';
+
+/**
+ * The Twilio edges of the scheduling agent's WhatsApp and SMS channels — one
+ * builder, two registered plugins, because the payloads differ only by the
+ * `whatsapp:` address prefix. Twilio posts two kinds of deliveries to each
+ * hook: inbound customer messages and status callbacks for Rivus's own sends
+ * (the StatusCallback URL the senders attach). Each route owns only the
+ * Twilio edges — the shared signature gate and the payload shape — then hands
+ * the canonical event to {@link dispatchPhoneChannelEvent}, the same shared
+ * body the Plivo and zernio routes use.
+ *
+ * One Twilio-specific contract: these webhooks answer with **empty TwiML**
+ * (`<Response/>`, text/xml), never JSON — Twilio texts a `text/plain` body
+ * back to the customer, and it expects a TwiML instruction set in reply. The
+ * dispatch outcome is logged instead of returned.
+ */
+
+/** Twilio-required acknowledgment: an empty TwiML instruction set. */
+const EMPTY_TWIML = '<Response/>';
+
+function buildTwilioMessagingRoutes(options: {
+	channel: TwilioChannel;
+	path: string;
+	summary: string;
+	pinnedUrl: (config: Config) => string | undefined;
+	adapter: (deps: AppDeps) => ChannelAdapter;
+}): FastifyPluginAsync {
+	return async (fastify) => {
+		const app = fastify.withTypeProvider<ZodTypeProvider>();
+		const deps = app.deps;
+		const { config, accounts, conversations, agentThreads, memberships, notifier, jobs } = deps;
+
+		const adapter = options.adapter(deps);
+		const capabilities = defaultCapabilities();
+		const dispatchDeps = {
+			config,
+			accounts,
+			conversations,
+			agentThreads,
+			memberships,
+			notifier,
+			jobs,
+		};
+
+		app.addContentTypeParser(
+			'application/x-www-form-urlencoded',
+			{ parseAs: 'string' },
+			formUrlencodedParser,
+		);
+		app.addHook('preValidation', twilioWebhookAuthHook(app, options.pinnedUrl(config)));
+
+		app.post(
+			options.path,
+			{
+				schema: {
+					tags: ['channels'],
+					summary: options.summary,
+					description:
+						'Twilio delivers events for the account’s provisioned number here: inbound ' +
+						'customer messages, and status callbacks for messages Rivus sent. The agent ' +
+						'handles the message exactly like the other provider edges; the response is ' +
+						'always the empty TwiML acknowledgment Twilio expects, with the handling ' +
+						'outcome recorded in the logs. Deliveries are authenticated with the ' +
+						'X-Twilio-Signature header when TWILIO_AUTH_TOKEN is configured.',
+					body: z.unknown(),
+					response: {
+						200: z.string(),
+						401: errorResponseSchema,
+						503: errorResponseSchema,
+					},
+				},
+			},
+			async (request, reply) => {
+				reply.type('text/xml');
+				const result = parseTwilioInbound(request.body, options.channel);
+				if (result.kind === 'unrecognized') {
+					request.log.info(
+						{ channel: options.channel, outcome: 'unrecognized_payload' },
+						'twilio webhook',
+					);
+					return EMPTY_TWIML;
+				}
+				if (result.kind === 'ignored') {
+					request.log.info(
+						{ channel: options.channel, outcome: 'ignored_event_type' },
+						'twilio webhook',
+					);
+					return EMPTY_TWIML;
+				}
+				try {
+					const outcome = await dispatchPhoneChannelEvent({
+						deps: dispatchDeps,
+						channel: options.channel,
+						adapter,
+						capabilities,
+						event: result.event,
+						logger: request.log,
+					});
+					request.log.info({ channel: options.channel, ...outcome }, 'twilio webhook');
+				} catch (error) {
+					// Unlike Plivo, Twilio never redelivers on an error status (its retries
+					// cover connection failures only), so a 5xx buys no durability here — it
+					// would only swap this ack for provider-side error noise. Log the loss
+					// loudly, with enough context to recover the message by hand.
+					request.log.error(
+						{
+							err: error,
+							channel: options.channel,
+							event: result.event.type,
+							from: result.event.data.from,
+							to: result.event.data.to,
+						},
+						'twilio webhook dispatch failed',
+					);
+				}
+				return EMPTY_TWIML;
+			},
+		);
+	};
+}
+
+export const agentWhatsappTwilioRoutes = buildTwilioMessagingRoutes({
+	channel: 'whatsapp',
+	path: '/whatsapp/twilio/inbound',
+	summary: 'Twilio WhatsApp webhook (inbound customer messages + delivery status)',
+	pinnedUrl: (config) => config.TWILIO_WHATSAPP_WEBHOOK_URL,
+	adapter: (deps) =>
+		createWhatsappChannelAdapter({ customers: deps.customers, sender: deps.whatsappSender }),
+});
+
+export const agentSmsTwilioRoutes = buildTwilioMessagingRoutes({
+	channel: 'sms',
+	path: '/sms/twilio/inbound',
+	summary: 'Twilio SMS webhook (inbound customer texts + delivery status)',
+	pinnedUrl: (config) => config.TWILIO_SMS_WEBHOOK_URL,
+	adapter: (deps) => createSmsChannelAdapter({ customers: deps.customers, sender: deps.smsSender }),
+});

--- a/packages/api/src/routes/agent-sms-plivo.ts
+++ b/packages/api/src/routes/agent-sms-plivo.ts
@@ -6,7 +6,8 @@ import { defaultCapabilities } from '../services/agent/capabilities';
 import { parsePlivoInbound } from '../services/agent/plivo-inbound';
 import { createSmsChannelAdapter } from '../services/agent/sms/adapter';
 import { channelWebhookResponseSchema, dispatchPhoneChannelEvent } from './agent-phone-shared';
-import { plivoFormBodyParser, plivoWebhookAuthHook } from './plivo-webhook-auth';
+import { plivoWebhookAuthHook } from './plivo-webhook-auth';
+import { formUrlencodedParser } from './webhook-http';
 
 /**
  * The Plivo edge of the scheduling agent's SMS channel — the mirror of the
@@ -52,7 +53,7 @@ export const agentSmsPlivoRoutes: FastifyPluginAsync = async (fastify) => {
 	app.addContentTypeParser(
 		'application/x-www-form-urlencoded',
 		{ parseAs: 'string' },
-		plivoFormBodyParser,
+		formUrlencodedParser,
 	);
 	app.addHook('onRequest', plivoWebhookAuthHook(app, config.PLIVO_SMS_WEBHOOK_URL));
 

--- a/packages/api/src/routes/agent-voice-plivo.ts
+++ b/packages/api/src/routes/agent-voice-plivo.ts
@@ -1,60 +1,34 @@
-import { type Account, normalizePhone } from '@rivus/core';
+import { normalizePhone } from '@rivus/core';
 import type { FastifyPluginAsync } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { errorResponseSchema } from '../http-schemas';
 import { defaultCapabilities } from '../services/agent/capabilities';
-import { handleInboundAgentMessage } from '../services/agent/orchestrator';
-import { createVoiceChannelAdapter } from '../services/agent/voice/adapter';
-import { plivoFormBodyParser, plivoWebhookAuthHook, requestOrigin } from './plivo-webhook-auth';
+import {
+	resolveVoiceAccount,
+	runVoiceTurn,
+	VOICE_LINES,
+	voiceGreeting,
+	xmlEscape,
+} from './agent-voice-shared';
+import { plivoWebhookAuthHook } from './plivo-webhook-auth';
+import { formUrlencodedParser, requestOrigin } from './webhook-http';
 
 /**
- * The Plivo edge of the scheduling agent's voice channel — the one channel
- * whose replies are SYNCHRONOUS: Plivo calls these webhooks and the call is
- * driven by the XML each response returns. A call arrives at the number's
- * `answer_url` (the answer route below), which greets the caller and listens
- * with `<GetInput inputType="speech">`; each transcribed utterance then POSTs
- * to the input route, which runs the same channel-agnostic orchestrator every
- * other channel uses — thread state, inbox mirroring (a `phone` conversation),
- * booking — and speaks the rendered reply back, looping the listen until the
- * conversation reaches a terminal outcome (booked, confirmed, or sent to
- * signup) and the call ends.
+ * The Plivo edge of the scheduling agent's voice channel. A call arrives at
+ * the number's `answer_url` (the answer route), which greets the caller and
+ * listens with `<GetInput inputType="speech">`; each transcribed utterance
+ * POSTs to the input route. This route owns only the Plivo dialect — field
+ * names and Plivo XML — and hands normalized numbers and speech to the shared
+ * voice core (`./agent-voice-shared`), the same core the Twilio route uses.
  *
- * v1 is turn-based (speak, listen, repeat) on the classic Voice API — a smart
- * receptionist cadence, not barge-in realtime speech. The channel plumbing
- * built here (provisioning, transcripts, guards) carries over unchanged if the
- * conversation loop later moves to Plivo Audio Streaming.
+ * v1 is turn-based (speak, listen, repeat) — a smart receptionist cadence,
+ * not barge-in realtime speech. The channel plumbing carries over unchanged
+ * if the conversation loop later moves to audio streaming.
  */
 
 /** The absolute path of the input webhook (`GetInput action`), under the app's mount. */
 const INPUT_PATH = '/v1/channels/voice/plivo/input';
-
-/** Outcomes after which the call ends instead of listening for another turn. */
-const TERMINAL_OUTCOMES = new Set(['book', 'confirm_existing', 'send_signup_link']);
-
-const GOODBYE = 'Thanks for calling. Goodbye!';
-const NO_INPUT = "I didn't catch anything — call back anytime. Goodbye!";
-const NOT_IN_SERVICE = "Sorry, this number isn't in service. Goodbye!";
-const ANONYMOUS =
-	"Sorry, we can't take calls from restricted or anonymous numbers. Please call back with caller I D enabled. Goodbye!";
-// Spoken with HTTP 200 instead of erroring — deliberately. These webhooks are
-// call-flow ACTION URLs, not async status callbacks: the response XML drives a
-// live call, so a non-200 buys no durable retry (Plivo's retry-on-non-200
-// applies to status callbacks like hangup_url; a live caller can't be parked
-// while the service recovers). Erroring would replace this polite goodbye with
-// Plivo's generic mid-call failure handling; "call back in a few minutes" IS
-// the retry path for a human on the phone.
-const APOLOGY =
-	'Sorry, something went wrong on our end. Please call back in a few minutes. Goodbye!';
-
-function xmlEscape(text: string): string {
-	return text
-		.replaceAll('&', '&amp;')
-		.replaceAll('<', '&lt;')
-		.replaceAll('>', '&gt;')
-		.replaceAll('"', '&quot;')
-		.replaceAll("'", '&apos;');
-}
 
 /** A closing document: speak, then Plivo ends the call at the end of the XML. */
 function speakDocument(text: string): string {
@@ -72,38 +46,9 @@ function listenDocument(prompt: string, actionUrl: string): string {
 		`<GetInput action="${xmlEscape(actionUrl)}" method="POST" inputType="speech" language="en-US" hints="option,one,two,three,four,five,tomorrow,morning,afternoon">` +
 		`<Speak>${xmlEscape(prompt)}</Speak>` +
 		'</GetInput>' +
-		`<Speak>${xmlEscape(NO_INPUT)}</Speak>` +
+		`<Speak>${xmlEscape(VOICE_LINES.noInput)}</Speak>` +
 		'</Response>'
 	);
-}
-
-/** Word numbers ASR may emit where the menu says "Option 1". */
-const SPOKEN_NUMBERS: Record<string, string> = {
-	one: '1',
-	two: '2',
-	three: '3',
-	four: '4',
-	five: '5',
-	six: '6',
-	seven: '7',
-	eight: '8',
-	nine: '9',
-	ten: '10',
-};
-
-/**
- * Voice-edge speech normalization: "option one" → "option 1" (also "number
- * one"), so a spoken menu pick parses exactly like a typed one. Bare word
- * numbers ("two") already parse in core; this only covers the phrasing the
- * spoken menu itself invites.
- */
-function normalizeSpeech(text: string): string {
-	return text
-		.trim()
-		.replace(
-			/\b(option|number)\s+(one|two|three|four|five|six|seven|eight|nine|ten)\b/gi,
-			(_, lead: string, word: string) => `${lead} ${SPOKEN_NUMBERS[word.toLowerCase()]}`,
-		);
 }
 
 // Plivo delivers numbers bare ("14155551234"); normalize like the other routes.
@@ -133,39 +78,12 @@ export const agentVoicePlivoRoutes: FastifyPluginAsync = async (fastify) => {
 	app.addContentTypeParser(
 		'application/x-www-form-urlencoded',
 		{ parseAs: 'string' },
-		plivoFormBodyParser,
+		formUrlencodedParser,
 	);
 	// Same V2 signature gate as the other Plivo webhooks. No pinned URL: the two
 	// voice endpoints have different paths, and nothing here doubles as a send-time
 	// callback, so verification reconstructs each request's own URL.
 	app.addHook('onRequest', plivoWebhookAuthHook(app, undefined));
-
-	/**
-	 * Resolve which account owns the called number, applying the same guards the
-	 * chat channels enforce — spoken, since a caller can't be answered with JSON.
-	 */
-	async function resolveAccount(to: string, from: string): Promise<Account | { speech: string }> {
-		const businessNumber = callerNumber(to);
-		// Both repository implementations already return null for '', so an
-		// unparseable To can never match an unprovisioned account — these explicit
-		// guards just spare the lookups and keep the route safe on its own terms.
-		if (businessNumber === '') {
-			return { speech: NOT_IN_SERVICE };
-		}
-		const account = await accounts.findByChannelAddress('voice', businessNumber);
-		if (!account || account.status === 'canceled') {
-			return { speech: NOT_IN_SERVICE };
-		}
-		if (!account.channels.voice.enabled) {
-			return { speech: `Sorry, ${account.name} isn't taking calls here right now. Goodbye!` };
-		}
-		// Loop guard: never converse with any account's own number.
-		const caller = callerNumber(from);
-		if (caller !== '' && (await accounts.findByChannelAddress('voice', caller))) {
-			return { speech: GOODBYE };
-		}
-		return account;
-	}
 
 	const voiceSchema = {
 		tags: ['channels'],
@@ -193,22 +111,26 @@ export const agentVoicePlivoRoutes: FastifyPluginAsync = async (fastify) => {
 			try {
 				const payload = callPayloadSchema.safeParse(request.body);
 				const { From = '', To = '' } = payload.success ? payload.data : {};
-				const resolved = await resolveAccount(To, From);
+				const resolved = await resolveVoiceAccount({
+					accounts,
+					businessNumber: callerNumber(To),
+					callerNumber: callerNumber(From),
+				});
 				if (!('id' in resolved)) {
 					return speakDocument(resolved.speech);
 				}
 				// A caller with no presentable number can never be recognized or booked —
 				// decline up front instead of greeting and hanging up a turn later.
 				if (callerNumber(From) === '') {
-					return speakDocument(ANONYMOUS);
+					return speakDocument(VOICE_LINES.anonymous);
 				}
-				const greeting =
-					`Hi! You've reached ${resolved.name}. I'm Rivus, their scheduling assistant. ` +
-					'How can I help you today?';
-				return listenDocument(greeting, `${requestOrigin(request)}${INPUT_PATH}`);
+				return listenDocument(
+					voiceGreeting(resolved.name),
+					`${requestOrigin(request)}${INPUT_PATH}`,
+				);
 			} catch (error) {
 				request.log.error({ err: error }, 'voice answer webhook failed');
-				return speakDocument(APOLOGY);
+				return speakDocument(VOICE_LINES.apology);
 			}
 		},
 	);
@@ -237,53 +159,34 @@ export const agentVoicePlivoRoutes: FastifyPluginAsync = async (fastify) => {
 					Speech = '',
 					CallUUID = '',
 				} = payload.success ? payload.data : {};
-				const resolved = await resolveAccount(To, From);
+				const resolved = await resolveVoiceAccount({
+					accounts,
+					businessNumber: callerNumber(To),
+					callerNumber: callerNumber(From),
+				});
 				if (!('id' in resolved)) {
 					return speakDocument(resolved.speech);
 				}
-				const actionUrl = `${requestOrigin(request)}${INPUT_PATH}`;
 				const caller = callerNumber(From);
 				if (caller === '') {
-					return speakDocument(ANONYMOUS);
+					return speakDocument(VOICE_LINES.anonymous);
 				}
-				const speech = normalizeSpeech(Speech);
-				if (speech === '') {
-					return listenDocument("Sorry, I didn't catch that. Could you say it again?", actionUrl);
-				}
-
-				// One spoken turn = one orchestrated agent turn, same as a chat message.
-				// The capture adapter hands back the rendered utterance to speak.
-				const capture = { text: '' };
-				const adapter = createVoiceChannelAdapter({ customers, capture });
-				const result = await handleInboundAgentMessage({
+				const turn = await runVoiceTurn({
 					deps: { config, jobs, conversations, agentThreads },
-					adapter,
+					customers,
 					capabilities,
 					account: resolved,
-					message: {
-						sender: { address: caller, name: '' },
-						text: speech,
-						subject: '',
-						// Plivo sends no per-utterance id, and a synthetic CallUUID+Speech key
-						// would dedupe a caller legitimately repeating themselves (same words,
-						// same call) into a goodbye — worse than the rare timeout-retry replay
-						// it would catch, which lands on the already-booked thread as
-						// confirm_existing rather than a double booking. So '' (dedup off).
-						externalMessageId: '',
-					},
+					caller,
+					speech: Speech,
 					logger: request.log.child({ callUuid: CallUUID }),
 				});
-
-				if (!result.handled || capture.text === '') {
-					return speakDocument(GOODBYE);
+				if (turn.mode === 'terminal') {
+					return speakDocument(turn.text);
 				}
-				if (TERMINAL_OUTCOMES.has(result.outcome)) {
-					return speakDocument(`${capture.text} ${GOODBYE}`);
-				}
-				return listenDocument(capture.text, actionUrl);
+				return listenDocument(turn.text, `${requestOrigin(request)}${INPUT_PATH}`);
 			} catch (error) {
 				request.log.error({ err: error }, 'voice input webhook failed');
-				return speakDocument(APOLOGY);
+				return speakDocument(VOICE_LINES.apology);
 			}
 		},
 	);

--- a/packages/api/src/routes/agent-voice-shared.ts
+++ b/packages/api/src/routes/agent-voice-shared.ts
@@ -1,0 +1,169 @@
+import type { Account } from '@rivus/core';
+import type { FastifyBaseLogger } from 'fastify';
+import type { AccountRepository, CustomerRepository } from '../repositories/types';
+import type { AgentCapability } from '../services/agent/capabilities';
+import { handleInboundAgentMessage } from '../services/agent/orchestrator';
+import { createVoiceChannelAdapter } from '../services/agent/voice/adapter';
+import type { AppDeps } from '../types';
+
+/**
+ * The provider-agnostic core shared by the voice webhook routes (Plivo,
+ * Twilio). Each provider route owns only its dialect — field names and the
+ * XML it answers with (Plivo XML vs TwiML) — and hands normalized numbers and
+ * transcribed speech here, so account resolution, the guards, the spoken
+ * wording, and the turn policy can never drift between providers.
+ */
+
+/** Outcomes after which the call ends instead of listening for another turn. */
+export const VOICE_TERMINAL_OUTCOMES = new Set(['book', 'confirm_existing', 'send_signup_link']);
+
+export const VOICE_LINES = {
+	goodbye: 'Thanks for calling. Goodbye!',
+	noInput: "I didn't catch anything — call back anytime. Goodbye!",
+	notInService: "Sorry, this number isn't in service. Goodbye!",
+	anonymous:
+		"Sorry, we can't take calls from restricted or anonymous numbers. Please call back with caller I D enabled. Goodbye!",
+	// Spoken with HTTP 200 instead of erroring — deliberately. Voice webhooks are
+	// call-flow requests, not async status callbacks: the response XML drives a
+	// live call, so a non-200 buys no durable retry (a live caller can't be
+	// parked while the service recovers); erroring would replace this polite
+	// goodbye with the provider's generic mid-call failure handling. "Call back
+	// in a few minutes" IS the retry path for a human on the phone.
+	apology: 'Sorry, something went wrong on our end. Please call back in a few minutes. Goodbye!',
+	reprompt: "Sorry, I didn't catch that. Could you say it again?",
+} as const;
+
+/** The greeting a connected caller hears — identical on every provider edge. */
+export function voiceGreeting(accountName: string): string {
+	return (
+		`Hi! You've reached ${accountName}. I'm Rivus, their scheduling assistant. ` +
+		'How can I help you today?'
+	);
+}
+
+/** XML text escaping shared by both dialects (Plivo XML and TwiML). */
+export function xmlEscape(text: string): string {
+	return text
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&apos;');
+}
+
+/** Word numbers ASR may emit where the menu says "Option 1". */
+const SPOKEN_NUMBERS: Record<string, string> = {
+	one: '1',
+	two: '2',
+	three: '3',
+	four: '4',
+	five: '5',
+	six: '6',
+	seven: '7',
+	eight: '8',
+	nine: '9',
+	ten: '10',
+};
+
+/**
+ * Voice-edge speech normalization: "option one" → "option 1" (also "number
+ * one"), so a spoken menu pick parses exactly like a typed one. Bare word
+ * numbers ("two") already parse in core; this only covers the phrasing the
+ * spoken menu itself invites.
+ */
+export function normalizeSpokenNumbers(text: string): string {
+	return text
+		.trim()
+		.replace(
+			/\b(option|number)\s+(one|two|three|four|five|six|seven|eight|nine|ten)\b/gi,
+			(_, lead: string, word: string) => `${lead} ${SPOKEN_NUMBERS[word.toLowerCase()]}`,
+		);
+}
+
+/**
+ * Resolve which account owns the called number, applying the same guards the
+ * chat channels enforce — spoken, since a caller can't be answered with JSON.
+ * Both numbers arrive already normalized to E.164 (or '') by the provider
+ * route. Both repository implementations return null for '' lookups; the
+ * explicit guards spare the lookups and keep the flow safe on its own terms.
+ */
+export async function resolveVoiceAccount(options: {
+	accounts: AccountRepository;
+	/** The called number, normalized ('' when unparseable). */
+	businessNumber: string;
+	/** The caller's number, normalized ('' for anonymous/restricted). */
+	callerNumber: string;
+}): Promise<Account | { speech: string }> {
+	const { accounts, businessNumber, callerNumber } = options;
+	if (businessNumber === '') {
+		return { speech: VOICE_LINES.notInService };
+	}
+	const account = await accounts.findByChannelAddress('voice', businessNumber);
+	if (!account || account.status === 'canceled') {
+		return { speech: VOICE_LINES.notInService };
+	}
+	if (!account.channels.voice.enabled) {
+		return { speech: `Sorry, ${account.name} isn't taking calls here right now. Goodbye!` };
+	}
+	// Loop guard: never converse with any account's own number.
+	if (callerNumber !== '' && (await accounts.findByChannelAddress('voice', callerNumber))) {
+		return { speech: VOICE_LINES.goodbye };
+	}
+	return account;
+}
+
+/** How the caller's turn resolved: keep listening, or speak and hang up. */
+export interface VoiceTurnResult {
+	mode: 'listen' | 'terminal';
+	text: string;
+}
+
+/**
+ * Run one spoken caller turn through the same channel-agnostic orchestrator
+ * every other channel uses — thread state, inbox mirroring as a `phone`
+ * conversation, booking — and decide the call flow from the outcome.
+ */
+export async function runVoiceTurn(options: {
+	deps: Pick<AppDeps, 'config' | 'jobs' | 'conversations' | 'agentThreads'>;
+	customers: CustomerRepository;
+	capabilities: AgentCapability[];
+	account: Account;
+	/** The caller's normalized E.164 number (non-empty — routes decline anonymous callers). */
+	caller: string;
+	/** The transcribed utterance, verbatim from the provider. */
+	speech: string;
+	logger: FastifyBaseLogger;
+}): Promise<VoiceTurnResult> {
+	const normalized = normalizeSpokenNumbers(options.speech);
+	if (normalized === '') {
+		return { mode: 'listen', text: VOICE_LINES.reprompt };
+	}
+	// The capture adapter hands back the rendered utterance to speak — voice is
+	// the one channel whose transport is the webhook's own response.
+	const capture = { text: '' };
+	const adapter = createVoiceChannelAdapter({ customers: options.customers, capture });
+	const result = await handleInboundAgentMessage({
+		deps: options.deps,
+		adapter,
+		capabilities: options.capabilities,
+		account: options.account,
+		message: {
+			sender: { address: options.caller, name: '' },
+			text: normalized,
+			subject: '',
+			// Providers send no per-utterance id, and a synthetic call+speech key
+			// would dedupe a caller legitimately repeating themselves into a goodbye
+			// — worse than the rare timeout-retry replay it would catch, which lands
+			// on the already-booked thread as confirm_existing. So '' (dedup off).
+			externalMessageId: '',
+		},
+		logger: options.logger,
+	});
+	if (!result.handled || capture.text === '') {
+		return { mode: 'terminal', text: VOICE_LINES.goodbye };
+	}
+	if (VOICE_TERMINAL_OUTCOMES.has(result.outcome)) {
+		return { mode: 'terminal', text: `${capture.text} ${VOICE_LINES.goodbye}` };
+	}
+	return { mode: 'listen', text: capture.text };
+}

--- a/packages/api/src/routes/agent-voice-twilio.ts
+++ b/packages/api/src/routes/agent-voice-twilio.ts
@@ -1,0 +1,216 @@
+import { normalizePhone } from '@rivus/core';
+import type { FastifyPluginAsync } from 'fastify';
+import type { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { errorResponseSchema } from '../http-schemas';
+import { defaultCapabilities } from '../services/agent/capabilities';
+import {
+	resolveVoiceAccount,
+	runVoiceTurn,
+	VOICE_LINES,
+	voiceGreeting,
+	xmlEscape,
+} from './agent-voice-shared';
+import { twilioWebhookAuthHook } from './twilio-webhook-auth';
+import { formUrlencodedParser, requestOrigin } from './webhook-http';
+
+/**
+ * The Twilio edge of the scheduling agent's voice channel. A call arrives at
+ * the number's VoiceUrl (the answer route — attached automatically when the
+ * provisioner rents the number), which greets the caller and listens with
+ * `<Gather input="speech">`; each transcribed utterance POSTs to the input
+ * route. This route owns only the Twilio dialect — field names and TwiML —
+ * and hands normalized numbers and speech to the shared voice core
+ * (`./agent-voice-shared`), the same core the Plivo route uses.
+ *
+ * v1 is turn-based (speak, listen, repeat) — a smart receptionist cadence,
+ * not barge-in realtime speech. The channel plumbing carries over unchanged
+ * if the conversation loop later moves to audio streaming.
+ */
+
+/** The absolute path of the input webhook (`Gather action`), under the app's mount. */
+const INPUT_PATH = '/v1/channels/voice/twilio/input';
+
+const ANSWER_SUFFIX = '/answer';
+
+/**
+ * The input endpoint's public URL, derived from the pinned answer URL
+ * (`TWILIO_VOICE_WEBHOOK_URL`, the VoiceUrl the provisioner attaches to rented
+ * numbers) by swapping the final path segment. Twilio signs the exact URL it
+ * requests, and for the input endpoint that is the `action` URL this route
+ * itself hands out — deriving the action and the verification URL from the
+ * same pin keeps them equal by construction. With no pin (or an unconventional
+ * one) both fall back to per-request reconstruction, like the Plivo pair.
+ */
+function derivedInputUrl(answerUrl: string | undefined): string | undefined {
+	if (!answerUrl?.endsWith(ANSWER_SUFFIX)) {
+		return undefined;
+	}
+	return `${answerUrl.slice(0, -ANSWER_SUFFIX.length)}/input`;
+}
+
+/** A closing document: say, then Twilio ends the call at the end of the TwiML. */
+function sayDocument(text: string): string {
+	return `<Response><Say>${xmlEscape(text)}</Say></Response>`;
+}
+
+/**
+ * A listening document: speak the prompt, gather one spoken utterance to the
+ * input route, and close politely if the caller says nothing (an empty Gather
+ * falls through to the next verb rather than requesting the action). `hints`
+ * biases recognition toward the option numbers the agent offers;
+ * `speechTimeout="auto"` ends the capture when the caller stops talking.
+ */
+function gatherDocument(prompt: string, actionUrl: string): string {
+	return (
+		'<Response>' +
+		`<Gather input="speech" action="${xmlEscape(actionUrl)}" method="POST" language="en-US" speechTimeout="auto" hints="option,one,two,three,four,five,tomorrow,morning,afternoon">` +
+		`<Say>${xmlEscape(prompt)}</Say>` +
+		'</Gather>' +
+		`<Say>${xmlEscape(VOICE_LINES.noInput)}</Say>` +
+		'</Response>'
+	);
+}
+
+// Twilio delivers numbers in E.164 (`+14155551234`) already; anonymous and
+// restricted callers arrive as non-numeric markers, which normalize to ''.
+function callerNumber(value: string | undefined): string {
+	return normalizePhone((value ?? '').trim());
+}
+
+// The call fields both webhooks carry (VoiceUrl and Gather action both POST forms).
+const callPayloadSchema = z.object({
+	From: z.string().optional(),
+	To: z.string().optional(),
+	CallSid: z.string().optional(),
+	/** Gather's transcription; absent on the answer webhook. */
+	SpeechResult: z.string().optional(),
+});
+
+export const agentVoiceTwilioRoutes: FastifyPluginAsync = async (fastify) => {
+	const app = fastify.withTypeProvider<ZodTypeProvider>();
+	const { config, accounts, customers, conversations, agentThreads, jobs } = app.deps;
+
+	const capabilities = defaultCapabilities();
+
+	app.addContentTypeParser(
+		'application/x-www-form-urlencoded',
+		{ parseAs: 'string' },
+		formUrlencodedParser,
+	);
+	// Same X-Twilio-Signature gate as the messaging webhooks, but registered per
+	// route: the two endpoints verify against different URLs (the answer route is
+	// the number's VoiceUrl; the input route is the Gather action derived from it).
+	const pinnedAnswerUrl = config.TWILIO_VOICE_WEBHOOK_URL;
+	const pinnedInputUrl = derivedInputUrl(pinnedAnswerUrl);
+
+	const voiceSchema = {
+		tags: ['channels'],
+		body: z.unknown(),
+		response: { 200: z.string(), 401: errorResponseSchema, 503: errorResponseSchema },
+	};
+
+	app.post(
+		'/voice/twilio/answer',
+		{
+			preValidation: twilioWebhookAuthHook(app, pinnedAnswerUrl),
+			schema: {
+				...voiceSchema,
+				summary: 'Twilio voice webhook — answers an inbound call (VoiceUrl)',
+				description:
+					'Twilio requests this URL when someone calls the account’s provisioned ' +
+					'number (the number’s VoiceUrl, attached at purchase). The response TwiML ' +
+					'greets the caller and listens for speech; each utterance is transcribed ' +
+					'and posted to the input webhook. Deliveries are authenticated with the ' +
+					'X-Twilio-Signature header when TWILIO_AUTH_TOKEN is configured.',
+			},
+		},
+		async (request, reply) => {
+			reply.type('text/xml');
+			try {
+				const payload = callPayloadSchema.safeParse(request.body);
+				const { From = '', To = '' } = payload.success ? payload.data : {};
+				const resolved = await resolveVoiceAccount({
+					accounts,
+					businessNumber: callerNumber(To),
+					callerNumber: callerNumber(From),
+				});
+				if (!('id' in resolved)) {
+					return sayDocument(resolved.speech);
+				}
+				// A caller with no presentable number can never be recognized or booked —
+				// decline up front instead of greeting and hanging up a turn later.
+				if (callerNumber(From) === '') {
+					return sayDocument(VOICE_LINES.anonymous);
+				}
+				return gatherDocument(
+					voiceGreeting(resolved.name),
+					pinnedInputUrl ?? `${requestOrigin(request)}${INPUT_PATH}`,
+				);
+			} catch (error) {
+				request.log.error({ err: error }, 'voice answer webhook failed');
+				return sayDocument(VOICE_LINES.apology);
+			}
+		},
+	);
+
+	app.post(
+		'/voice/twilio/input',
+		{
+			preValidation: twilioWebhookAuthHook(app, pinnedInputUrl),
+			schema: {
+				...voiceSchema,
+				summary: 'Twilio voice webhook — one transcribed caller utterance (Gather action)',
+				description:
+					'Gather posts each transcribed utterance here. The utterance runs ' +
+					'through the same channel-agnostic scheduling orchestrator as every ' +
+					'other channel (threads, inbox mirroring as a phone conversation, ' +
+					'booking); the response TwiML speaks the agent’s reply and either ' +
+					'listens for the next turn or ends the call on a terminal outcome.',
+			},
+		},
+		async (request, reply) => {
+			reply.type('text/xml');
+			try {
+				const payload = callPayloadSchema.safeParse(request.body);
+				const {
+					From = '',
+					To = '',
+					SpeechResult = '',
+					CallSid = '',
+				} = payload.success ? payload.data : {};
+				const resolved = await resolveVoiceAccount({
+					accounts,
+					businessNumber: callerNumber(To),
+					callerNumber: callerNumber(From),
+				});
+				if (!('id' in resolved)) {
+					return sayDocument(resolved.speech);
+				}
+				const caller = callerNumber(From);
+				if (caller === '') {
+					return sayDocument(VOICE_LINES.anonymous);
+				}
+				const turn = await runVoiceTurn({
+					deps: { config, jobs, conversations, agentThreads },
+					customers,
+					capabilities,
+					account: resolved,
+					caller,
+					speech: SpeechResult,
+					logger: request.log.child({ callSid: CallSid }),
+				});
+				if (turn.mode === 'terminal') {
+					return sayDocument(turn.text);
+				}
+				return gatherDocument(
+					turn.text,
+					pinnedInputUrl ?? `${requestOrigin(request)}${INPUT_PATH}`,
+				);
+			} catch (error) {
+				request.log.error({ err: error }, 'voice input webhook failed');
+				return sayDocument(VOICE_LINES.apology);
+			}
+		},
+	);
+};

--- a/packages/api/src/routes/agent-whatsapp-plivo.ts
+++ b/packages/api/src/routes/agent-whatsapp-plivo.ts
@@ -6,7 +6,8 @@ import { defaultCapabilities } from '../services/agent/capabilities';
 import { parsePlivoInbound } from '../services/agent/plivo-inbound';
 import { createWhatsappChannelAdapter } from '../services/agent/whatsapp/adapter';
 import { channelWebhookResponseSchema, dispatchPhoneChannelEvent } from './agent-phone-shared';
-import { plivoFormBodyParser, plivoWebhookAuthHook } from './plivo-webhook-auth';
+import { plivoWebhookAuthHook } from './plivo-webhook-auth';
+import { formUrlencodedParser } from './webhook-http';
 
 /**
  * The Plivo edge of the scheduling agent's WhatsApp channel. Plivo posts two
@@ -51,7 +52,7 @@ export const agentWhatsappPlivoRoutes: FastifyPluginAsync = async (fastify) => {
 	app.addContentTypeParser(
 		'application/x-www-form-urlencoded',
 		{ parseAs: 'string' },
-		plivoFormBodyParser,
+		formUrlencodedParser,
 	);
 	app.addHook('onRequest', plivoWebhookAuthHook(app, config.PLIVO_WEBHOOK_URL));
 

--- a/packages/api/src/routes/plivo-webhook-auth.ts
+++ b/packages/api/src/routes/plivo-webhook-auth.ts
@@ -1,35 +1,16 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { verifyPlivoSignature } from '../services/plivo';
+import { headerValue, requestOrigin } from './webhook-http';
 
 /**
- * The authenticity gate shared by the Plivo webhook routes (WhatsApp and SMS).
- * Plivo V2 signs the webhook URL + a nonce with the account's auth token — the
- * body is not part of the signature — so unlike the zernio route (whose scheme
- * signs the raw body and must wait for it), this runs at `onRequest`: an
- * unauthenticated delivery is rejected before the body parser does any work on
- * it. Registered per route plugin, once per channel, with that channel's
- * pinned public URL.
+ * The authenticity gate shared by the Plivo webhook routes (WhatsApp, SMS,
+ * voice). Plivo V2 signs the webhook URL + a nonce with the account's auth
+ * token — the body is not part of the signature — so unlike the Twilio gate
+ * (whose scheme signs the form parameters and must wait for them) this runs at
+ * `onRequest`: an unauthenticated delivery is rejected before the body parser
+ * does any work on it. Registered per route plugin, once per channel, with
+ * that channel's pinned public URL.
  */
-
-/** First value of a possibly-repeated header, as a string. */
-function headerValue(value: string | string[] | undefined): string {
-	if (Array.isArray(value)) {
-		return value[0] ?? '';
-	}
-	return value ?? '';
-}
-
-/**
- * The public origin of a request (`https://api.rivus.ai`), honoring the
- * forwarding headers the front-door proxy sets. Used to reconstruct signed
- * webhook URLs and to build absolute callback URLs (the voice route's
- * `GetInput action`).
- */
-export function requestOrigin(request: FastifyRequest): string {
-	const proto = headerValue(request.headers['x-forwarded-proto']) || request.protocol;
-	const host = headerValue(request.headers['x-forwarded-host']) || request.headers.host || '';
-	return `${proto}://${host}`;
-}
 
 /**
  * The URL Plivo signed. The pinned URL (the exact URL configured in the Plivo
@@ -83,18 +64,4 @@ export function plivoWebhookAuthHook(
 			throw app.httpErrors.unauthorized('Invalid webhook signature');
 		}
 	};
-}
-
-/**
- * Parse Plivo's form-encoded callback variant to the same plain-object shape as
- * JSON, so the payload mapper sees one input. Registered plugin-scoped by each
- * Plivo route. TODO(plivo): confirm whether the hooks also use JSON in
- * production — both are accepted either way.
- */
-export function plivoFormBodyParser(
-	_request: FastifyRequest,
-	payload: string,
-	done: (error: Error | null, result?: unknown) => void,
-): void {
-	done(null, Object.fromEntries(new URLSearchParams(payload)));
 }

--- a/packages/api/src/routes/twilio-webhook-auth.ts
+++ b/packages/api/src/routes/twilio-webhook-auth.ts
@@ -33,11 +33,12 @@ function formParams(body: unknown): TwilioWebhookParams {
 
 /**
  * Build the `preValidation` hook for one Twilio channel webhook. `pinnedUrl`
- * is that channel's public webhook URL (`TWILIO_*_WEBHOOK_URL`); when unset
- * the URL is reconstructed from the request, honoring forwarding headers.
- * Voice pins the answer endpoint's URL, so its input endpoint (different
- * path) always verifies against the reconstructed URL — pass `pinnedUrl`
- * only when it matches the route's own path.
+ * is that endpoint's public URL; when unset the URL is reconstructed from the
+ * request, honoring forwarding headers. The messaging channels pin their
+ * `TWILIO_*_WEBHOOK_URL` directly; the voice pair pins the answer endpoint
+ * with `TWILIO_VOICE_WEBHOOK_URL` and its input endpoint with the URL derived
+ * from that pin (the same URL the answer TwiML hands out as the Gather
+ * action). Pass `pinnedUrl` only when it matches the route's own path.
  */
 export function twilioWebhookAuthHook(
 	app: FastifyInstance,

--- a/packages/api/src/routes/twilio-webhook-auth.ts
+++ b/packages/api/src/routes/twilio-webhook-auth.ts
@@ -1,0 +1,78 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { type TwilioWebhookParams, verifyTwilioSignature } from '../services/twilio';
+import { headerValue, requestOrigin } from './webhook-http';
+
+/**
+ * The authenticity gate shared by the Twilio webhook routes (WhatsApp, SMS,
+ * voice). Twilio signs the request URL **plus every form parameter**
+ * (X-Twilio-Signature), so unlike the Plivo gate this must run at
+ * `preValidation` — after the form body is parsed — and hand the whole
+ * parameter set to the verifier. Registered per route plugin with that
+ * channel's pinned public URL.
+ */
+
+/**
+ * Every string(-array) field of the parsed form body — Twilio signs all of
+ * them, including every occurrence of a repeated key (the form parser keeps
+ * repeats as arrays).
+ */
+function formParams(body: unknown): TwilioWebhookParams {
+	if (body === null || typeof body !== 'object') {
+		return {};
+	}
+	const params: TwilioWebhookParams = {};
+	for (const [key, value] of Object.entries(body)) {
+		if (typeof value === 'string') {
+			params[key] = value;
+		} else if (Array.isArray(value) && value.every((entry) => typeof entry === 'string')) {
+			params[key] = value;
+		}
+	}
+	return params;
+}
+
+/**
+ * Build the `preValidation` hook for one Twilio channel webhook. `pinnedUrl`
+ * is that channel's public webhook URL (`TWILIO_*_WEBHOOK_URL`); when unset
+ * the URL is reconstructed from the request, honoring forwarding headers.
+ * Voice pins the answer endpoint's URL, so its input endpoint (different
+ * path) always verifies against the reconstructed URL — pass `pinnedUrl`
+ * only when it matches the route's own path.
+ */
+export function twilioWebhookAuthHook(
+	app: FastifyInstance,
+	pinnedUrl: string | undefined,
+): (request: FastifyRequest, reply: FastifyReply) => Promise<FastifyReply | undefined> {
+	const { config } = app.deps;
+	return async (request, reply) => {
+		if (request.method !== 'POST') {
+			return;
+		}
+		const authToken = config.TWILIO_AUTH_TOKEN;
+		// Same predicate as the provider factories: with a partial credential pair
+		// the sender is a silent no-op, so production refuses deliveries it could
+		// never answer rather than acknowledging them into a black hole.
+		if (config.NODE_ENV === 'production' && !(config.TWILIO_ACCOUNT_SID && authToken)) {
+			return reply.code(503).send({
+				error: 'Service Unavailable',
+				message:
+					'The channel is not configured (TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN must both be set).',
+				statusCode: 503,
+			});
+		}
+		// Unconfigured outside production: accept unsigned deliveries (local curls).
+		if (!authToken) {
+			return;
+		}
+		const url = pinnedUrl || `${requestOrigin(request)}${request.raw.url ?? request.url}`;
+		const verified = verifyTwilioSignature({
+			authToken,
+			url,
+			params: formParams(request.body),
+			signature: headerValue(request.headers['x-twilio-signature']),
+		});
+		if (!verified) {
+			throw app.httpErrors.unauthorized('Invalid webhook signature');
+		}
+	};
+}

--- a/packages/api/src/routes/webhook-http.ts
+++ b/packages/api/src/routes/webhook-http.ts
@@ -1,0 +1,50 @@
+import type { FastifyRequest } from 'fastify';
+
+/**
+ * Provider-neutral HTTP plumbing shared by the webhook routes (Plivo, Twilio).
+ */
+
+/** First value of a possibly-repeated header, as a string. */
+export function headerValue(value: string | string[] | undefined): string {
+	if (Array.isArray(value)) {
+		return value[0] ?? '';
+	}
+	return value ?? '';
+}
+
+/**
+ * The public origin of a request (`https://api.rivus.ai`), honoring the
+ * forwarding headers the front-door proxy sets. Used to reconstruct signed
+ * webhook URLs and to build absolute callback URLs (the voice routes' action
+ * attributes).
+ */
+export function requestOrigin(request: FastifyRequest): string {
+	const proto = headerValue(request.headers['x-forwarded-proto']) || request.protocol;
+	const host = headerValue(request.headers['x-forwarded-host']) || request.headers.host || '';
+	return `${proto}://${host}`;
+}
+
+/**
+ * Parse a provider's form-encoded callback to the same plain-object shape as
+ * JSON, so payload mappers see one input. Registered plugin-scoped by each
+ * webhook route that accepts `application/x-www-form-urlencoded`.
+ *
+ * A repeated key becomes an array (instead of silently keeping only the last
+ * value): Twilio signs every occurrence, so signature verification must see
+ * them all. The payload schemas expect single strings for the fields they
+ * read, so a pathological repeat of a meaningful field parses as unrecognized
+ * rather than as a half-read message.
+ */
+export function formUrlencodedParser(
+	_request: FastifyRequest,
+	payload: string,
+	done: (error: Error | null, result?: unknown) => void,
+): void {
+	const form = new URLSearchParams(payload);
+	const body: Record<string, string | string[]> = {};
+	for (const key of new Set(form.keys())) {
+		const all = form.getAll(key);
+		body[key] = all.length > 1 ? all : (all[0] ?? '');
+	}
+	done(null, body);
+}

--- a/packages/api/src/services/agent/sms/adapter.ts
+++ b/packages/api/src/services/agent/sms/adapter.ts
@@ -54,6 +54,7 @@ export function createSmsChannelAdapter(deps: {
 				from: ctx.account.channels.sms.address,
 				to: ctx.to.address,
 				text,
+				providerRef: ctx.account.channels.sms.providerRef,
 			});
 			return text;
 		},

--- a/packages/api/src/services/agent/twilio-inbound.ts
+++ b/packages/api/src/services/agent/twilio-inbound.ts
@@ -109,14 +109,16 @@ export function parseTwilioInbound(body: unknown, channel: TwilioChannel): Twili
 		};
 	}
 
-	// An inbound message. A hook only handles its own channel.
-	if (whatsappShaped !== (channel === 'whatsapp')) {
-		return { kind: 'ignored' };
-	}
+	// An inbound message. Unreadable numbers mean this isn't a delivery we
+	// understand at all; a readable delivery shaped like the other channel is
+	// recognized and ignored (a hook only handles its own channel).
 	const from = twilioNumber(payload.From);
 	const to = twilioNumber(payload.To);
 	if (from === '' || to === '') {
 		return { kind: 'unrecognized' };
+	}
+	if (whatsappShaped !== (channel === 'whatsapp')) {
+		return { kind: 'ignored' };
 	}
 	// A media-only message has an empty Body, which the dispatcher declines as
 	// unsupported — same policy as the Plivo path.

--- a/packages/api/src/services/agent/twilio-inbound.ts
+++ b/packages/api/src/services/agent/twilio-inbound.ts
@@ -1,0 +1,136 @@
+import { normalizePhone } from '@rivus/core';
+import { z } from 'zod';
+import {
+	WHATSAPP_FAILED_EVENT,
+	WHATSAPP_MESSAGE_EVENT,
+	type WhatsappInboundEvent,
+} from './whatsapp/inbound';
+
+/**
+ * Parsing of Twilio's message webhooks into the canonical channel event —
+ * Twilio's counterpart of `./plivo-inbound`. One form-encoded payload family
+ * serves both channels: WhatsApp deliveries carry `whatsapp:`-prefixed
+ * From/To addresses, SMS deliveries bare E.164, so the channel a hook is
+ * configured for is checked against the address shape and cross-channel
+ * deliveries are recognized and ignored rather than misrouted. Two kinds of
+ * deliveries arrive: inbound customer messages (`MessageSid`/`From`/`To`/
+ * `Body`, plus `ProfileName` on WhatsApp) and status callbacks for our own
+ * sends (`MessageStatus`, with `ErrorCode` on failures), which land on the
+ * StatusCallback URL the senders attach to every message.
+ *
+ * The canonical event type is {@link WhatsappInboundEvent} — named for the
+ * channel that introduced it, structurally channel-neutral; the dispatcher
+ * supplies the actual channel.
+ */
+
+/** The channels a Twilio hook can be configured for. */
+export type TwilioChannel = 'whatsapp' | 'sms';
+
+/** How a Twilio delivery was classified. */
+export type TwilioInboundResult =
+	/** An event Rivus acts on (inbound message, or a failed delivery). */
+	| { kind: 'event'; event: WhatsappInboundEvent }
+	/** A recognized delivery Rivus deliberately ignores (e.g. MessageStatus=delivered). */
+	| { kind: 'ignored' }
+	/** Not a Twilio delivery we understand. */
+	| { kind: 'unrecognized' };
+
+// Every field optional: payloads vary by delivery kind, Twilio adds parameters
+// without notice, and form-encoded values are always strings.
+const twilioPayloadSchema = z.object({
+	From: z.string().optional(),
+	To: z.string().optional(),
+	Body: z.string().optional(),
+	MessageSid: z.string().optional(),
+	/** The sender's WhatsApp profile name, when Twilio forwards it. */
+	ProfileName: z.string().optional(),
+	/** Present only on status callbacks: queued|sending|sent|delivered|undelivered|failed|read|canceled. */
+	MessageStatus: z.string().optional(),
+	ErrorCode: z.union([z.string(), z.number()]).optional(),
+});
+
+const WHATSAPP_PREFIX = 'whatsapp:';
+
+/** Whether a Twilio address is WhatsApp-prefixed (`whatsapp:+E164`). */
+function isWhatsappAddress(value: string): boolean {
+	return value.startsWith(WHATSAPP_PREFIX);
+}
+
+/** A Twilio address → canonical E.164 (`whatsapp:` prefix stripped, `+` kept). */
+function twilioNumber(value: string | undefined): string {
+	const trimmed = (value ?? '').trim();
+	if (trimmed === '') {
+		return '';
+	}
+	const bare = trimmed.startsWith(WHATSAPP_PREFIX)
+		? trimmed.slice(WHATSAPP_PREFIX.length)
+		: trimmed;
+	return normalizePhone(bare.startsWith('+') ? bare : `+${bare}`);
+}
+
+/**
+ * Map a Twilio webhook payload (form-encoded, already parsed to an object)
+ * into a canonical {@link WhatsappInboundEvent} for the given channel.
+ * Status callbacks for still-in-flight or successful sends are
+ * recognized-but-ignored; only `failed`/`undelivered` become the canonical
+ * failure event. A delivery whose addresses belong to the other channel (an
+ * SMS on the WhatsApp hook, or vice versa) is likewise ignored, never
+ * misrouted.
+ */
+export function parseTwilioInbound(body: unknown, channel: TwilioChannel): TwilioInboundResult {
+	const parsed = twilioPayloadSchema.safeParse(body);
+	if (!parsed.success) {
+		return { kind: 'unrecognized' };
+	}
+	const payload = parsed.data;
+	// The whatsapp: prefix on From/To is the channel discriminator.
+	const whatsappShaped = isWhatsappAddress((payload.From ?? '').trim());
+
+	// A status callback for a message Rivus sent. `From` is the account's
+	// business number (the outbound sender), `To` the customer it failed to reach.
+	if (payload.MessageStatus !== undefined) {
+		if (whatsappShaped !== (channel === 'whatsapp')) {
+			return { kind: 'ignored' };
+		}
+		const status = payload.MessageStatus.trim().toLowerCase();
+		if (status !== 'failed' && status !== 'undelivered') {
+			return { kind: 'ignored' };
+		}
+		return {
+			kind: 'event',
+			event: {
+				type: WHATSAPP_FAILED_EVENT,
+				data: {
+					from: twilioNumber(payload.From),
+					to: twilioNumber(payload.To),
+					reason: payload.ErrorCode !== undefined ? String(payload.ErrorCode) : status,
+				},
+			},
+		};
+	}
+
+	// An inbound message. A hook only handles its own channel.
+	if (whatsappShaped !== (channel === 'whatsapp')) {
+		return { kind: 'ignored' };
+	}
+	const from = twilioNumber(payload.From);
+	const to = twilioNumber(payload.To);
+	if (from === '' || to === '') {
+		return { kind: 'unrecognized' };
+	}
+	// A media-only message has an empty Body, which the dispatcher declines as
+	// unsupported — same policy as the Plivo path.
+	return {
+		kind: 'event',
+		event: {
+			type: WHATSAPP_MESSAGE_EVENT,
+			data: {
+				to,
+				from,
+				text: payload.Body ?? '',
+				messageId: payload.MessageSid ?? '',
+				profileName: payload.ProfileName ?? '',
+			},
+		},
+	};
+}

--- a/packages/api/src/services/agent/whatsapp/adapter.ts
+++ b/packages/api/src/services/agent/whatsapp/adapter.ts
@@ -50,6 +50,7 @@ export function createWhatsappChannelAdapter(deps: {
 				from: ctx.account.channels.whatsapp.address,
 				to: ctx.to.address,
 				text,
+				providerRef: ctx.account.channels.whatsapp.providerRef,
 			});
 			return text;
 		},

--- a/packages/api/src/services/messaging-provider.ts
+++ b/packages/api/src/services/messaging-provider.ts
@@ -1,34 +1,56 @@
 import type { Config } from '../config';
 import type { ChannelProvisioner } from './channel-provisioning';
-import { createPlivoProvisioner, createPlivoSmsSender, createPlivoWhatsappSender } from './plivo';
+import {
+	createPlivoProvisioner,
+	createPlivoSmsSender,
+	createPlivoWhatsappSender,
+	plivoOwnsRef,
+} from './plivo';
 import type { FetchLike } from './resend-mailer';
-import type { SmsSender } from './sms';
-import type { WhatsappSender } from './whatsapp';
+import type { SmsMessage, SmsSender } from './sms';
+import {
+	createTwilioProvisioner,
+	createTwilioSmsSender,
+	createTwilioWhatsappSender,
+	twilioOwnsRef,
+} from './twilio';
+import type { WhatsappMessage, WhatsappSender } from './whatsapp';
 import {
 	createWhatsappProvisioner as createZernioProvisioner,
 	createWhatsappSender as createZernioWhatsappSender,
 } from './zernio-whatsapp';
 
 /**
- * Selection of the active messaging providers from the config. Plivo is the
+ * Selection of the active messaging providers from the config. Twilio is the
  * primary for every phone-number channel (WhatsApp and SMS share the one
- * number it rents; voice will ride the same account later); zernio remains
- * wired as the alternative WhatsApp provider and is chosen when only its key
- * is set. SMS has no zernio path — it is Plivo or a no-op. With nothing
- * configured all factories degrade to no-ops, so the API still boots and tests
- * run without provider credentials. Each provider's webhook route is always
- * registered — inbound is gated by that route's own config, not here.
+ * number it rents; voice rides the same number): new numbers provision through
+ * it whenever its credentials are set. Plivo stays fully wired during the
+ * migration — accounts still holding Plivo numbers keep working — and zernio
+ * remains the alternative WhatsApp provider, chosen when only its key is set.
+ * SMS and voice have no zernio path. With nothing configured all factories
+ * degrade to no-ops, so the API still boots and tests run without provider
+ * credentials. Each provider's webhook route is always registered — inbound is
+ * gated by that route's own config, not here.
  *
- * Selection is deliberately global (config-level), not per account: zernio has
- * never been live (its wire format is still `TODO(zernio)`), so no deployment
- * holds numbers from two providers at once. If zernio is brought live alongside
- * Plivo, selection must move to the account's stored channel identity
- * (`providerRef`) so a reply always leaves through the provider that owns the
- * number it is sent from.
+ * Outbound sends are NOT config-global: mid-migration a deployment holds
+ * numbers from two providers at once, and a reply must always leave through
+ * the provider that owns the number it is sent from — Twilio cannot send from
+ * a Plivo number or vice versa. Each message therefore routes by the sending
+ * number's stored fingerprint (`providerRef`: Twilio's `PN…` SID, Plivo's
+ * bare digits), falling back to the primary chain when no configured provider
+ * claims it (fresh dev fakes, zernio's opaque ids — zernio has never been
+ * live; give it a fingerprint here if that changes).
  */
 
 type MessagingProviderConfig = Pick<
 	Config,
+	| 'TWILIO_ACCOUNT_SID'
+	| 'TWILIO_AUTH_TOKEN'
+	| 'TWILIO_API_URL'
+	| 'TWILIO_WHATSAPP_WEBHOOK_URL'
+	| 'TWILIO_SMS_WEBHOOK_URL'
+	| 'TWILIO_VOICE_WEBHOOK_URL'
+	| 'TWILIO_NUMBER_COUNTRY'
 	| 'PLIVO_AUTH_ID'
 	| 'PLIVO_AUTH_TOKEN'
 	| 'PLIVO_API_URL'
@@ -39,45 +61,122 @@ type MessagingProviderConfig = Pick<
 	| 'ZERNIO_API_URL'
 >;
 
+function twilioConfigured(config: MessagingProviderConfig): boolean {
+	return Boolean(config.TWILIO_ACCOUNT_SID && config.TWILIO_AUTH_TOKEN);
+}
+
 function plivoConfigured(config: MessagingProviderConfig): boolean {
 	return Boolean(config.PLIVO_AUTH_ID && config.PLIVO_AUTH_TOKEN);
 }
 
-/** The active provider's WhatsApp sender: Plivo, else zernio, else a no-op. */
+/** The message shape both channel senders share, as far as routing cares. */
+interface RoutableMessage {
+	from: string;
+	providerRef?: string;
+}
+
+/** One owner a message can route to: a fingerprint test and that provider's sender. */
+interface SenderRoute<M extends RoutableMessage> {
+	owns: (message: M) => boolean;
+	sender: { sendMessage(message: M): Promise<void> };
+}
+
+/**
+ * Routes each message to the provider whose fingerprint the sending number's
+ * `providerRef` carries, else to the primary sender. Routes exist only for
+ * *configured* providers: a message from a number whose owner has no
+ * credentials goes to the primary and fails loudly there — a visible delivery
+ * error beats a silent no-op drop.
+ */
+class RoutingMessageSender<M extends RoutableMessage> {
+	constructor(
+		private readonly routes: SenderRoute<M>[],
+		private readonly primary: { sendMessage(message: M): Promise<void> },
+	) {}
+
+	async sendMessage(message: M): Promise<void> {
+		for (const route of this.routes) {
+			if (route.owns(message)) {
+				return route.sender.sendMessage(message);
+			}
+		}
+		return this.primary.sendMessage(message);
+	}
+}
+
+/** The fingerprint tests, shared by both channels. */
+const ownsTwilioNumber = (message: RoutableMessage) => twilioOwnsRef(message.providerRef ?? '');
+const ownsPlivoNumber = (message: RoutableMessage) =>
+	plivoOwnsRef(message.providerRef ?? '', message.from);
+
+/**
+ * The WhatsApp sender: routes each message by the sending number's owner
+ * (Twilio or Plivo), with the primary chain — Twilio, else Plivo, else zernio,
+ * else a no-op — for numbers neither fingerprint claims.
+ */
 export function createWhatsappSender(
 	config: MessagingProviderConfig,
 	fetchImpl?: FetchLike,
 ): WhatsappSender {
-	if (plivoConfigured(config)) {
-		return createPlivoWhatsappSender(config, fetchImpl);
+	const routes: SenderRoute<WhatsappMessage>[] = [];
+	if (twilioConfigured(config)) {
+		routes.push({ owns: ownsTwilioNumber, sender: createTwilioWhatsappSender(config, fetchImpl) });
 	}
-	return createZernioWhatsappSender(config, fetchImpl);
+	if (plivoConfigured(config)) {
+		routes.push({ owns: ownsPlivoNumber, sender: createPlivoWhatsappSender(config, fetchImpl) });
+	}
+	const primary = routes[0]?.sender ?? createZernioWhatsappSender(config, fetchImpl);
+	return new RoutingMessageSender(routes, primary);
 }
 
-/** The active provider's WhatsApp number provisioner: Plivo, else zernio, else a no-op. */
+/**
+ * The WhatsApp number provisioner for *new* numbers: Twilio, else Plivo, else
+ * zernio, else a no-op. (Existing numbers never re-provision — the enable
+ * route is idempotent and shares the sibling channels' number.)
+ */
 export function createWhatsappProvisioner(
 	config: MessagingProviderConfig,
 	fetchImpl?: FetchLike,
 ): ChannelProvisioner {
+	if (twilioConfigured(config)) {
+		return createTwilioProvisioner(config, fetchImpl);
+	}
 	if (plivoConfigured(config)) {
 		return createPlivoProvisioner(config, fetchImpl);
 	}
 	return createZernioProvisioner(config, fetchImpl);
 }
 
-/** The SMS sender: Plivo when configured, else a no-op (zernio has no SMS). */
+/**
+ * The SMS sender: routes each message by the sending number's owner (Twilio
+ * or Plivo), with the primary chain — Twilio, else Plivo, else a no-op — for
+ * numbers neither fingerprint claims (zernio has no SMS).
+ */
 export function createSmsSender(config: MessagingProviderConfig, fetchImpl?: FetchLike): SmsSender {
-	return createPlivoSmsSender(config, fetchImpl);
+	const routes: SenderRoute<SmsMessage>[] = [];
+	if (twilioConfigured(config)) {
+		routes.push({ owns: ownsTwilioNumber, sender: createTwilioSmsSender(config, fetchImpl) });
+	}
+	if (plivoConfigured(config)) {
+		routes.push({ owns: ownsPlivoNumber, sender: createPlivoSmsSender(config, fetchImpl) });
+	}
+	// createPlivoSmsSender self-noops when unconfigured, covering the empty chain.
+	const primary = routes[0]?.sender ?? createPlivoSmsSender(config, fetchImpl);
+	return new RoutingMessageSender(routes, primary);
 }
 
 /**
- * The SMS number provisioner: Plivo when configured, else the no-op fake. The
- * enable route prefers the sibling channel's Plivo-owned number over renting,
- * so this is only reached when the account holds no shareable number yet.
+ * The SMS (and voice) number provisioner for new numbers: Twilio, else Plivo
+ * — which self-noops when unconfigured. The enable route prefers a sibling
+ * channel's provider-owned number over renting, so this is only reached when
+ * the account holds no shareable number yet.
  */
 export function createSmsProvisioner(
 	config: MessagingProviderConfig,
 	fetchImpl?: FetchLike,
 ): ChannelProvisioner {
+	if (twilioConfigured(config)) {
+		return createTwilioProvisioner(config, fetchImpl);
+	}
 	return createPlivoProvisioner(config, fetchImpl);
 }

--- a/packages/api/src/services/plivo.ts
+++ b/packages/api/src/services/plivo.ts
@@ -14,13 +14,14 @@ import { NoopWhatsappSender, type WhatsappMessage, type WhatsappSender } from '.
 /**
  * The Plivo adapter for the messaging seams — the only module that knows
  * Plivo's wire format. Plivo fronts the same Messages API for SMS, MMS, and
- * WhatsApp (`type` selects the channel), which is why it's Rivus's primary
- * provider: the WhatsApp and SMS senders below differ by one request field,
- * both channels share the one number `PlivoProvisioner` rents, and voice can
- * later ride the same account. Like `ZernioWhatsappSender` (kept as an
- * alternative WhatsApp provider) and `ResendMailer`, it calls the documented
- * REST endpoints with `fetch`, so it adds no dependency and is trivially faked
- * in tests.
+ * WhatsApp (`type` selects the channel), and one rented number carries every
+ * channel. It was the original primary provider; it is retained during the
+ * migration to Twilio (`./twilio`) so numbers Plivo still owns keep sending
+ * and receiving — `./messaging-provider` routes each outbound message through
+ * the number's owner. Like `ZernioWhatsappSender` (kept as an alternative
+ * WhatsApp provider) and `ResendMailer`, it calls the documented REST
+ * endpoints with `fetch`, so it adds no dependency and is trivially faked in
+ * tests.
  *
  * Wire format sources: Plivo's Messages API and Numbers API references, and the
  * signature algorithm from Plivo's published node SDK (`validateSignature`).

--- a/packages/api/src/services/plivo.ts
+++ b/packages/api/src/services/plivo.ts
@@ -233,7 +233,10 @@ export class PlivoProvisioner implements ChannelProvisioner {
 		if (address === '') {
 			throw new Error(`Plivo offered a number that is not valid E.164: ${number}`);
 		}
-		return { address, providerRef: number };
+		// The ref is the address's own bare digits — the exact fingerprint
+		// `plivoOwnsRef` checks — not the raw search result, so a `+`-formed or
+		// formatted number from Plivo can never break ownership routing/sharing.
+		return { address, providerRef: address.slice(1) };
 	}
 
 	/** Search for a rentable number that supports voice + SMS (one number, every channel). */
@@ -338,19 +341,25 @@ export function createPlivoProvisioner(
 }
 
 /**
- * The identifier a channel config holds **iff Plivo owns its number** — the
- * fingerprint is `providerRef` being exactly the address's bare digits, which
- * is what {@link PlivoProvisioner} stores and no other provisioner does (zernio
- * keeps its own opaque id, the no-op stores `'noop'`). The channel-enable route
- * uses this to give a channel its sibling's Plivo number instead of renting a
- * second one — the one-number-across-channels story — while numbers Plivo does
- * not own are never shared onto a channel Plivo would have to send from.
+ * Whether a stored providerRef names a Plivo-owned number: {@link
+ * PlivoProvisioner} stores exactly the address's bare digits, which no other
+ * provisioner writes (Twilio stores a `PN…` SID, zernio an opaque id, the
+ * no-op `'noop'`).
+ */
+export function plivoOwnsRef(providerRef: string, address: string): boolean {
+	return providerRef !== '' && providerRef === address.replace(/^\+/, '');
+}
+
+/**
+ * The identifier a channel config holds **iff Plivo owns its number**. The
+ * channel-enable route uses this to give a channel its sibling's Plivo number
+ * instead of renting a second one — the one-number-across-channels story —
+ * while numbers Plivo does not own are never shared onto a channel Plivo would
+ * have to send from; `messaging-provider` uses the same fingerprint to route
+ * each send through the number's owner.
  */
 export function plivoOwnedIdentifier(config: AccountChannelConfig): ProvisionedIdentifier | null {
-	if (config.address === '' || config.providerRef === '') {
-		return null;
-	}
-	if (config.providerRef !== config.address.replace(/^\+/, '')) {
+	if (config.address === '' || !plivoOwnsRef(config.providerRef, config.address)) {
 		return null;
 	}
 	return { address: config.address, providerRef: config.providerRef };

--- a/packages/api/src/services/sms.ts
+++ b/packages/api/src/services/sms.ts
@@ -13,6 +13,12 @@ export interface SmsMessage {
 	to: string;
 	/** Plain-text message body. */
 	text: string;
+	/**
+	 * The provider's handle for the sending number, as stored on the account's
+	 * channel config ('' / absent when unknown) — see {@link WhatsappMessage}
+	 * (`./whatsapp`): multi-provider deployments route by the number's owner.
+	 */
+	providerRef?: string;
 }
 
 /** Delivers SMS messages. Implementations reject on delivery failure. */

--- a/packages/api/src/services/twilio.ts
+++ b/packages/api/src/services/twilio.ts
@@ -1,0 +1,402 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { type AccountChannelConfig, type AccountId, normalizePhone } from '@rivus/core';
+import { z } from 'zod';
+import type { Config } from '../config';
+import {
+	type ChannelProvisioner,
+	NoopChannelProvisioner,
+	type ProvisionedIdentifier,
+} from './channel-provisioning';
+import type { FetchLike } from './resend-mailer';
+import { NoopSmsSender, type SmsMessage, type SmsSender } from './sms';
+import { NoopWhatsappSender, type WhatsappMessage, type WhatsappSender } from './whatsapp';
+
+/**
+ * The Twilio adapter for the messaging seams — the only module that knows
+ * Twilio's wire format. Twilio is the primary provider: one Messages API
+ * fronts SMS and WhatsApp (the `whatsapp:` address prefix selects the
+ * channel), numbers rent with their webhooks attached in the same purchase
+ * call, and voice rides the same number via TwiML. The Plivo adapter
+ * (`./plivo`) stays wired for numbers it still owns during the migration —
+ * outbound sends route per number owner in `./messaging-provider`.
+ *
+ * Wire format sources: Twilio's Message resource, IncomingPhoneNumbers, and
+ * request-validation docs (the signature test vector in `test/twilio.test.ts`
+ * is Twilio's own published example).
+ */
+
+const API_VERSION = '2010-04-01';
+
+interface TwilioOptions {
+	accountSid: string;
+	authToken: string;
+	apiUrl: string;
+	fetchImpl?: FetchLike;
+}
+
+function basicAuth(accountSid: string, authToken: string): Record<string, string> {
+	const credentials = Buffer.from(`${accountSid}:${authToken}`).toString('base64');
+	return {
+		authorization: `Basic ${credentials}`,
+		'content-type': 'application/x-www-form-urlencoded',
+	};
+}
+
+function accountUrl(apiUrl: string, accountSid: string, leaf: string): string {
+	return `${apiUrl.replace(/\/+$/, '')}/${API_VERSION}/Accounts/${accountSid}${leaf}`;
+}
+
+/** The parsed form parameters of a webhook request (a repeated key is an array). */
+export type TwilioWebhookParams = Record<string, string | string[]>;
+
+/**
+ * Compute the `X-Twilio-Signature` for a webhook request — Twilio's published
+ * algorithm: take the full URL exactly as requested (query string included,
+ * still URL-encoded), append each POST parameter's name and value (form-decoded,
+ * no delimiters) sorted by name in code-point order, HMAC-SHA1 the result keyed
+ * by the auth token, and base64-encode. A repeated parameter contributes each
+ * *distinct* value once, sorted, name re-attached per value — the behavior of
+ * Twilio's own SDK validators. The counterpart of {@link verifyTwilioSignature},
+ * used by tests (and handy for local `curl`s).
+ */
+export function signTwilioRequest(options: {
+	authToken: string;
+	url: string;
+	params: TwilioWebhookParams;
+}): string {
+	const data =
+		options.url +
+		Object.keys(options.params)
+			.sort()
+			.map((key) => {
+				const value = options.params[key];
+				if (Array.isArray(value)) {
+					return Array.from(new Set(value))
+						.sort()
+						.map((entry) => key + entry)
+						.join('');
+				}
+				return key + value;
+			})
+			.join('');
+	return createHmac('sha1', options.authToken).update(Buffer.from(data, 'utf8')).digest('base64');
+}
+
+/**
+ * The URL variants a Twilio signature may have been computed over: Twilio's
+ * own back end is inconsistent about explicit default ports (their SDKs accept
+ * a match with or without one), so verification tries the URL as reconstructed
+ * plus its with-/without-default-port sibling.
+ */
+function urlCandidates(url: string): string[] {
+	const candidates = [url];
+	const match = url.match(/^(https?):\/\/([^/]+)(.*)$/);
+	if (!match) {
+		return candidates;
+	}
+	const [, scheme, host, rest] = match;
+	const defaultPort = scheme === 'https' ? ':443' : ':80';
+	if (host?.endsWith(defaultPort)) {
+		candidates.push(`${scheme}://${host.slice(0, -defaultPort.length)}${rest}`);
+	} else if (host && !host.includes(':')) {
+		candidates.push(`${scheme}://${host}${defaultPort}${rest}`);
+	}
+	return candidates;
+}
+
+/**
+ * Verify a Twilio webhook delivery. Unlike Plivo's URL+nonce scheme, Twilio
+ * signs the URL **plus every form parameter**, so callers pass the parsed
+ * form body — all of it, since Twilio adds parameters without notice.
+ */
+export function verifyTwilioSignature(options: {
+	/** The account auth token (the signing key). */
+	authToken: string;
+	/** The URL Twilio called, as configured/reconstructed (query kept encoded). */
+	url: string;
+	/** Every form parameter of the request, form-decoded. */
+	params: TwilioWebhookParams;
+	/** The `X-Twilio-Signature` header value. */
+	signature: string;
+}): boolean {
+	if (!options.authToken || options.signature === '') {
+		return false;
+	}
+	const provided = Buffer.from(options.signature.trim(), 'utf8');
+	return urlCandidates(options.url).some((url) => {
+		const expected = Buffer.from(
+			signTwilioRequest({ authToken: options.authToken, url, params: options.params }),
+			'utf8',
+		);
+		return provided.length === expected.length && timingSafeEqual(provided, expected);
+	});
+}
+
+/**
+ * The Messages-API transport both channel senders share: one endpoint, one
+ * auth header, one form-encoded payload — only the `whatsapp:` address prefix
+ * and the status-callback URL (each channel's own webhook) differ per channel.
+ */
+class TwilioMessageTransport {
+	private readonly endpoint: string;
+	private readonly headers: Record<string, string>;
+	private readonly statusCallbackUrl: string;
+	private readonly fetchImpl: FetchLike;
+
+	constructor(options: TwilioOptions & { statusCallbackUrl?: string }) {
+		this.endpoint = accountUrl(options.apiUrl, options.accountSid, '/Messages.json');
+		this.headers = basicAuth(options.accountSid, options.authToken);
+		this.statusCallbackUrl = options.statusCallbackUrl ?? '';
+		this.fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+	}
+
+	protected async post(
+		message: { from: string; to: string; text: string },
+		addressPrefix: '' | 'whatsapp:',
+		label: string,
+	): Promise<void> {
+		const form = new URLSearchParams({
+			From: `${addressPrefix}${message.from}`,
+			To: `${addressPrefix}${message.to}`,
+			Body: message.text,
+		});
+		// Delivery reports come back to the channel's webhook so failures flag the inbox.
+		if (this.statusCallbackUrl !== '') {
+			form.set('StatusCallback', this.statusCallbackUrl);
+		}
+		const response = await this.fetchImpl(this.endpoint, {
+			method: 'POST',
+			headers: this.headers,
+			body: form.toString(),
+		});
+		if (!response.ok) {
+			const detail = await response.text().catch(() => '');
+			throw new Error(
+				`Twilio rejected the ${label} message (status ${response.status})${detail ? `: ${detail}` : ''}`,
+			);
+		}
+	}
+}
+
+export class TwilioWhatsappSender extends TwilioMessageTransport implements WhatsappSender {
+	/**
+	 * Send a free-form WhatsApp text. Meta only allows free-form messages inside
+	 * the 24-hour customer-service window, which every agent send satisfies (the
+	 * customer always messages first). TODO(twilio): templated sends via the
+	 * Content API when Rivus initiates conversations outside the window.
+	 */
+	async sendMessage(message: WhatsappMessage): Promise<void> {
+		await this.post(message, 'whatsapp:', 'WhatsApp');
+	}
+}
+
+export class TwilioSmsSender extends TwilioMessageTransport implements SmsSender {
+	/** Send an SMS. The SMS renderer caps bodies at Twilio's 1600-char limit already. */
+	async sendMessage(message: SmsMessage): Promise<void> {
+		await this.post(message, '', 'SMS');
+	}
+}
+
+const searchResponseSchema = z.object({
+	available_phone_numbers: z.array(z.object({ phone_number: z.string() })).default([]),
+});
+
+const purchaseResponseSchema = z.object({
+	sid: z.string().default(''),
+	phone_number: z.string().default(''),
+});
+
+/**
+ * Rents an SMS+voice-capable number from Twilio when an owner enables a
+ * channel — the same one-number-across-channels model as the Plivo
+ * provisioner, with one improvement Twilio makes possible: the purchase call
+ * attaches the number's inbound webhooks (SmsUrl, VoiceUrl) in the same
+ * request, so no console step is needed for SMS or voice to start flowing.
+ *
+ * WhatsApp still needs the number registered as a WhatsApp sender afterwards
+ * (Twilio's Senders API can do it programmatically, but it requires a WABA
+ * link and an OTP round-trip). TODO(twilio): automate sender registration via
+ * POST messaging.twilio.com/v2/Channels/Senders once WABA onboarding is set up.
+ */
+export class TwilioProvisioner implements ChannelProvisioner {
+	private readonly apiUrl: string;
+	private readonly accountSid: string;
+	private readonly headers: Record<string, string>;
+	private readonly country: string;
+	private readonly webhooks: { smsUrl: string; voiceUrl: string };
+	private readonly fetchImpl: FetchLike;
+
+	constructor(
+		options: TwilioOptions & {
+			numberCountry: string;
+			/** Public webhook URLs to attach to the number at purchase ('' skips). */
+			smsUrl?: string;
+			voiceUrl?: string;
+		},
+	) {
+		this.apiUrl = options.apiUrl;
+		this.accountSid = options.accountSid;
+		this.headers = basicAuth(options.accountSid, options.authToken);
+		this.country = options.numberCountry.toUpperCase();
+		this.webhooks = { smsUrl: options.smsUrl ?? '', voiceUrl: options.voiceUrl ?? '' };
+		this.fetchImpl = options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+	}
+
+	async provision(input: {
+		accountId: AccountId;
+		accountName: string;
+		existing: ProvisionedIdentifier;
+	}): Promise<ProvisionedIdentifier> {
+		// Idempotent: never re-provision an account that already holds a number.
+		if (input.existing.address !== '') {
+			return input.existing;
+		}
+		const number = await this.findAvailableNumber();
+		const purchased = await this.purchase(number);
+		// Twilio returns E.164 with the leading `+` already.
+		const address = normalizePhone(purchased.phoneNumber);
+		if (address === '') {
+			throw new Error(`Twilio offered a number that is not valid E.164: ${purchased.phoneNumber}`);
+		}
+		return { address, providerRef: purchased.sid };
+	}
+
+	/** Search for a rentable local number that supports voice + SMS. */
+	private async findAvailableNumber(): Promise<string> {
+		const query = new URLSearchParams({
+			SmsEnabled: 'true',
+			VoiceEnabled: 'true',
+			PageSize: '5',
+		});
+		const response = await this.fetchImpl(
+			`${accountUrl(this.apiUrl, this.accountSid, `/AvailablePhoneNumbers/${this.country}/Local.json`)}?${query}`,
+			{ method: 'GET', headers: this.headers },
+		);
+		if (!response.ok) {
+			const detail = await response.text().catch(() => '');
+			throw new Error(
+				`Twilio number search failed (status ${response.status})${detail ? `: ${detail}` : ''}`,
+			);
+		}
+		const parsed = searchResponseSchema.safeParse(JSON.parse(await response.text()));
+		const number = parsed.success
+			? parsed.data.available_phone_numbers[0]?.phone_number
+			: undefined;
+		if (!number) {
+			throw new Error(`Twilio has no ${this.country} numbers with voice+SMS available to rent.`);
+		}
+		return number;
+	}
+
+	private async purchase(number: string): Promise<{ sid: string; phoneNumber: string }> {
+		const form = new URLSearchParams({ PhoneNumber: number });
+		// Attach the inbound webhooks in the same call — the number is live for
+		// SMS and voice the moment it is rented, no console step.
+		if (this.webhooks.smsUrl !== '') {
+			form.set('SmsUrl', this.webhooks.smsUrl);
+			form.set('SmsMethod', 'POST');
+		}
+		if (this.webhooks.voiceUrl !== '') {
+			form.set('VoiceUrl', this.webhooks.voiceUrl);
+			form.set('VoiceMethod', 'POST');
+		}
+		const response = await this.fetchImpl(
+			accountUrl(this.apiUrl, this.accountSid, '/IncomingPhoneNumbers.json'),
+			{ method: 'POST', headers: this.headers, body: form.toString() },
+		);
+		if (!response.ok) {
+			const detail = await response.text().catch(() => '');
+			throw new Error(
+				`Twilio refused to rent ${number} (status ${response.status})${detail ? `: ${detail}` : ''}`,
+			);
+		}
+		const parsed = purchaseResponseSchema.safeParse(JSON.parse(await response.text()));
+		if (!parsed.success || parsed.data.sid === '') {
+			throw new Error(`Twilio did not confirm the rental of ${number}.`);
+		}
+		return { sid: parsed.data.sid, phoneNumber: parsed.data.phone_number || number };
+	}
+}
+
+/** Twilio phone-number SIDs: `PN` + 32 hex characters. */
+const TWILIO_NUMBER_SID = /^PN[0-9a-fA-F]{32}$/;
+
+/** Whether a stored providerRef names a Twilio-owned number. */
+export function twilioOwnsRef(providerRef: string): boolean {
+	return TWILIO_NUMBER_SID.test(providerRef);
+}
+
+/**
+ * The identifier a channel config holds **iff Twilio owns its number** — the
+ * fingerprint is the `PN…` phone-number SID {@link TwilioProvisioner} stores,
+ * which no other provisioner writes (Plivo stores the bare digits, zernio its
+ * own opaque id, the no-op `'noop'`). The channel-enable route uses this to
+ * share one number across channels; `messaging-provider` uses it to route each
+ * send through the number's owner.
+ */
+export function twilioOwnedIdentifier(config: AccountChannelConfig): ProvisionedIdentifier | null {
+	if (config.address === '' || !twilioOwnsRef(config.providerRef)) {
+		return null;
+	}
+	return { address: config.address, providerRef: config.providerRef };
+}
+
+type TwilioCredentials = Pick<
+	Config,
+	'TWILIO_ACCOUNT_SID' | 'TWILIO_AUTH_TOKEN' | 'TWILIO_API_URL'
+>;
+
+/** A WhatsApp sender for the config: real Twilio when credentials are present, else a no-op. */
+export function createTwilioWhatsappSender(
+	config: TwilioCredentials & Pick<Config, 'TWILIO_WHATSAPP_WEBHOOK_URL'>,
+	fetchImpl?: FetchLike,
+): WhatsappSender {
+	if (!config.TWILIO_ACCOUNT_SID || !config.TWILIO_AUTH_TOKEN) {
+		return new NoopWhatsappSender();
+	}
+	return new TwilioWhatsappSender({
+		accountSid: config.TWILIO_ACCOUNT_SID,
+		authToken: config.TWILIO_AUTH_TOKEN,
+		apiUrl: config.TWILIO_API_URL,
+		statusCallbackUrl: config.TWILIO_WHATSAPP_WEBHOOK_URL,
+		fetchImpl,
+	});
+}
+
+/** An SMS sender for the config: real Twilio when credentials are present, else a no-op. */
+export function createTwilioSmsSender(
+	config: TwilioCredentials & Pick<Config, 'TWILIO_SMS_WEBHOOK_URL'>,
+	fetchImpl?: FetchLike,
+): SmsSender {
+	if (!config.TWILIO_ACCOUNT_SID || !config.TWILIO_AUTH_TOKEN) {
+		return new NoopSmsSender();
+	}
+	return new TwilioSmsSender({
+		accountSid: config.TWILIO_ACCOUNT_SID,
+		authToken: config.TWILIO_AUTH_TOKEN,
+		apiUrl: config.TWILIO_API_URL,
+		statusCallbackUrl: config.TWILIO_SMS_WEBHOOK_URL,
+		fetchImpl,
+	});
+}
+
+/** A channel provisioner for the config: real Twilio when credentials are present, else a no-op. */
+export function createTwilioProvisioner(
+	config: TwilioCredentials &
+		Pick<Config, 'TWILIO_NUMBER_COUNTRY' | 'TWILIO_SMS_WEBHOOK_URL' | 'TWILIO_VOICE_WEBHOOK_URL'>,
+	fetchImpl?: FetchLike,
+): ChannelProvisioner {
+	if (!config.TWILIO_ACCOUNT_SID || !config.TWILIO_AUTH_TOKEN) {
+		return new NoopChannelProvisioner();
+	}
+	return new TwilioProvisioner({
+		accountSid: config.TWILIO_ACCOUNT_SID,
+		authToken: config.TWILIO_AUTH_TOKEN,
+		apiUrl: config.TWILIO_API_URL,
+		numberCountry: config.TWILIO_NUMBER_COUNTRY,
+		smsUrl: config.TWILIO_SMS_WEBHOOK_URL,
+		// The number's VoiceUrl is the answer endpoint of the voice webhook pair.
+		voiceUrl: config.TWILIO_VOICE_WEBHOOK_URL,
+		fetchImpl,
+	});
+}

--- a/packages/api/src/services/whatsapp.ts
+++ b/packages/api/src/services/whatsapp.ts
@@ -13,6 +13,13 @@ export interface WhatsappMessage {
 	to: string;
 	/** Plain-text message body. */
 	text: string;
+	/**
+	 * The provider's handle for the sending number, as stored on the account's
+	 * channel config ('' / absent when unknown). A multi-provider deployment
+	 * routes each send through the provider that owns the number (mid-migration,
+	 * Twilio and Plivo numbers coexist); single-provider senders ignore it.
+	 */
+	providerRef?: string;
 }
 
 /** Delivers WhatsApp messages. Implementations reject on delivery failure. */

--- a/packages/api/test/account-channels-route.test.ts
+++ b/packages/api/test/account-channels-route.test.ts
@@ -163,8 +163,26 @@ describe('one provider-owned number shared across channels', () => {
 		app = undefined;
 	});
 
+	// Adoption requires the number's owning provider to be configured (an
+	// unconfigured owner can neither send from nor receive on the number), so
+	// each case states which providers the deployment has.
+	function configuredWith(env: Record<string, string>) {
+		return loadConfig({
+			NODE_ENV: 'test',
+			JWT_SECRET: 'test-secret-value-1234',
+			...env,
+		} as NodeJS.ProcessEnv);
+	}
+	const PLIVO_CREDS = { PLIVO_AUTH_ID: 'MA_X', PLIVO_AUTH_TOKEN: 'plivo-token' };
+	const TWILIO_CREDS = {
+		TWILIO_ACCOUNT_SID: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+		TWILIO_AUTH_TOKEN: 'twilio-token',
+	};
+
 	it('enabling SMS adopts the WhatsApp channel’s Plivo-owned number', async () => {
-		const { app: built, repos } = await buildTestAppWithRepos();
+		const { app: built, repos } = await buildTestAppWithRepos({
+			config: configuredWith(PLIVO_CREDS),
+		});
 		app = built;
 		const owner = await signupOwner(app);
 		// A Plivo-provisioned WhatsApp number: providerRef is the bare digits.
@@ -183,7 +201,9 @@ describe('one provider-owned number shared across channels', () => {
 	});
 
 	it('enabling WhatsApp adopts the SMS channel’s Plivo-owned number (either direction)', async () => {
-		const { app: built, repos } = await buildTestAppWithRepos();
+		const { app: built, repos } = await buildTestAppWithRepos({
+			config: configuredWith(PLIVO_CREDS),
+		});
 		app = built;
 		const owner = await signupOwner(app);
 		await repos.accounts.setChannelConfig(owner.account.id as AccountId, 'sms', {
@@ -231,7 +251,9 @@ describe('one provider-owned number shared across channels', () => {
 	});
 
 	it('enabling voice adopts the account’s Plivo-owned messaging number', async () => {
-		const { app: built, repos } = await buildTestAppWithRepos();
+		const { app: built, repos } = await buildTestAppWithRepos({
+			config: configuredWith(PLIVO_CREDS),
+		});
 		app = built;
 		const owner = await signupOwner(app);
 		await repos.accounts.setChannelConfig(owner.account.id as AccountId, 'sms', {
@@ -249,7 +271,9 @@ describe('one provider-owned number shared across channels', () => {
 	});
 
 	it('enabling SMS adopts the WhatsApp channel’s Twilio-owned number (PN ref)', async () => {
-		const { app: built, repos } = await buildTestAppWithRepos();
+		const { app: built, repos } = await buildTestAppWithRepos({
+			config: configuredWith(TWILIO_CREDS),
+		});
 		app = built;
 		const owner = await signupOwner(app);
 		const accountId = owner.account.id as AccountId;
@@ -271,8 +295,11 @@ describe('one provider-owned number shared across channels', () => {
 		expect(account?.channels.sms.providerRef).toBe('PN0123456789abcdef0123456789abcdef');
 	});
 
-	it('never shares a number Plivo does not own (zernio ids, dev fakes)', async () => {
-		const { app: built, repos } = await buildTestAppWithRepos();
+	it('never shares a number neither phone provider owns (zernio ids, dev fakes)', async () => {
+		// Both providers configured — the only reason not to share is the ref shape.
+		const { app: built, repos } = await buildTestAppWithRepos({
+			config: configuredWith({ ...PLIVO_CREDS, ...TWILIO_CREDS }),
+		});
 		app = built;
 		const owner = await signupOwner(app);
 		// A zernio-provisioned WhatsApp number: opaque providerRef, not bare digits.
@@ -291,6 +318,31 @@ describe('one provider-owned number shared across channels', () => {
 		const smsAddress = res.json().channels.sms.address;
 		expect(smsAddress).toMatch(/^\+1555\d{7}$/);
 		expect(smsAddress).not.toBe('+14155550102');
+	});
+
+	it('rents fresh instead of adopting a number whose provider is no longer configured', async () => {
+		// Only Twilio configured; the sibling holds a Plivo-owned number. Adopting
+		// it would enable a channel that can neither send nor receive — a fresh
+		// number through the configured primary keeps the new channel working.
+		const { app: built, repos } = await buildTestAppWithRepos({
+			config: configuredWith(TWILIO_CREDS),
+		});
+		app = built;
+		const owner = await signupOwner(app);
+		await repos.accounts.setChannelConfig(owner.account.id as AccountId, 'whatsapp', {
+			enabled: true,
+			address: '+14155550105',
+			providerRef: '14155550105',
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: ENABLE_SMS,
+			headers: authHeader(owner.token),
+		});
+		expect(res.statusCode).toBe(200);
+		const smsAddress = res.json().channels.sms.address;
+		expect(smsAddress).toMatch(/^\+1555\d{7}$/);
+		expect(smsAddress).not.toBe('+14155550105');
 	});
 });
 

--- a/packages/api/test/account-channels-route.test.ts
+++ b/packages/api/test/account-channels-route.test.ts
@@ -156,7 +156,7 @@ describe('account channel provisioning', () => {
 	});
 });
 
-describe('one Plivo number shared across channels', () => {
+describe('one provider-owned number shared across channels', () => {
 	let app: FastifyInstance | undefined;
 	afterEach(async () => {
 		await app?.close();
@@ -248,6 +248,29 @@ describe('one Plivo number shared across channels', () => {
 		expect(res.json().channels.voice).toMatchObject({ enabled: true, address: '+14155550103' });
 	});
 
+	it('enabling SMS adopts the WhatsApp channel’s Twilio-owned number (PN ref)', async () => {
+		const { app: built, repos } = await buildTestAppWithRepos();
+		app = built;
+		const owner = await signupOwner(app);
+		const accountId = owner.account.id as AccountId;
+		// A Twilio-provisioned number: providerRef is the PN… phone-number SID.
+		await repos.accounts.setChannelConfig(accountId, 'whatsapp', {
+			enabled: true,
+			address: '+14155550104',
+			providerRef: 'PN0123456789abcdef0123456789abcdef',
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: ENABLE_SMS,
+			headers: authHeader(owner.token),
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.json().channels.sms).toMatchObject({ enabled: true, address: '+14155550104' });
+		// The fingerprint rode along, so outbound SMS routes through Twilio.
+		const account = await repos.accounts.findById(accountId);
+		expect(account?.channels.sms.providerRef).toBe('PN0123456789abcdef0123456789abcdef');
+	});
+
 	it('never shares a number Plivo does not own (zernio ids, dev fakes)', async () => {
 		const { app: built, repos } = await buildTestAppWithRepos();
 		app = built;
@@ -328,5 +351,32 @@ describe('production refuses channels with no configured provider', () => {
 		});
 		// The injected (noop) provisioner answers; the config gate passed.
 		expect(res.statusCode).toBe(200);
+	});
+
+	it('allows every channel when only Twilio is configured', async () => {
+		app = await buildTestApp({
+			config: productionConfig({
+				TWILIO_ACCOUNT_SID: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+				TWILIO_AUTH_TOKEN: 'twilio-token',
+			}),
+		});
+		const owner = await signupOwner(app);
+		for (const url of [ENABLE, ENABLE_SMS, '/v1/account/channels/voice/enable']) {
+			const res = await app.inject({ method: 'POST', url, headers: authHeader(owner.token) });
+			expect(res.statusCode).toBe(200);
+		}
+	});
+
+	it('503s on a partial Twilio credential pair (sid without token)', async () => {
+		app = await buildTestApp({
+			config: productionConfig({ TWILIO_ACCOUNT_SID: 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' }),
+		});
+		const owner = await signupOwner(app);
+		const res = await app.inject({
+			method: 'POST',
+			url: ENABLE_SMS,
+			headers: authHeader(owner.token),
+		});
+		expect(res.statusCode).toBe(503);
 	});
 });

--- a/packages/api/test/agent-messaging-twilio-route.test.ts
+++ b/packages/api/test/agent-messaging-twilio-route.test.ts
@@ -257,6 +257,16 @@ describe('POST /v1/channels/whatsapp/twilio/inbound', () => {
 			},
 		});
 		expectEmptyTwiml(delivered);
+		// The successful report was recognized-and-ignored: nothing got flagged.
+		const threadAfterDelivered = await repos.agentThreads.findByContact(
+			accountId,
+			'whatsapp',
+			SENDER,
+		);
+		const afterDelivered = threadAfterDelivered
+			? await repos.conversations.findById(accountId, threadAfterDelivered.conversationId)
+			: null;
+		expect(afterDelivered?.status).not.toBe('needs_attention');
 		const failed = await app.inject({
 			method: 'POST',
 			url: WHATSAPP_URL,

--- a/packages/api/test/agent-messaging-twilio-route.test.ts
+++ b/packages/api/test/agent-messaging-twilio-route.test.ts
@@ -1,0 +1,655 @@
+import type { AccountId } from '@rivus/core';
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildApp } from '../src/app';
+import { loadConfig } from '../src/config';
+import { createInMemoryRepositories } from '../src/repositories/memory';
+import { NoopReceivedEmailReader } from '../src/services/agent/email/received';
+import { parseTwilioInbound, type TwilioInboundResult } from '../src/services/agent/twilio-inbound';
+import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
+import { NoopFaqAnswerService } from '../src/services/faq-answer';
+import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
+import { createNotificationService } from '../src/services/notifications';
+import { signTwilioRequest } from '../src/services/twilio';
+import {
+	buildTestAppWithRepos,
+	RecordingMailer,
+	RecordingSmsSender,
+	RecordingWhatsappSender,
+	signupOwner,
+} from './helpers';
+
+const WHATSAPP_URL = '/v1/channels/whatsapp/twilio/inbound';
+const SMS_URL = '/v1/channels/sms/twilio/inbound';
+const BIZ = '+15550001111';
+const SENDER = '+15559990000';
+const NUMBER_SID = 'PN0123456789abcdef0123456789abcdef';
+const EMPTY_TWIML = '<Response/>';
+
+/** Twilio's WhatsApp address form. */
+function wa(number: string): string {
+	return `whatsapp:${number}`;
+}
+
+/** A Twilio-shaped inbound WhatsApp message, as the form parser presents it. */
+function inboundWhatsapp(overrides: Record<string, string> = {}) {
+	return {
+		From: wa(SENDER),
+		To: wa(BIZ),
+		Body: 'Hi there',
+		MessageSid: 'SMinbound001',
+		ProfileName: 'Dana',
+		NumMedia: '0',
+		...overrides,
+	};
+}
+
+/** A Twilio-shaped inbound SMS. */
+function inboundSms(overrides: Record<string, string> = {}) {
+	return {
+		From: SENDER,
+		To: BIZ,
+		Body: 'Hi there',
+		MessageSid: 'SMinbound001',
+		...overrides,
+	};
+}
+
+function whatsappSender(app: FastifyInstance): RecordingWhatsappSender {
+	return app.deps.whatsappSender as RecordingWhatsappSender;
+}
+
+function smsSender(app: FastifyInstance): RecordingSmsSender {
+	return app.deps.smsSender as RecordingSmsSender;
+}
+
+/** Build an app + repos and enable a Twilio-owned number on the owner's account. */
+async function setup(channel: 'whatsapp' | 'sms') {
+	const { app, repos } = await buildTestAppWithRepos();
+	const owner = await signupOwner(app);
+	const accountId = owner.account.id as AccountId;
+	await repos.accounts.setChannelConfig(accountId, channel, {
+		enabled: true,
+		address: BIZ,
+		providerRef: NUMBER_SID,
+	});
+	return { app, repos, accountId, owner };
+}
+
+/** Every Twilio webhook answer is the empty TwiML acknowledgment. */
+function expectEmptyTwiml(res: { statusCode: number; body: string; headers: unknown }) {
+	expect(res.statusCode).toBe(200);
+	expect(res.body).toBe(EMPTY_TWIML);
+	expect((res.headers as Record<string, string>)['content-type']).toContain('text/xml');
+}
+
+describe('POST /v1/channels/whatsapp/twilio/inbound', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('sends an unknown sender a signup link, threading the number’s providerRef', async () => {
+		const built = await setup('whatsapp');
+		app = built.app;
+		// Twilio posts form-encoded; the route registers the form parser.
+		const res = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: new URLSearchParams(inboundWhatsapp()).toString(),
+			headers: { 'content-type': 'application/x-www-form-urlencoded' },
+		});
+		expectEmptyTwiml(res);
+		const sent = whatsappSender(app).messages.at(-1);
+		expect(sent?.from).toBe(BIZ);
+		expect(sent?.to).toBe(SENDER);
+		expect(sent?.text).toContain(`phone=${encodeURIComponent(SENDER)}`);
+		// The reply carries the sending number's fingerprint so the outbound
+		// router sends it through Twilio, the number's owner.
+		expect(sent?.providerRef).toBe(NUMBER_SID);
+	});
+
+	it('books a slot for a recognized customer over two turns', async () => {
+		const { app: built, repos, accountId } = await setup('whatsapp');
+		app = built;
+		await repos.customers.create(accountId, {
+			name: 'Dana Fox',
+			email: '',
+			phone: '(555) 999-0000',
+			address: '12 Pine St',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+		const offer = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: new URLSearchParams(
+				inboundWhatsapp({ Body: 'When are you free?', MessageSid: 'SMa' }),
+			).toString(),
+			headers: { 'content-type': 'application/x-www-form-urlencoded' },
+		});
+		expectEmptyTwiml(offer);
+		expect(whatsappSender(app).messages.at(-1)?.text).toContain('1.');
+		const book = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: new URLSearchParams(inboundWhatsapp({ Body: '1', MessageSid: 'SMb' })).toString(),
+			headers: { 'content-type': 'application/x-www-form-urlencoded' },
+		});
+		expectEmptyTwiml(book);
+		const { total } = await repos.jobs.list({ accountId, page: 1, pageSize: 10 });
+		expect(total).toBe(1);
+	});
+
+	it('ignores an exact redelivery of an already-processed MessageSid', async () => {
+		const built = await setup('whatsapp');
+		app = built.app;
+		await app.inject({ method: 'POST', url: WHATSAPP_URL, payload: inboundWhatsapp() });
+		expect(whatsappSender(app).messages).toHaveLength(1);
+		const second = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: inboundWhatsapp(),
+		});
+		expectEmptyTwiml(second);
+		// The duplicate is acknowledged without a second reply.
+		expect(whatsappSender(app).messages).toHaveLength(1);
+	});
+
+	it('acknowledges without replying when the channel is disabled or the number unknown', async () => {
+		const { app: built, repos, accountId } = await setup('whatsapp');
+		app = built;
+		const unknown = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: inboundWhatsapp({ To: wa('+15557778888') }),
+		});
+		expectEmptyTwiml(unknown);
+		await repos.accounts.setChannelConfig(accountId, 'whatsapp', {
+			enabled: false,
+			address: BIZ,
+			providerRef: NUMBER_SID,
+		});
+		const disabled = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: inboundWhatsapp(),
+		});
+		expectEmptyTwiml(disabled);
+		expect(whatsappSender(app).messages).toHaveLength(0);
+	});
+
+	it('refuses to converse with any account’s own business number (loop guard)', async () => {
+		const built = await setup('whatsapp');
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: inboundWhatsapp({ From: wa(BIZ) }),
+		});
+		expectEmptyTwiml(res);
+		expect(whatsappSender(app).messages).toHaveLength(0);
+	});
+
+	it('declines media-only messages (text only) without replying', async () => {
+		const built = await setup('whatsapp');
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: inboundWhatsapp({ Body: '', NumMedia: '1' }),
+		});
+		expectEmptyTwiml(res);
+		expect(whatsappSender(app).messages).toHaveLength(0);
+	});
+
+	it('ignores an SMS-shaped delivery (bare addresses) on the WhatsApp hook', async () => {
+		const built = await setup('whatsapp');
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: inboundSms(),
+		});
+		expectEmptyTwiml(res);
+		expect(whatsappSender(app).messages).toHaveLength(0);
+	});
+
+	it('acknowledges with empty TwiML even when dispatch fails (Twilio never redelivers)', async () => {
+		const { app: built, repos } = await setup('whatsapp');
+		app = built;
+		vi.spyOn(repos.accounts, 'findByChannelAddress').mockRejectedValueOnce(new Error('db down'));
+		const res = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: inboundWhatsapp(),
+		});
+		// A 5xx would buy no redelivery from Twilio — the loss is logged instead.
+		expectEmptyTwiml(res);
+	});
+
+	it('answers unrecognized payloads with the empty TwiML (never a retry storm)', async () => {
+		const built = await setup('whatsapp');
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: { hello: 'world' },
+		});
+		expectEmptyTwiml(res);
+	});
+
+	it('flags the conversation when a status callback says failed, ignores the rest', async () => {
+		const { app: built, repos, accountId } = await setup('whatsapp');
+		app = built;
+		// Open a thread first (an unknown sender gets a signup link).
+		await app.inject({ method: 'POST', url: WHATSAPP_URL, payload: inboundWhatsapp() });
+		const delivered = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: {
+				From: wa(BIZ),
+				To: wa(SENDER),
+				MessageStatus: 'delivered',
+				MessageSid: 'SMout1',
+			},
+		});
+		expectEmptyTwiml(delivered);
+		const failed = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: new URLSearchParams({
+				From: wa(BIZ),
+				To: wa(SENDER),
+				MessageStatus: 'failed',
+				ErrorCode: '63024',
+				MessageSid: 'SMout1',
+			}).toString(),
+			headers: { 'content-type': 'application/x-www-form-urlencoded' },
+		});
+		expectEmptyTwiml(failed);
+		const thread = await repos.agentThreads.findByContact(accountId, 'whatsapp', SENDER);
+		const conversation = thread
+			? await repos.conversations.findById(accountId, thread.conversationId)
+			: null;
+		expect(conversation?.status).toBe('needs_attention');
+	});
+});
+
+describe('POST /v1/channels/sms/twilio/inbound', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('sends an unknown sender a signup link, threading the number’s providerRef', async () => {
+		const built = await setup('sms');
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: SMS_URL,
+			payload: new URLSearchParams(inboundSms()).toString(),
+			headers: { 'content-type': 'application/x-www-form-urlencoded' },
+		});
+		expectEmptyTwiml(res);
+		const sent = smsSender(app).messages.at(-1);
+		expect(sent?.from).toBe(BIZ);
+		expect(sent?.to).toBe(SENDER);
+		expect(sent?.providerRef).toBe(NUMBER_SID);
+	});
+
+	it('books a slot for a recognized customer over two turns', async () => {
+		const { app: built, repos, accountId } = await setup('sms');
+		app = built;
+		await repos.customers.create(accountId, {
+			name: 'Dana Fox',
+			email: '',
+			phone: '(555) 999-0000',
+			address: '12 Pine St',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+		await app.inject({
+			method: 'POST',
+			url: SMS_URL,
+			payload: inboundSms({ Body: 'When are you free?', MessageSid: 'SMa' }),
+		});
+		expect(smsSender(app).messages.at(-1)?.text).toContain('1.');
+		await app.inject({
+			method: 'POST',
+			url: SMS_URL,
+			payload: inboundSms({ Body: '1', MessageSid: 'SMb' }),
+		});
+		const { total } = await repos.jobs.list({ accountId, page: 1, pageSize: 10 });
+		expect(total).toBe(1);
+	});
+
+	it('ignores a WhatsApp-shaped delivery on the SMS hook', async () => {
+		const built = await setup('sms');
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: SMS_URL,
+			payload: inboundWhatsapp(),
+		});
+		expectEmptyTwiml(res);
+		expect(smsSender(app).messages).toHaveLength(0);
+	});
+
+	it('flags the conversation when a status callback says undelivered', async () => {
+		const { app: built, repos, accountId } = await setup('sms');
+		app = built;
+		await app.inject({ method: 'POST', url: SMS_URL, payload: inboundSms() });
+		const failed = await app.inject({
+			method: 'POST',
+			url: SMS_URL,
+			payload: { From: BIZ, To: SENDER, MessageStatus: 'undelivered', MessageSid: 'SMout1' },
+		});
+		expectEmptyTwiml(failed);
+		const thread = await repos.agentThreads.findByContact(accountId, 'sms', SENDER);
+		const conversation = thread
+			? await repos.conversations.findById(accountId, thread.conversationId)
+			: null;
+		expect(conversation?.status).toBe('needs_attention');
+	});
+});
+
+// --- Signature (separate config) ---------------------------------------------
+
+const ACCOUNT_SID = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const AUTH_TOKEN = 'twilio-test-auth-token';
+const PINNED_URL = 'https://api.rivus.ai/v1/channels/whatsapp/twilio/inbound';
+
+function buildTwilioApp(extraConfig: Record<string, string> = {}): FastifyInstance {
+	const repos = createInMemoryRepositories();
+	return buildApp({
+		config: loadConfig({
+			NODE_ENV: 'test',
+			JWT_SECRET: 'test-secret-value-1234',
+			...extraConfig,
+		} as NodeJS.ProcessEnv),
+		...repos,
+		mailer: new RecordingMailer(),
+		receivedEmails: new NoopReceivedEmailReader(),
+		whatsappSender: new RecordingWhatsappSender(),
+		whatsappProvisioner: new NoopChannelProvisioner(),
+		smsSender: new RecordingSmsSender(),
+		smsProvisioner: new NoopChannelProvisioner(),
+		notifier: createNotificationService({ notifications: repos.notifications }),
+		faqSimilarity: new NoopFaqSimilarityService(),
+		faqAnswer: new NoopFaqAnswerService(),
+		ping: async () => ({ ready: true }),
+	});
+}
+
+/** Sign `params` for `url` and POST them form-encoded with the signature header. */
+function signedInject(
+	app: FastifyInstance,
+	options: {
+		url: string;
+		signedUrl: string;
+		params: Record<string, string>;
+		extraHeaders?: Record<string, string>;
+		signature?: string;
+	},
+) {
+	return app.inject({
+		method: 'POST',
+		url: options.url,
+		payload: new URLSearchParams(options.params).toString(),
+		headers: {
+			'content-type': 'application/x-www-form-urlencoded',
+			'x-twilio-signature':
+				options.signature ??
+				signTwilioRequest({
+					authToken: AUTH_TOKEN,
+					url: options.signedUrl,
+					params: options.params,
+				}),
+			...options.extraHeaders,
+		},
+	});
+}
+
+describe('POST /v1/channels/whatsapp/twilio/inbound — signature', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('accepts a delivery signed for the pinned webhook URL and rejects the rest', async () => {
+		app = buildTwilioApp({
+			TWILIO_ACCOUNT_SID: ACCOUNT_SID,
+			TWILIO_AUTH_TOKEN: AUTH_TOKEN,
+			TWILIO_WHATSAPP_WEBHOOK_URL: PINNED_URL,
+		});
+		const params = inboundWhatsapp();
+		const ok = await signedInject(app, { url: WHATSAPP_URL, signedUrl: PINNED_URL, params });
+		// Unknown account, but the signature passed (a 401 would mean it didn't).
+		expect(ok.statusCode).toBe(200);
+		expect(ok.body).toBe(EMPTY_TWIML);
+
+		// Twilio signs the form parameters too — a tampered body invalidates it.
+		const tamperedParams = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: new URLSearchParams({ ...params, Body: 'tampered' }).toString(),
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded',
+				'x-twilio-signature': signTwilioRequest({
+					authToken: AUTH_TOKEN,
+					url: PINNED_URL,
+					params,
+				}),
+			},
+		});
+		expect(tamperedParams.statusCode).toBe(401);
+
+		const badSignature = await signedInject(app, {
+			url: WHATSAPP_URL,
+			signedUrl: PINNED_URL,
+			params,
+			signature: 'bm90LXRoZS1zaWduYXR1cmU=',
+		});
+		expect(badSignature.statusCode).toBe(401);
+
+		const unsigned = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: params,
+		});
+		expect(unsigned.statusCode).toBe(401);
+	});
+
+	it('verifies a delivery that repeats a form key (every occurrence is signed)', async () => {
+		app = buildTwilioApp({
+			TWILIO_ACCOUNT_SID: ACCOUNT_SID,
+			TWILIO_AUTH_TOKEN: AUTH_TOKEN,
+			TWILIO_WHATSAPP_WEBHOOK_URL: PINNED_URL,
+		});
+		const single = inboundWhatsapp();
+		const body = `${new URLSearchParams(single).toString()}&Extra=2&Extra=1`;
+		const res = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: body,
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded',
+				// Twilio's SDKs sign a repeated key as its distinct values, sorted.
+				'x-twilio-signature': signTwilioRequest({
+					authToken: AUTH_TOKEN,
+					url: PINNED_URL,
+					params: { ...single, Extra: ['2', '1'] },
+				}),
+			},
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.body).toBe(EMPTY_TWIML);
+	});
+
+	it('derives the signed URL from forwarding headers when none is pinned', async () => {
+		app = buildTwilioApp({
+			TWILIO_ACCOUNT_SID: ACCOUNT_SID,
+			TWILIO_AUTH_TOKEN: AUTH_TOKEN,
+		});
+		const params = inboundWhatsapp();
+		const res = await signedInject(app, {
+			url: WHATSAPP_URL,
+			signedUrl: PINNED_URL,
+			params,
+			extraHeaders: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'api.rivus.ai' },
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.body).toBe(EMPTY_TWIML);
+	});
+
+	it('keeps the query string in the signed URL (Twilio signs it verbatim)', async () => {
+		app = buildTwilioApp({
+			TWILIO_ACCOUNT_SID: ACCOUNT_SID,
+			TWILIO_AUTH_TOKEN: AUTH_TOKEN,
+		});
+		const params = inboundSms();
+		const res = await signedInject(app, {
+			url: `${SMS_URL}?foo=1&bar=2`,
+			signedUrl: `https://api.rivus.ai${SMS_URL}?foo=1&bar=2`,
+			params,
+			extraHeaders: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'api.rivus.ai' },
+		});
+		expect(res.statusCode).toBe(200);
+		// Signed without the query → rejected; the query is part of the signature.
+		const missingQuery = await signedInject(app, {
+			url: `${SMS_URL}?foo=1&bar=2`,
+			signedUrl: `https://api.rivus.ai${SMS_URL}`,
+			params,
+			extraHeaders: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'api.rivus.ai' },
+		});
+		expect(missingQuery.statusCode).toBe(401);
+	});
+
+	it('stays open when unconfigured outside production, and 503s in production', async () => {
+		app = buildTwilioApp();
+		const open = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: inboundWhatsapp(),
+		});
+		expect(open.statusCode).toBe(200);
+		expect(open.body).toBe(EMPTY_TWIML);
+		await app.close();
+
+		app = buildTwilioApp({
+			NODE_ENV: 'production',
+			JWT_SECRET: 'x'.repeat(32),
+			RESEND_API_KEY: 're_test_key',
+			LOG_LEVEL: 'silent',
+			CORS_ORIGIN: 'https://app.rivus.ai',
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: WHATSAPP_URL,
+			payload: inboundWhatsapp(),
+		});
+		expect(res.statusCode).toBe(503);
+	});
+
+	it('503s in production on a partial credential pair (token without account sid)', async () => {
+		app = buildTwilioApp({
+			NODE_ENV: 'production',
+			JWT_SECRET: 'x'.repeat(32),
+			RESEND_API_KEY: 're_test_key',
+			LOG_LEVEL: 'silent',
+			CORS_ORIGIN: 'https://app.rivus.ai',
+			TWILIO_AUTH_TOKEN: AUTH_TOKEN,
+		});
+		const params = inboundSms();
+		const res = await signedInject(app, {
+			url: SMS_URL,
+			signedUrl: `https://api.rivus.ai${SMS_URL}`,
+			params,
+			extraHeaders: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'api.rivus.ai' },
+		});
+		expect(res.statusCode).toBe(503);
+	});
+});
+
+// --- Payload mapping edges the route tests don't reach ------------------------
+
+describe('parseTwilioInbound', () => {
+	function kind(result: TwilioInboundResult): string {
+		return result.kind;
+	}
+
+	it('maps an inbound WhatsApp message, stripping the whatsapp: prefix', () => {
+		expect(parseTwilioInbound(inboundWhatsapp(), 'whatsapp')).toEqual({
+			kind: 'event',
+			event: {
+				type: 'whatsapp.message.received',
+				data: {
+					to: BIZ,
+					from: SENDER,
+					text: 'Hi there',
+					messageId: 'SMinbound001',
+					profileName: 'Dana',
+				},
+			},
+		});
+	});
+
+	it('uses the status as the failure reason when there is no error code', () => {
+		expect(
+			parseTwilioInbound({ From: BIZ, To: SENDER, MessageStatus: 'undelivered' }, 'sms'),
+		).toEqual({
+			kind: 'event',
+			event: {
+				type: 'whatsapp.message.failed',
+				data: { from: BIZ, to: SENDER, reason: 'undelivered' },
+			},
+		});
+	});
+
+	it('stringifies a numeric ErrorCode (JSON status callbacks)', () => {
+		expect(
+			parseTwilioInbound(
+				{ From: BIZ, To: SENDER, MessageStatus: 'failed', ErrorCode: 30008 },
+				'sms',
+			),
+		).toEqual({
+			kind: 'event',
+			event: {
+				type: 'whatsapp.message.failed',
+				data: { from: BIZ, to: SENDER, reason: '30008' },
+			},
+		});
+	});
+
+	it('ignores in-flight and successful status callbacks (case-insensitive)', () => {
+		for (const status of ['queued', 'sending', 'sent', 'delivered', 'read', 'DELIVERED']) {
+			expect(
+				kind(parseTwilioInbound({ From: BIZ, To: SENDER, MessageStatus: status }, 'sms')),
+			).toBe('ignored');
+		}
+	});
+
+	it('ignores cross-channel status callbacks rather than misrouting them', () => {
+		expect(
+			kind(parseTwilioInbound({ From: wa(BIZ), To: wa(SENDER), MessageStatus: 'failed' }, 'sms')),
+		).toBe('ignored');
+		expect(
+			kind(parseTwilioInbound({ From: BIZ, To: SENDER, MessageStatus: 'failed' }, 'whatsapp')),
+		).toBe('ignored');
+	});
+
+	it('rejects non-object and number-less payloads', () => {
+		expect(kind(parseTwilioInbound('a string', 'sms'))).toBe('unrecognized');
+		expect(kind(parseTwilioInbound(null, 'sms'))).toBe('unrecognized');
+		expect(kind(parseTwilioInbound({ From: 'garbage', To: BIZ, Body: 'x' }, 'sms'))).toBe(
+			'unrecognized',
+		);
+		expect(kind(parseTwilioInbound({ From: SENDER, Body: 'x' }, 'sms'))).toBe('unrecognized');
+	});
+});

--- a/packages/api/test/agent-voice-twilio-route.test.ts
+++ b/packages/api/test/agent-voice-twilio-route.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { buildApp } from '../src/app';
 import { loadConfig } from '../src/config';
 import { createInMemoryRepositories } from '../src/repositories/memory';
+import { runVoiceTurn, VOICE_LINES } from '../src/routes/agent-voice-shared';
 import { NoopReceivedEmailReader } from '../src/services/agent/email/received';
 import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
 import { NoopFaqAnswerService } from '../src/services/faq-answer';
@@ -82,6 +83,18 @@ describe('POST /v1/channels/voice/twilio/answer', () => {
 			method: 'POST',
 			url: ANSWER_URL,
 			payload: call({ To: '+15557778888' }),
+		});
+		expect(res.body).toContain('isn&apos;t in service');
+		expect(res.body).not.toContain('<Gather');
+	});
+
+	it('speaks not-in-service when the called number is missing entirely', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: ANSWER_URL,
+			payload: { From: CALLER, CallSid: 'CAcall0002' },
 		});
 		expect(res.body).toContain('isn&apos;t in service');
 		expect(res.body).not.toContain('<Gather');
@@ -218,6 +231,18 @@ describe('POST /v1/channels/voice/twilio/input', () => {
 		});
 		expect(res.body).toContain('didn&apos;t catch that');
 		expect(res.body).toContain('<Gather');
+	});
+
+	it('declines restricted/anonymous callers mid-call too', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ From: 'anonymous', SpeechResult: 'hello' }),
+		});
+		expect(res.body).toContain('restricted or anonymous');
+		expect(res.body).not.toContain('<Gather');
 	});
 
 	it('speaks an apology when the orchestrator fails mid-turn', async () => {
@@ -439,5 +464,52 @@ describe('POST /v1/channels/voice/twilio/* — signature', () => {
 		});
 		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
 		expect(res.statusCode).toBe(503);
+	});
+});
+
+// --- The shared voice core's fallback edge ------------------------------------
+
+describe('runVoiceTurn', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('ends the call politely when the turn produces nothing to speak', async () => {
+		const { app: built, repos } = await buildTestAppWithRepos();
+		app = built;
+		const owner = await signupOwner(app);
+		const account = await repos.accounts.findById(owner.account.id as AccountId);
+		if (!account) {
+			throw new Error('account missing');
+		}
+		const turn = await runVoiceTurn({
+			deps: {
+				config: app.deps.config,
+				jobs: repos.jobs,
+				conversations: repos.conversations,
+				agentThreads: repos.agentThreads,
+			},
+			customers: repos.customers,
+			// A capability whose reply renders to empty speech — there is nothing
+			// to say, so the call must close politely instead of looping silence.
+			capabilities: [
+				{
+					id: 'mute',
+					matches: () => true,
+					handle: async () => ({
+						response: { blocks: [] },
+						outcome: 'mute',
+						threadPatch: {},
+					}),
+				},
+			],
+			account,
+			caller: CALLER,
+			speech: 'hello there',
+			logger: app.log,
+		});
+		expect(turn).toEqual({ mode: 'terminal', text: VOICE_LINES.goodbye });
 	});
 });

--- a/packages/api/test/agent-voice-twilio-route.test.ts
+++ b/packages/api/test/agent-voice-twilio-route.test.ts
@@ -1,0 +1,443 @@
+import type { AccountId } from '@rivus/core';
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildApp } from '../src/app';
+import { loadConfig } from '../src/config';
+import { createInMemoryRepositories } from '../src/repositories/memory';
+import { NoopReceivedEmailReader } from '../src/services/agent/email/received';
+import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
+import { NoopFaqAnswerService } from '../src/services/faq-answer';
+import { NoopFaqSimilarityService } from '../src/services/faq-similarity';
+import { createNotificationService } from '../src/services/notifications';
+import { signTwilioRequest } from '../src/services/twilio';
+import {
+	buildTestAppWithRepos,
+	RecordingMailer,
+	RecordingSmsSender,
+	RecordingWhatsappSender,
+	signupOwner,
+} from './helpers';
+
+const ANSWER_URL = '/v1/channels/voice/twilio/answer';
+const INPUT_URL = '/v1/channels/voice/twilio/input';
+// Twilio delivers numbers already in E.164.
+const BIZ = '+15550003333';
+const CALLER = '+15559990000';
+const NUMBER_SID = 'PN0123456789abcdef0123456789abcdef';
+
+function call(overrides: Record<string, string> = {}) {
+	return {
+		From: CALLER,
+		To: BIZ,
+		CallSid: 'CAcall0001',
+		...overrides,
+	};
+}
+
+/** Build an app + repos and enable voice on the signed-up owner's account. */
+async function setup() {
+	const { app, repos } = await buildTestAppWithRepos();
+	const owner = await signupOwner(app);
+	const accountId = owner.account.id as AccountId;
+	await repos.accounts.setChannelConfig(accountId, 'voice', {
+		enabled: true,
+		address: BIZ,
+		providerRef: NUMBER_SID,
+	});
+	return { app, repos, accountId, owner };
+}
+
+describe('POST /v1/channels/voice/twilio/answer', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('greets the caller by business name and gathers speech', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(res.statusCode).toBe(200);
+		expect(res.headers['content-type']).toContain('xml');
+		expect(res.body).toContain('<Gather');
+		expect(res.body).toContain('input="speech"');
+		expect(res.body).toContain('speechTimeout="auto"');
+		expect(res.body).toContain(`action="http://localhost:80${INPUT_URL}"`);
+		expect(res.body).toContain('scheduling assistant');
+	});
+
+	it('escapes XML-significant characters in the spoken account name', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.accounts.update(accountId, { name: 'Smith & Sons <Plumbing>' });
+		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(res.body).toContain('Smith &amp; Sons &lt;Plumbing&gt;');
+	});
+
+	it('speaks a not-in-service message for a number no account holds', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: ANSWER_URL,
+			payload: call({ To: '+15557778888' }),
+		});
+		expect(res.body).toContain('isn&apos;t in service');
+		expect(res.body).not.toContain('<Gather');
+	});
+
+	it('declines restricted/anonymous callers up front instead of greeting them', async () => {
+		const built = await setup();
+		app = built.app;
+		// Twilio marks withheld caller IDs with non-numeric From values.
+		for (const from of ['', 'anonymous', 'restricted']) {
+			const res = await app.inject({
+				method: 'POST',
+				url: ANSWER_URL,
+				payload: call({ From: from }),
+			});
+			expect(res.body).toContain('restricted or anonymous');
+			expect(res.body).not.toContain('<Gather');
+		}
+	});
+
+	it('speaks an apology instead of JSON when a dependency fails (Twilio needs TwiML)', async () => {
+		const { app: built, repos } = await setup();
+		app = built;
+		vi.spyOn(repos.accounts, 'findByChannelAddress').mockRejectedValueOnce(new Error('db down'));
+		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(res.statusCode).toBe(200);
+		expect(res.headers['content-type']).toContain('xml');
+		expect(res.body).toContain('something went wrong');
+		expect(res.body).not.toContain('<Gather');
+	});
+
+	it('declines the call when the channel is disabled', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.accounts.setChannelConfig(accountId, 'voice', {
+			enabled: false,
+			address: BIZ,
+			providerRef: NUMBER_SID,
+		});
+		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(res.body).toContain('isn&apos;t taking calls');
+		expect(res.body).not.toContain('<Gather');
+	});
+});
+
+describe('POST /v1/channels/voice/twilio/input', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('offers slots to a recognized caller and keeps gathering', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.customers.create(accountId, {
+			name: 'Dana Fox',
+			email: '',
+			phone: '(555) 999-0000',
+			address: '12 Pine St',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ SpeechResult: 'When are you free?' }),
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.body).toContain('Option 1:');
+		expect(res.body).toContain('Say the number that works for you');
+		expect(res.body).toContain('<Gather');
+	});
+
+	it('books when the caller picks a slot, then ends the call', async () => {
+		const { app: built, repos, accountId } = await setup();
+		app = built;
+		await repos.customers.create(accountId, {
+			name: 'Dana Fox',
+			email: '',
+			phone: '+1 (555) 999-0000',
+			address: '12 Pine St',
+			lifetimeValue: 0,
+			balance: 0,
+			notes: '',
+		});
+		await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ SpeechResult: 'When are you free?' }),
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			// ASR often writes the pick out in words; the shared core normalizes it.
+			payload: call({ SpeechResult: 'option one' }),
+		});
+		expect(res.body).toContain('You&apos;re booked!');
+		expect(res.body).toContain('Goodbye');
+		expect(res.body).not.toContain('<Gather');
+		const { total } = await repos.jobs.list({ accountId, page: 1, pageSize: 10 });
+		expect(total).toBe(1);
+		// The call landed in the inbox as a phone conversation with a transcript.
+		const thread = await repos.agentThreads.findByContact(accountId, 'phone', CALLER);
+		expect(thread).not.toBeNull();
+		const messages = thread
+			? await repos.conversations.listMessages(accountId, thread.conversationId)
+			: [];
+		expect(messages?.some((m) => m.author === 'customer' && m.body === 'option 1')).toBe(true);
+	});
+
+	it('sends an unknown caller to signup and ends the call with the spoken link', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ SpeechResult: 'Can I book something?' }),
+		});
+		expect(res.body).toContain('rivus.ai/customers/join/');
+		expect(res.body).not.toContain('https://');
+		expect(res.body).not.toContain('<Gather');
+		expect(res.body).toContain('Goodbye');
+	});
+
+	it('re-prompts when nothing was transcribed', async () => {
+		const built = await setup();
+		app = built.app;
+		const res = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ SpeechResult: '   ' }),
+		});
+		expect(res.body).toContain('didn&apos;t catch that');
+		expect(res.body).toContain('<Gather');
+	});
+
+	it('speaks an apology when the orchestrator fails mid-turn', async () => {
+		const { app: built, repos } = await setup();
+		app = built;
+		vi.spyOn(repos.agentThreads, 'findByContact').mockRejectedValueOnce(new Error('db down'));
+		const res = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ SpeechResult: 'When are you free?' }),
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.headers['content-type']).toContain('xml');
+		expect(res.body).toContain('something went wrong');
+	});
+
+	it('hangs up on calls for unknown numbers or from an account’s own number', async () => {
+		const { app: built, repos } = await setup();
+		app = built;
+		const unknown = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ To: '+15557778888', SpeechResult: 'hello' }),
+		});
+		expect(unknown.body).toContain('isn&apos;t in service');
+
+		// A second account whose voice number calls the first (loop guard).
+		const other = await signupOwner(app);
+		await repos.accounts.setChannelConfig(other.account.id as AccountId, 'voice', {
+			enabled: true,
+			address: '+15552224444',
+			providerRef: 'PNfeedfacefeedfacefeedfacefeedface',
+		});
+		const loop = await app.inject({
+			method: 'POST',
+			url: INPUT_URL,
+			payload: call({ From: '+15552224444', SpeechResult: 'hello' }),
+		});
+		expect(loop.body).toContain('Goodbye');
+		expect(loop.body).not.toContain('<Gather');
+	});
+});
+
+// --- Signature and pinned URLs (separate config) -------------------------------
+
+const ACCOUNT_SID = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const AUTH_TOKEN = 'twilio-test-auth-token';
+const PINNED_ANSWER_URL = 'https://api.rivus.ai/v1/channels/voice/twilio/answer';
+const PINNED_INPUT_URL = 'https://api.rivus.ai/v1/channels/voice/twilio/input';
+
+function buildVoiceApp(extraConfig: Record<string, string> = {}): FastifyInstance {
+	const repos = createInMemoryRepositories();
+	return buildApp({
+		config: loadConfig({
+			NODE_ENV: 'test',
+			JWT_SECRET: 'test-secret-value-1234',
+			...extraConfig,
+		} as NodeJS.ProcessEnv),
+		...repos,
+		mailer: new RecordingMailer(),
+		receivedEmails: new NoopReceivedEmailReader(),
+		whatsappSender: new RecordingWhatsappSender(),
+		whatsappProvisioner: new NoopChannelProvisioner(),
+		smsSender: new RecordingSmsSender(),
+		smsProvisioner: new NoopChannelProvisioner(),
+		notifier: createNotificationService({ notifications: repos.notifications }),
+		faqSimilarity: new NoopFaqSimilarityService(),
+		faqAnswer: new NoopFaqAnswerService(),
+		ping: async () => ({ ready: true }),
+	});
+}
+
+/** POST `params` form-encoded with an X-Twilio-Signature minted for `signedUrl`. */
+function signedInject(
+	app: FastifyInstance,
+	options: { url: string; signedUrl: string; params: Record<string, string> },
+) {
+	return app.inject({
+		method: 'POST',
+		url: options.url,
+		payload: new URLSearchParams(options.params).toString(),
+		headers: {
+			'content-type': 'application/x-www-form-urlencoded',
+			'x-twilio-signature': signTwilioRequest({
+				authToken: AUTH_TOKEN,
+				url: options.signedUrl,
+				params: options.params,
+			}),
+		},
+	});
+}
+
+describe('POST /v1/channels/voice/twilio/* — signature', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('verifies against each endpoint’s own reconstructed URL when nothing is pinned', async () => {
+		app = buildVoiceApp({ TWILIO_ACCOUNT_SID: ACCOUNT_SID, TWILIO_AUTH_TOKEN: AUTH_TOKEN });
+		const signed = await signedInject(app, {
+			url: ANSWER_URL,
+			signedUrl: `http://localhost:80${ANSWER_URL}`,
+			params: call(),
+		});
+		// Unknown account, but spoken politely — the signature passed.
+		expect(signed.statusCode).toBe(200);
+		expect(signed.body).toContain('isn&apos;t in service');
+
+		const unsigned = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(unsigned.statusCode).toBe(401);
+
+		// A signature minted for the answer URL never opens the input URL.
+		const crossPath = await signedInject(app, {
+			url: INPUT_URL,
+			signedUrl: `http://localhost:80${ANSWER_URL}`,
+			params: call({ SpeechResult: 'hi' }),
+		});
+		expect(crossPath.statusCode).toBe(401);
+
+		// The form parameters are part of the signature.
+		const params = call();
+		const tampered = await app.inject({
+			method: 'POST',
+			url: ANSWER_URL,
+			payload: new URLSearchParams({ ...params, From: '+15550009999' }).toString(),
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded',
+				'x-twilio-signature': signTwilioRequest({
+					authToken: AUTH_TOKEN,
+					url: `http://localhost:80${ANSWER_URL}`,
+					params,
+				}),
+			},
+		});
+		expect(tampered.statusCode).toBe(401);
+	});
+
+	it('pins the answer URL and derives the input and action URLs from it', async () => {
+		app = buildVoiceApp({
+			TWILIO_ACCOUNT_SID: ACCOUNT_SID,
+			TWILIO_AUTH_TOKEN: AUTH_TOKEN,
+			TWILIO_VOICE_WEBHOOK_URL: PINNED_ANSWER_URL,
+		});
+		// The answer endpoint verifies against the pinned URL (no forwarding
+		// headers needed) and hands Gather the pinned origin's input URL.
+		const answer = await signedInject(app, {
+			url: ANSWER_URL,
+			signedUrl: PINNED_ANSWER_URL,
+			params: call(),
+		});
+		expect(answer.statusCode).toBe(200);
+
+		// The input endpoint verifies against the derived input URL — exactly the
+		// action URL the answer TwiML hands out.
+		const input = await signedInject(app, {
+			url: INPUT_URL,
+			signedUrl: PINNED_INPUT_URL,
+			params: call({ SpeechResult: 'hi' }),
+		});
+		expect(input.statusCode).toBe(200);
+
+		// With a pin, a request-derived signature no longer verifies.
+		const requestDerived = await signedInject(app, {
+			url: ANSWER_URL,
+			signedUrl: `http://localhost:80${ANSWER_URL}`,
+			params: call(),
+		});
+		expect(requestDerived.statusCode).toBe(401);
+	});
+
+	it('speaks the pinned origin in the Gather action URL', async () => {
+		// Signature checking off (no token) to reach the handler easily; the pin
+		// still steers the action URL.
+		const repos = createInMemoryRepositories();
+		const built = buildApp({
+			config: loadConfig({
+				NODE_ENV: 'test',
+				JWT_SECRET: 'test-secret-value-1234',
+				TWILIO_VOICE_WEBHOOK_URL: PINNED_ANSWER_URL,
+			} as NodeJS.ProcessEnv),
+			...repos,
+			mailer: new RecordingMailer(),
+			receivedEmails: new NoopReceivedEmailReader(),
+			whatsappSender: new RecordingWhatsappSender(),
+			whatsappProvisioner: new NoopChannelProvisioner(),
+			smsSender: new RecordingSmsSender(),
+			smsProvisioner: new NoopChannelProvisioner(),
+			notifier: createNotificationService({ notifications: repos.notifications }),
+			faqSimilarity: new NoopFaqSimilarityService(),
+			faqAnswer: new NoopFaqAnswerService(),
+			ping: async () => ({ ready: true }),
+		});
+		app = built;
+		const owner = await signupOwner(app);
+		await repos.accounts.setChannelConfig(owner.account.id as AccountId, 'voice', {
+			enabled: true,
+			address: BIZ,
+			providerRef: NUMBER_SID,
+		});
+		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(res.body).toContain(`action="${PINNED_INPUT_URL}"`);
+		expect(res.body).not.toContain('localhost');
+	});
+
+	it('stays open when unconfigured outside production, and 503s in production', async () => {
+		app = buildVoiceApp();
+		const open = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(open.statusCode).toBe(200);
+		await app.close();
+
+		app = buildVoiceApp({
+			NODE_ENV: 'production',
+			JWT_SECRET: 'x'.repeat(32),
+			RESEND_API_KEY: 're_test_key',
+			LOG_LEVEL: 'silent',
+			CORS_ORIGIN: 'https://app.rivus.ai',
+		});
+		const res = await app.inject({ method: 'POST', url: ANSWER_URL, payload: call() });
+		expect(res.statusCode).toBe(503);
+	});
+});

--- a/packages/api/test/plivo.test.ts
+++ b/packages/api/test/plivo.test.ts
@@ -4,12 +4,6 @@ import { describe, expect, it } from 'vitest';
 import { loadConfig } from '../src/config';
 import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
 import {
-	createSmsProvisioner,
-	createSmsSender,
-	createWhatsappProvisioner,
-	createWhatsappSender,
-} from '../src/services/messaging-provider';
-import {
 	createPlivoProvisioner,
 	createPlivoSmsSender,
 	createPlivoWhatsappSender,
@@ -23,7 +17,6 @@ import {
 import type { FetchLike } from '../src/services/resend-mailer';
 import { NoopSmsSender } from '../src/services/sms';
 import { NoopWhatsappSender } from '../src/services/whatsapp';
-import { ZernioProvisioner, ZernioWhatsappSender } from '../src/services/zernio-whatsapp';
 
 const AUTH_ID = 'MA_TEST_AUTH_ID';
 const AUTH_TOKEN = 'test-auth-token';
@@ -349,6 +342,19 @@ describe('PlivoProvisioner', () => {
 		});
 	});
 
+	it('stores the address’s own bare digits as the ref, whatever form the search returned', async () => {
+		// The ref is the ownership fingerprint (`plivoOwnsRef`), so it must be
+		// canonical even if Plivo ever returns a `+`-formed number.
+		const { fetchImpl } = fakeFetch([
+			{ ok: true, status: 200, body: '{"objects":[{"number":"+14154009186"}]}' },
+			{ ok: true, status: 201, body: '{"numbers":[{"number":"14154009186","status":"Success"}]}' },
+		]);
+		await expect(provisioner(fetchImpl).provision(INPUT)).resolves.toEqual({
+			address: '+14154009186',
+			providerRef: '14154009186',
+		});
+	});
+
 	it('fails when Plivo offers a number that is not valid E.164', async () => {
 		const { fetchImpl } = fakeFetch([
 			{ ok: true, status: 200, body: '{"objects":[{"number":"not-a-number"}]}' },
@@ -358,47 +364,26 @@ describe('PlivoProvisioner', () => {
 	});
 });
 
+// Provider *selection* (which provider a config routes to, mixed-fleet
+// outbound routing) is covered in test/twilio.test.ts alongside the Twilio
+// adapter; this section covers only the Plivo factories themselves.
 describe('provider factories', () => {
 	it('Plivo factories degrade to no-ops without credentials', () => {
 		const config = testConfig();
 		expect(createPlivoWhatsappSender(config)).toBeInstanceOf(NoopWhatsappSender);
+		expect(createPlivoSmsSender(config)).toBeInstanceOf(NoopSmsSender);
 		expect(createPlivoProvisioner(config)).toBeInstanceOf(NoopChannelProvisioner);
+
+		// One Plivo credential alone is not a configured provider.
+		const partial = testConfig({ PLIVO_AUTH_ID: AUTH_ID });
+		expect(createPlivoWhatsappSender(partial)).toBeInstanceOf(NoopWhatsappSender);
+		expect(createPlivoProvisioner(partial)).toBeInstanceOf(NoopChannelProvisioner);
 	});
 
 	it('Plivo factories build real adapters when credentials are set', () => {
 		const config = testConfig({ PLIVO_AUTH_ID: AUTH_ID, PLIVO_AUTH_TOKEN: AUTH_TOKEN });
 		expect(createPlivoWhatsappSender(config)).toBeInstanceOf(PlivoWhatsappSender);
+		expect(createPlivoSmsSender(config)).toBeInstanceOf(PlivoSmsSender);
 		expect(createPlivoProvisioner(config)).toBeInstanceOf(PlivoProvisioner);
-	});
-
-	it('selects Plivo first, then zernio, then the no-ops', () => {
-		const plivo = testConfig({
-			PLIVO_AUTH_ID: AUTH_ID,
-			PLIVO_AUTH_TOKEN: AUTH_TOKEN,
-			ZERNIO_API_KEY: 'zk_1',
-		});
-		expect(createWhatsappSender(plivo)).toBeInstanceOf(PlivoWhatsappSender);
-		expect(createWhatsappProvisioner(plivo)).toBeInstanceOf(PlivoProvisioner);
-
-		const zernio = testConfig({ ZERNIO_API_KEY: 'zk_1' });
-		expect(createWhatsappSender(zernio)).toBeInstanceOf(ZernioWhatsappSender);
-		expect(createWhatsappProvisioner(zernio)).toBeInstanceOf(ZernioProvisioner);
-
-		// One Plivo credential alone is not a configured provider — fall through.
-		const partial = testConfig({ PLIVO_AUTH_ID: AUTH_ID });
-		expect(createWhatsappSender(partial)).toBeInstanceOf(NoopWhatsappSender);
-		expect(createWhatsappProvisioner(partial)).toBeInstanceOf(NoopChannelProvisioner);
-	});
-
-	it('SMS is Plivo or a no-op — zernio never serves it', () => {
-		const plivo = testConfig({ PLIVO_AUTH_ID: AUTH_ID, PLIVO_AUTH_TOKEN: AUTH_TOKEN });
-		expect(createSmsSender(plivo)).toBeInstanceOf(PlivoSmsSender);
-		expect(createSmsProvisioner(plivo)).toBeInstanceOf(PlivoProvisioner);
-
-		const zernioOnly = testConfig({ ZERNIO_API_KEY: 'zk_1' });
-		expect(createSmsSender(zernioOnly)).toBeInstanceOf(NoopSmsSender);
-		expect(createSmsProvisioner(zernioOnly)).toBeInstanceOf(NoopChannelProvisioner);
-
-		expect(createPlivoSmsSender(testConfig())).toBeInstanceOf(NoopSmsSender);
 	});
 });

--- a/packages/api/test/twilio.test.ts
+++ b/packages/api/test/twilio.test.ts
@@ -181,6 +181,12 @@ describe('signTwilioRequest / verifyTwilioSignature', () => {
 			verifyTwilioSignature({ authToken: AUTH_TOKEN, url: DOC_URL, params: {}, signature: '' }),
 		).toBe(false);
 	});
+
+	it('verifies a non-URL string as-is (no port variants to try)', () => {
+		const url = 'not-a-url';
+		const signature = signTwilioRequest({ authToken: AUTH_TOKEN, url, params: {} });
+		expect(verifyTwilioSignature({ authToken: AUTH_TOKEN, url, params: {}, signature })).toBe(true);
+	});
 });
 
 describe('TwilioWhatsappSender', () => {
@@ -278,6 +284,23 @@ describe('TwilioSmsSender', () => {
 		await expect(sender.sendMessage(MESSAGE)).rejects.toThrow(
 			/SMS message \(status 402\).*insufficient funds/,
 		);
+	});
+
+	it('reports the bare status when the error body cannot be read', async () => {
+		const fetchImpl: FetchLike = async () => ({
+			ok: false,
+			status: 500,
+			text: async () => {
+				throw new Error('stream torn down');
+			},
+		});
+		const sender = new TwilioSmsSender({
+			accountSid: ACCOUNT_SID,
+			authToken: AUTH_TOKEN,
+			apiUrl: API_URL,
+			fetchImpl,
+		});
+		await expect(sender.sendMessage(MESSAGE)).rejects.toThrow(/SMS message \(status 500\)$/);
 	});
 });
 

--- a/packages/api/test/twilio.test.ts
+++ b/packages/api/test/twilio.test.ts
@@ -1,0 +1,613 @@
+import type { AccountId } from '@rivus/core';
+import { describe, expect, it } from 'vitest';
+import { loadConfig } from '../src/config';
+import { NoopChannelProvisioner } from '../src/services/channel-provisioning';
+import {
+	createSmsProvisioner,
+	createSmsSender,
+	createWhatsappProvisioner,
+	createWhatsappSender,
+} from '../src/services/messaging-provider';
+import { PlivoProvisioner } from '../src/services/plivo';
+import type { FetchLike } from '../src/services/resend-mailer';
+import { NoopSmsSender } from '../src/services/sms';
+import {
+	createTwilioProvisioner,
+	createTwilioSmsSender,
+	createTwilioWhatsappSender,
+	signTwilioRequest,
+	TwilioProvisioner,
+	TwilioSmsSender,
+	TwilioWhatsappSender,
+	twilioOwnedIdentifier,
+	twilioOwnsRef,
+	verifyTwilioSignature,
+} from '../src/services/twilio';
+import { NoopWhatsappSender } from '../src/services/whatsapp';
+import { ZernioProvisioner } from '../src/services/zernio-whatsapp';
+
+const ACCOUNT_SID = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const AUTH_TOKEN = 'twilio-test-auth-token';
+const API_URL = 'https://api.twilio.example';
+const NUMBER_SID = 'PN0123456789abcdef0123456789abcdef';
+
+interface RecordedCall {
+	url: string;
+	init: { method: string; headers: Record<string, string>; body?: string };
+}
+
+interface CannedResponse {
+	ok: boolean;
+	status: number;
+	body: string;
+}
+
+/** A FetchLike that replays canned responses in order and records every call. */
+function fakeFetch(responses: CannedResponse[]): { fetchImpl: FetchLike; calls: RecordedCall[] } {
+	const calls: RecordedCall[] = [];
+	const fetchImpl: FetchLike = async (url, init) => {
+		calls.push({ url, init });
+		const canned = responses[calls.length - 1];
+		if (!canned) {
+			throw new Error(`unexpected fetch #${calls.length} to ${url}`);
+		}
+		return { ok: canned.ok, status: canned.status, text: async () => canned.body };
+	};
+	return { fetchImpl, calls };
+}
+
+function testConfig(env: Record<string, string> = {}) {
+	return loadConfig({
+		NODE_ENV: 'test',
+		JWT_SECRET: 'test-secret-value-1234',
+		...env,
+	} as NodeJS.ProcessEnv);
+}
+
+describe('signTwilioRequest / verifyTwilioSignature', () => {
+	// Twilio's own worked example from the request-validation docs ("Explore the
+	// algorithm yourself"): the query string stays exactly as requested (foo
+	// before bar), the POST params are sorted and appended name+value with no
+	// delimiters, HMAC-SHA1 keyed by the auth token, base64.
+	const DOC_URL = 'https://example.com/myapp.php?foo=1&bar=2';
+	const DOC_PARAMS = {
+		CallSid: 'CA1234567890ABCDE',
+		Caller: '+14158675310',
+		Digits: '1234',
+		From: '+14158675310',
+		To: '+18005551212',
+	};
+
+	it("reproduces Twilio's published signature for the documented example", () => {
+		expect(signTwilioRequest({ authToken: '12345', url: DOC_URL, params: DOC_PARAMS })).toBe(
+			'L/OH5YylLD5NRKLltdqwSvS0BnU=',
+		);
+	});
+
+	it('accepts the documented signature and rejects tampering', () => {
+		const signature = 'L/OH5YylLD5NRKLltdqwSvS0BnU=';
+		expect(
+			verifyTwilioSignature({ authToken: '12345', url: DOC_URL, params: DOC_PARAMS, signature }),
+		).toBe(true);
+		// A changed parameter value (the body is signed, unlike Plivo's scheme).
+		expect(
+			verifyTwilioSignature({
+				authToken: '12345',
+				url: DOC_URL,
+				params: { ...DOC_PARAMS, Digits: '9999' },
+				signature,
+			}),
+		).toBe(false);
+		// An added parameter.
+		expect(
+			verifyTwilioSignature({
+				authToken: '12345',
+				url: DOC_URL,
+				params: { ...DOC_PARAMS, Extra: 'x' },
+				signature,
+			}),
+		).toBe(false);
+		// The wrong URL or the wrong token.
+		expect(
+			verifyTwilioSignature({
+				authToken: '12345',
+				url: 'https://elsewhere.example/hook',
+				params: DOC_PARAMS,
+				signature,
+			}),
+		).toBe(false);
+		expect(
+			verifyTwilioSignature({ authToken: 'other', url: DOC_URL, params: DOC_PARAMS, signature }),
+		).toBe(false);
+	});
+
+	it('accepts a signature computed with or without the default port (both directions)', () => {
+		const withPort = 'https://api.rivus.example:443/v1/channels/sms/twilio/inbound';
+		const withoutPort = 'https://api.rivus.example/v1/channels/sms/twilio/inbound';
+		const params = { From: '+15550001111', Body: 'hi' };
+		const signedWithout = signTwilioRequest({ authToken: AUTH_TOKEN, url: withoutPort, params });
+		const signedWith = signTwilioRequest({ authToken: AUTH_TOKEN, url: withPort, params });
+		// Twilio's own back end is inconsistent about explicit default ports, so
+		// the SDKs (and this verifier) accept either variant of the same URL.
+		expect(
+			verifyTwilioSignature({
+				authToken: AUTH_TOKEN,
+				url: withPort,
+				params,
+				signature: signedWithout,
+			}),
+		).toBe(true);
+		expect(
+			verifyTwilioSignature({
+				authToken: AUTH_TOKEN,
+				url: withoutPort,
+				params,
+				signature: signedWith,
+			}),
+		).toBe(true);
+		// A non-default port is not rewritten — only :443/:80 get the sibling check.
+		const oddPort = 'https://api.rivus.example:8443/hook';
+		expect(
+			verifyTwilioSignature({
+				authToken: AUTH_TOKEN,
+				url: oddPort,
+				params,
+				signature: signTwilioRequest({ authToken: AUTH_TOKEN, url: oddPort, params }),
+			}),
+		).toBe(true);
+	});
+
+	it('signs a repeated parameter as its distinct values, sorted, name re-attached', () => {
+		// The behavior of Twilio's own SDK validators: dedupe, sort, append per value.
+		const repeated = signTwilioRequest({
+			authToken: AUTH_TOKEN,
+			url: 'https://example.com/hook',
+			params: { A: ['2', '1', '2'], B: 'x' },
+		});
+		const flattened = signTwilioRequest({
+			authToken: AUTH_TOKEN,
+			url: 'https://example.com/hookA1A2', // A1A2 appended = what the array must produce
+			params: { B: 'x' },
+		});
+		expect(repeated).toBe(flattened);
+	});
+
+	it('rejects when the token or signature is missing', () => {
+		const signature = signTwilioRequest({ authToken: AUTH_TOKEN, url: DOC_URL, params: {} });
+		expect(verifyTwilioSignature({ authToken: '', url: DOC_URL, params: {}, signature })).toBe(
+			false,
+		);
+		expect(
+			verifyTwilioSignature({ authToken: AUTH_TOKEN, url: DOC_URL, params: {}, signature: '' }),
+		).toBe(false);
+	});
+});
+
+describe('TwilioWhatsappSender', () => {
+	const MESSAGE = { from: '+15550001111', to: '+15559990000', text: 'Your slot is booked.' };
+
+	it('POSTs a form-encoded message with whatsapp:-prefixed addresses and Basic auth', async () => {
+		const { fetchImpl, calls } = fakeFetch([
+			{ ok: true, status: 201, body: '{"sid":"SM123","status":"queued"}' },
+		]);
+		const sender = new TwilioWhatsappSender({
+			accountSid: ACCOUNT_SID,
+			authToken: AUTH_TOKEN,
+			apiUrl: API_URL,
+			fetchImpl,
+		});
+		await sender.sendMessage(MESSAGE);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toBe(`${API_URL}/2010-04-01/Accounts/${ACCOUNT_SID}/Messages.json`);
+		expect(calls[0]?.init.method).toBe('POST');
+		const credentials = Buffer.from(`${ACCOUNT_SID}:${AUTH_TOKEN}`).toString('base64');
+		expect(calls[0]?.init.headers.authorization).toBe(`Basic ${credentials}`);
+		expect(calls[0]?.init.headers['content-type']).toBe('application/x-www-form-urlencoded');
+		const form = new URLSearchParams(calls[0]?.init.body ?? '');
+		expect(form.get('From')).toBe('whatsapp:+15550001111');
+		expect(form.get('To')).toBe('whatsapp:+15559990000');
+		expect(form.get('Body')).toBe(MESSAGE.text);
+		expect(form.has('StatusCallback')).toBe(false);
+	});
+
+	it('attaches the delivery-status callback URL when configured', async () => {
+		const { fetchImpl, calls } = fakeFetch([{ ok: true, status: 201, body: '{"sid":"SM1"}' }]);
+		const sender = new TwilioWhatsappSender({
+			accountSid: ACCOUNT_SID,
+			authToken: AUTH_TOKEN,
+			apiUrl: API_URL,
+			statusCallbackUrl: 'https://api.rivus.ai/v1/channels/whatsapp/twilio/inbound',
+			fetchImpl,
+		});
+		await sender.sendMessage(MESSAGE);
+		const form = new URLSearchParams(calls[0]?.init.body ?? '');
+		expect(form.get('StatusCallback')).toBe(
+			'https://api.rivus.ai/v1/channels/whatsapp/twilio/inbound',
+		);
+	});
+
+	it('rejects with the status and response detail when Twilio refuses the send', async () => {
+		const { fetchImpl } = fakeFetch([
+			{
+				ok: false,
+				status: 400,
+				body: '{"code":63016,"message":"outside the allowed window"}',
+			},
+		]);
+		const sender = new TwilioWhatsappSender({
+			accountSid: ACCOUNT_SID,
+			authToken: AUTH_TOKEN,
+			apiUrl: API_URL,
+			fetchImpl,
+		});
+		await expect(sender.sendMessage(MESSAGE)).rejects.toThrow(
+			/WhatsApp message \(status 400\).*outside the allowed window/,
+		);
+	});
+});
+
+describe('TwilioSmsSender', () => {
+	const MESSAGE = { from: '+15550001111', to: '+15559990000', text: 'See you at 2pm.' };
+
+	it('POSTs bare E.164 addresses (no channel prefix) with the SMS status callback', async () => {
+		const { fetchImpl, calls } = fakeFetch([{ ok: true, status: 201, body: '{"sid":"SM2"}' }]);
+		const sender = new TwilioSmsSender({
+			accountSid: ACCOUNT_SID,
+			authToken: AUTH_TOKEN,
+			apiUrl: API_URL,
+			statusCallbackUrl: 'https://api.rivus.ai/v1/channels/sms/twilio/inbound',
+			fetchImpl,
+		});
+		await sender.sendMessage(MESSAGE);
+		expect(calls[0]?.url).toBe(`${API_URL}/2010-04-01/Accounts/${ACCOUNT_SID}/Messages.json`);
+		const form = new URLSearchParams(calls[0]?.init.body ?? '');
+		expect(form.get('From')).toBe('+15550001111');
+		expect(form.get('To')).toBe('+15559990000');
+		expect(form.get('Body')).toBe(MESSAGE.text);
+		expect(form.get('StatusCallback')).toBe('https://api.rivus.ai/v1/channels/sms/twilio/inbound');
+	});
+
+	it('rejects with the status and response detail when Twilio refuses the send', async () => {
+		const { fetchImpl } = fakeFetch([{ ok: false, status: 402, body: 'insufficient funds' }]);
+		const sender = new TwilioSmsSender({
+			accountSid: ACCOUNT_SID,
+			authToken: AUTH_TOKEN,
+			apiUrl: API_URL,
+			fetchImpl,
+		});
+		await expect(sender.sendMessage(MESSAGE)).rejects.toThrow(
+			/SMS message \(status 402\).*insufficient funds/,
+		);
+	});
+});
+
+describe('twilioOwnsRef / twilioOwnedIdentifier', () => {
+	it('recognizes a Twilio-provisioned config (providerRef = PN… phone-number SID)', () => {
+		expect(twilioOwnsRef(NUMBER_SID)).toBe(true);
+		expect(
+			twilioOwnedIdentifier({ enabled: true, address: '+14155552671', providerRef: NUMBER_SID }),
+		).toEqual({ address: '+14155552671', providerRef: NUMBER_SID });
+	});
+
+	it("rejects refs Twilio does not own (Plivo's bare digits, zernio ids, dev fakes, empties)", () => {
+		expect(twilioOwnsRef('14155552671')).toBe(false);
+		expect(twilioOwnsRef('zwa_1')).toBe(false);
+		expect(twilioOwnsRef('noop')).toBe(false);
+		expect(twilioOwnsRef('')).toBe(false);
+		// Truncated and over-long SIDs are not fingerprints.
+		expect(twilioOwnsRef(NUMBER_SID.slice(0, -1))).toBe(false);
+		expect(twilioOwnsRef(`${NUMBER_SID}0`)).toBe(false);
+		expect(
+			twilioOwnedIdentifier({ enabled: true, address: '+14155552671', providerRef: '14155552671' }),
+		).toBeNull();
+		expect(twilioOwnedIdentifier({ enabled: false, address: '', providerRef: '' })).toBeNull();
+		// A ref with no address can't be shared or sent from.
+		expect(
+			twilioOwnedIdentifier({ enabled: true, address: '', providerRef: NUMBER_SID }),
+		).toBeNull();
+	});
+});
+
+describe('TwilioProvisioner', () => {
+	const INPUT = {
+		accountId: 'acc_1' as AccountId,
+		accountName: 'Cascade Plumbing',
+		existing: { address: '', providerRef: '' },
+	};
+
+	function provisioner(
+		fetchImpl: FetchLike,
+		options: { country?: string; smsUrl?: string; voiceUrl?: string } = {},
+	) {
+		return new TwilioProvisioner({
+			accountSid: ACCOUNT_SID,
+			authToken: AUTH_TOKEN,
+			apiUrl: API_URL,
+			numberCountry: options.country ?? 'us',
+			smsUrl: options.smsUrl,
+			voiceUrl: options.voiceUrl,
+			fetchImpl,
+		});
+	}
+
+	it('returns the existing identifier untouched (idempotent re-enable)', async () => {
+		const { fetchImpl, calls } = fakeFetch([]);
+		const existing = { address: '+15551234567', providerRef: NUMBER_SID };
+		await expect(provisioner(fetchImpl).provision({ ...INPUT, existing })).resolves.toEqual(
+			existing,
+		);
+		expect(calls).toHaveLength(0);
+	});
+
+	it('searches for a voice+SMS local number, rents it with webhooks attached, and stores the PN sid', async () => {
+		const { fetchImpl, calls } = fakeFetch([
+			{
+				ok: true,
+				status: 200,
+				body: '{"available_phone_numbers":[{"phone_number":"+14155552671"}]}',
+			},
+			{ ok: true, status: 201, body: `{"sid":"${NUMBER_SID}","phone_number":"+14155552671"}` },
+		]);
+		const provisioned = await provisioner(fetchImpl, {
+			smsUrl: 'https://api.rivus.ai/v1/channels/sms/twilio/inbound',
+			voiceUrl: 'https://api.rivus.ai/v1/channels/voice/twilio/answer',
+		}).provision(INPUT);
+		expect(provisioned).toEqual({ address: '+14155552671', providerRef: NUMBER_SID });
+
+		const searchUrl = new URL(calls[0]?.url ?? '');
+		expect(searchUrl.pathname).toBe(
+			`/2010-04-01/Accounts/${ACCOUNT_SID}/AvailablePhoneNumbers/US/Local.json`,
+		);
+		expect(searchUrl.searchParams.get('SmsEnabled')).toBe('true');
+		expect(searchUrl.searchParams.get('VoiceEnabled')).toBe('true');
+		expect(calls[0]?.init.method).toBe('GET');
+		expect(calls[0]?.init.body).toBeUndefined();
+
+		expect(calls[1]?.url).toBe(
+			`${API_URL}/2010-04-01/Accounts/${ACCOUNT_SID}/IncomingPhoneNumbers.json`,
+		);
+		expect(calls[1]?.init.method).toBe('POST');
+		const form = new URLSearchParams(calls[1]?.init.body ?? '');
+		expect(form.get('PhoneNumber')).toBe('+14155552671');
+		// The webhooks ride the same purchase call — the number is live immediately.
+		expect(form.get('SmsUrl')).toBe('https://api.rivus.ai/v1/channels/sms/twilio/inbound');
+		expect(form.get('SmsMethod')).toBe('POST');
+		expect(form.get('VoiceUrl')).toBe('https://api.rivus.ai/v1/channels/voice/twilio/answer');
+		expect(form.get('VoiceMethod')).toBe('POST');
+	});
+
+	it('omits the webhook parameters when no public URLs are configured', async () => {
+		const { fetchImpl, calls } = fakeFetch([
+			{
+				ok: true,
+				status: 200,
+				body: '{"available_phone_numbers":[{"phone_number":"+14155552671"}]}',
+			},
+			{ ok: true, status: 201, body: `{"sid":"${NUMBER_SID}","phone_number":"+14155552671"}` },
+		]);
+		await provisioner(fetchImpl).provision(INPUT);
+		const form = new URLSearchParams(calls[1]?.init.body ?? '');
+		expect(form.has('SmsUrl')).toBe(false);
+		expect(form.has('SmsMethod')).toBe(false);
+		expect(form.has('VoiceUrl')).toBe(false);
+		expect(form.has('VoiceMethod')).toBe(false);
+	});
+
+	it('fails when the search errors or returns no numbers', async () => {
+		const errored = fakeFetch([{ ok: false, status: 500, body: 'upstream sad' }]);
+		await expect(provisioner(errored.fetchImpl).provision(INPUT)).rejects.toThrow(
+			/number search failed \(status 500\)/,
+		);
+		const empty = fakeFetch([{ ok: true, status: 200, body: '{"available_phone_numbers":[]}' }]);
+		await expect(provisioner(empty.fetchImpl).provision(INPUT)).rejects.toThrow(
+			/no US numbers with voice\+SMS/,
+		);
+	});
+
+	it('fails when the rental errors or is not confirmed', async () => {
+		const search = {
+			ok: true,
+			status: 200,
+			body: '{"available_phone_numbers":[{"phone_number":"+14155552671"}]}',
+		};
+		const refused = fakeFetch([search, { ok: false, status: 403, body: 'not available' }]);
+		await expect(provisioner(refused.fetchImpl).provision(INPUT)).rejects.toThrow(
+			/refused to rent \+14155552671 \(status 403\)/,
+		);
+		const unconfirmed = fakeFetch([search, { ok: true, status: 201, body: '{}' }]);
+		await expect(provisioner(unconfirmed.fetchImpl).provision(INPUT)).rejects.toThrow(
+			/did not confirm the rental/,
+		);
+	});
+
+	it('fails when Twilio offers a number that is not valid E.164', async () => {
+		const { fetchImpl } = fakeFetch([
+			{
+				ok: true,
+				status: 200,
+				body: '{"available_phone_numbers":[{"phone_number":"not-a-number"}]}',
+			},
+			{ ok: true, status: 201, body: `{"sid":"${NUMBER_SID}","phone_number":"not-a-number"}` },
+		]);
+		await expect(provisioner(fetchImpl).provision(INPUT)).rejects.toThrow(/not valid E\.164/);
+	});
+});
+
+describe('Twilio factories', () => {
+	it('degrade to no-ops without a full credential pair', () => {
+		const none = testConfig();
+		expect(createTwilioWhatsappSender(none)).toBeInstanceOf(NoopWhatsappSender);
+		expect(createTwilioSmsSender(none)).toBeInstanceOf(NoopSmsSender);
+		expect(createTwilioProvisioner(none)).toBeInstanceOf(NoopChannelProvisioner);
+
+		const partial = testConfig({ TWILIO_ACCOUNT_SID: ACCOUNT_SID });
+		expect(createTwilioWhatsappSender(partial)).toBeInstanceOf(NoopWhatsappSender);
+		expect(createTwilioSmsSender(partial)).toBeInstanceOf(NoopSmsSender);
+		expect(createTwilioProvisioner(partial)).toBeInstanceOf(NoopChannelProvisioner);
+	});
+
+	it('build real adapters when both credentials are set', () => {
+		const config = testConfig({
+			TWILIO_ACCOUNT_SID: ACCOUNT_SID,
+			TWILIO_AUTH_TOKEN: AUTH_TOKEN,
+		});
+		expect(createTwilioWhatsappSender(config)).toBeInstanceOf(TwilioWhatsappSender);
+		expect(createTwilioSmsSender(config)).toBeInstanceOf(TwilioSmsSender);
+		expect(createTwilioProvisioner(config)).toBeInstanceOf(TwilioProvisioner);
+	});
+});
+
+describe('provider selection and outbound routing', () => {
+	const PLIVO_ENV = {
+		PLIVO_AUTH_ID: 'MA_TEST_AUTH_ID',
+		PLIVO_AUTH_TOKEN: 'plivo-token',
+		PLIVO_API_URL: 'https://api.plivo.example/v1',
+	};
+	const TWILIO_ENV = {
+		TWILIO_ACCOUNT_SID: ACCOUNT_SID,
+		TWILIO_AUTH_TOKEN: AUTH_TOKEN,
+		TWILIO_API_URL: API_URL,
+	};
+	const ZERNIO_ENV = { ZERNIO_API_KEY: 'zk_1', ZERNIO_API_URL: 'https://api.zernio.example/v1' };
+
+	const OK = { ok: true, status: 201, body: '{"sid":"SM1"}' };
+
+	it('provisions new WhatsApp numbers via Twilio first, then Plivo, then zernio, then the no-op', () => {
+		const all = testConfig({ ...TWILIO_ENV, ...PLIVO_ENV, ...ZERNIO_ENV });
+		expect(createWhatsappProvisioner(all)).toBeInstanceOf(TwilioProvisioner);
+		expect(createWhatsappProvisioner(testConfig({ ...PLIVO_ENV, ...ZERNIO_ENV }))).toBeInstanceOf(
+			PlivoProvisioner,
+		);
+		expect(createWhatsappProvisioner(testConfig(ZERNIO_ENV))).toBeInstanceOf(ZernioProvisioner);
+		expect(createWhatsappProvisioner(testConfig())).toBeInstanceOf(NoopChannelProvisioner);
+		// One Twilio credential alone is not a configured provider — fall through.
+		expect(
+			createWhatsappProvisioner(testConfig({ TWILIO_ACCOUNT_SID: ACCOUNT_SID, ...PLIVO_ENV })),
+		).toBeInstanceOf(PlivoProvisioner);
+	});
+
+	it('provisions new SMS/voice numbers via Twilio first, then Plivo — zernio never serves them', () => {
+		expect(createSmsProvisioner(testConfig({ ...TWILIO_ENV, ...PLIVO_ENV }))).toBeInstanceOf(
+			TwilioProvisioner,
+		);
+		expect(createSmsProvisioner(testConfig(PLIVO_ENV))).toBeInstanceOf(PlivoProvisioner);
+		expect(createSmsProvisioner(testConfig(ZERNIO_ENV))).toBeInstanceOf(NoopChannelProvisioner);
+		expect(createSmsProvisioner(testConfig())).toBeInstanceOf(NoopChannelProvisioner);
+	});
+
+	it('routes each WhatsApp send through the provider that owns the number', async () => {
+		const config = testConfig({ ...TWILIO_ENV, ...PLIVO_ENV, ...ZERNIO_ENV });
+
+		// A Twilio-owned number (PN… ref) → the Twilio Messages API.
+		const viaTwilio = fakeFetch([OK]);
+		await createWhatsappSender(config, viaTwilio.fetchImpl).sendMessage({
+			from: '+15550001111',
+			to: '+15559990000',
+			text: 'hello',
+			providerRef: NUMBER_SID,
+		});
+		expect(viaTwilio.calls[0]?.url).toBe(
+			`${API_URL}/2010-04-01/Accounts/${ACCOUNT_SID}/Messages.json`,
+		);
+		expect(new URLSearchParams(viaTwilio.calls[0]?.init.body ?? '').get('From')).toBe(
+			'whatsapp:+15550001111',
+		);
+
+		// A Plivo-owned number (bare-digits ref) → the Plivo Message API.
+		const viaPlivo = fakeFetch([{ ok: true, status: 202, body: '{}' }]);
+		await createWhatsappSender(config, viaPlivo.fetchImpl).sendMessage({
+			from: '+15550001111',
+			to: '+15559990000',
+			text: 'hello',
+			providerRef: '15550001111',
+		});
+		expect(viaPlivo.calls[0]?.url).toBe(
+			'https://api.plivo.example/v1/Account/MA_TEST_AUTH_ID/Message/',
+		);
+		expect(JSON.parse(viaPlivo.calls[0]?.init.body ?? '{}').type).toBe('whatsapp');
+
+		// No fingerprint claims the ref → the primary (Twilio when configured).
+		const viaPrimary = fakeFetch([OK]);
+		await createWhatsappSender(config, viaPrimary.fetchImpl).sendMessage({
+			from: '+15550001111',
+			to: '+15559990000',
+			text: 'hello',
+			providerRef: '',
+		});
+		expect(viaPrimary.calls[0]?.url).toContain(API_URL);
+	});
+
+	it('routes SMS sends the same way, without the whatsapp: prefix', async () => {
+		const config = testConfig({ ...TWILIO_ENV, ...PLIVO_ENV });
+
+		const viaTwilio = fakeFetch([OK]);
+		await createSmsSender(config, viaTwilio.fetchImpl).sendMessage({
+			from: '+15550001111',
+			to: '+15559990000',
+			text: 'hi',
+			providerRef: NUMBER_SID,
+		});
+		expect(viaTwilio.calls[0]?.url).toBe(
+			`${API_URL}/2010-04-01/Accounts/${ACCOUNT_SID}/Messages.json`,
+		);
+		expect(new URLSearchParams(viaTwilio.calls[0]?.init.body ?? '').get('From')).toBe(
+			'+15550001111',
+		);
+
+		const viaPlivo = fakeFetch([{ ok: true, status: 202, body: '{}' }]);
+		await createSmsSender(config, viaPlivo.fetchImpl).sendMessage({
+			from: '+15550001111',
+			to: '+15559990000',
+			text: 'hi',
+			providerRef: '15550001111',
+		});
+		expect(viaPlivo.calls[0]?.url).toBe(
+			'https://api.plivo.example/v1/Account/MA_TEST_AUTH_ID/Message/',
+		);
+		expect(JSON.parse(viaPlivo.calls[0]?.init.body ?? '{}').type).toBe('sms');
+	});
+
+	it('sends a Twilio-fingerprinted number to the configured provider even when Twilio is not primary', async () => {
+		// Only Plivo configured: a PN… ref has no configured owner, so the send
+		// goes to the primary (Plivo) and fails loudly at the provider — a visible
+		// delivery error beats a silent no-op drop.
+		const plivoOnly = testConfig(PLIVO_ENV);
+		const { fetchImpl, calls } = fakeFetch([{ ok: true, status: 202, body: '{}' }]);
+		await createWhatsappSender(plivoOnly, fetchImpl).sendMessage({
+			from: '+15550001111',
+			to: '+15559990000',
+			text: 'hello',
+			providerRef: NUMBER_SID,
+		});
+		expect(calls[0]?.url).toBe('https://api.plivo.example/v1/Account/MA_TEST_AUTH_ID/Message/');
+	});
+
+	it('falls back to zernio for WhatsApp when it is the only configured provider', async () => {
+		const zernioOnly = testConfig(ZERNIO_ENV);
+		const { fetchImpl, calls } = fakeFetch([{ ok: true, status: 200, body: '{}' }]);
+		await createWhatsappSender(zernioOnly, fetchImpl).sendMessage({
+			from: '+15550001111',
+			to: '+15559990000',
+			text: 'hello',
+		});
+		expect(calls[0]?.url).toContain('https://api.zernio.example/v1');
+	});
+
+	it('degrades to silent no-ops when nothing is configured (dev/test boot)', async () => {
+		const none = testConfig();
+		const whatsapp = fakeFetch([]);
+		await createWhatsappSender(none, whatsapp.fetchImpl).sendMessage({
+			from: '+15550001111',
+			to: '+15559990000',
+			text: 'hello',
+		});
+		expect(whatsapp.calls).toHaveLength(0);
+		const sms = fakeFetch([]);
+		await createSmsSender(none, sms.fetchImpl).sendMessage({
+			from: '+15550001111',
+			to: '+15559990000',
+			text: 'hi',
+		});
+		expect(sms.calls).toHaveLength(0);
+	});
+});

--- a/packages/docs/site/openapi.json
+++ b/packages/docs/site/openapi.json
@@ -4607,6 +4607,202 @@
         }
       }
     },
+    "/v1/channels/whatsapp/twilio/inbound": {
+      "post": {
+        "summary": "Twilio WhatsApp webhook (inbound customer messages + delivery status)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Twilio delivers events for the account’s provisioned number here: inbound customer messages, and status callbacks for messages Rivus sent. The agent handles the message exactly like the other provider edges; the response is always the empty TwiML acknowledgment Twilio expects, with the handling outcome recorded in the logs. Deliveries are authenticated with the X-Twilio-Signature header when TWILIO_AUTH_TOKEN is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/sms/twilio/inbound": {
+      "post": {
+        "summary": "Twilio SMS webhook (inbound customer texts + delivery status)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Twilio delivers events for the account’s provisioned number here: inbound customer messages, and status callbacks for messages Rivus sent. The agent handles the message exactly like the other provider edges; the response is always the empty TwiML acknowledgment Twilio expects, with the handling outcome recorded in the logs. Deliveries are authenticated with the X-Twilio-Signature header when TWILIO_AUTH_TOKEN is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/voice/twilio/answer": {
+      "post": {
+        "summary": "Twilio voice webhook — answers an inbound call (VoiceUrl)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Twilio requests this URL when someone calls the account’s provisioned number (the number’s VoiceUrl, attached at purchase). The response TwiML greets the caller and listens for speech; each utterance is transcribed and posted to the input webhook. Deliveries are authenticated with the X-Twilio-Signature header when TWILIO_AUTH_TOKEN is configured.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/channels/voice/twilio/input": {
+      "post": {
+        "summary": "Twilio voice webhook — one transcribed caller utterance (Gather action)",
+        "tags": [
+          "channels"
+        ],
+        "description": "Gather posts each transcribed utterance here. The utterance runs through the same channel-agnostic scheduling orchestrator as every other channel (threads, inbox mirroring as a phone conversation, booking); the response TwiML speaks the agent’s reply and either listens for the next turn or ends the call on a terminal outcome.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/channels/whatsapp/plivo/inbound": {
       "post": {
         "summary": "Plivo WhatsApp webhook (inbound customer messages + delivery status)",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — migrates the messaging stack to **Twilio as the primary provider** for WhatsApp, SMS, and voice, with per-number outbound routing so the existing Plivo fleet keeps working throughout the migration. zernio stays wired as the WhatsApp-only alternative, untouched.

### Why

One Twilio number per account now fronts all three channels through one Messages API (the `whatsapp:` address prefix selects the channel) and TwiML voice — and Twilio lets the provisioner attach the SMS/voice webhooks **in the same purchase call**, removing the per-number console step Plivo required.

### How the mixed fleet stays safe

Outbound sends are no longer config-global. Every send routes by the sending number's stored fingerprint (`providerRef`):

- `PN…` phone-number SID → Twilio sender
- bare digits of the address → Plivo sender
- unclaimed (dev fakes, zernio's opaque ids) → primary chain: Twilio → Plivo → zernio (WhatsApp only) → no-op

A reply always leaves through the provider that owns the number it is sent from — Twilio cannot send from a Plivo number or vice versa. `WhatsappMessage`/`SmsMessage` carry `providerRef` through both delivery paths (agent replies and inbox reply-out share the same channel adapters). Routes exist only for *configured* providers, so an orphaned fingerprint fails loudly at the primary rather than silently no-op dropping.

### What's included

- **`services/twilio.ts`** — Messages API senders (form-encoded, Basic auth, `StatusCallback` per channel), number provisioner (`AvailablePhoneNumbers` search → `IncomingPhoneNumbers` purchase with `SmsUrl`/`VoiceUrl` attached), `X-Twilio-Signature` sign/verify (HMAC-SHA1 over exact URL + all form params; accepts the with/without-default-port variants like Twilio's own SDKs; repeated form keys handled the SDK way), `PN…` ownership fingerprints.
- **Webhook routes** — `/v1/channels/{whatsapp,sms}/twilio/inbound` (inbound messages + status callbacks; always answer the empty TwiML `<Response/>` Twilio expects — and still acknowledge on dispatch failure, since Twilio never redelivers on 5xx) and `/v1/channels/voice/twilio/{answer,input}` (TwiML `<Gather input="speech">` dialect). Signature gates run at `preValidation` because Twilio signs the form body.
- **Shared voice core** (`routes/agent-voice-shared.ts`) — account resolution, guards, spoken lines, and turn policy extracted from the Plivo voice route and now shared by both dialects, so they cannot drift (the 16 pre-existing Plivo voice tests pass unchanged).
- **Channel enable/sharing** — a sibling channel's Twilio- or Plivo-owned number is adopted instead of renting a second one; the production gate accepts either provider. The Plivo provisioner now stores its ref as the address's own bare digits, so ownership routing can't be broken by a formatted search result.
- **Config** — `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_API_URL`, `TWILIO_{WHATSAPP,SMS,VOICE}_WEBHOOK_URL`, `TWILIO_NUMBER_COUNTRY`; the voice input endpoint's pinned URL (and the `Gather` action) derive from the voice pin. README rewritten (Twilio primary section, Plivo retitled *retained during the migration*); OpenAPI regenerated + docs synced.
- **Tests** — 110 new/updated: Twilio's published signature test vector reproduced exactly, wire-format suites for senders/provisioner/fingerprints, full route suites for all three channels (including signature/pinned-URL/prod-503 gates and cross-channel isolation), the routing/selection matrix, sharing + prod-gate cases. All wire formats were verified against Twilio's documentation before implementation.

### Migration follow-ups (not in this PR)

- WhatsApp sender registration per number (Twilio Senders API needs a WABA link + OTP round-trip) — `TODO(twilio)` in `services/twilio.ts`.
- Porting existing Plivo numbers to Twilio; until then the router keeps both fleets live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2)_