### PR TITLE
fix(api): forward messaging-provider env vars into the container

### DIFF
--- a/packages/api/test/worker-env.test.ts
+++ b/packages/api/test/worker-env.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { FORWARDED_VARS, forwardedEnv } from '../worker/env';
+
+/**
+ * Guards the Worker→container env bridge. The messaging channels shipped broken
+ * to the deployed environment because these provider vars were set on the
+ * Worker but never forwarded into the Fastify container, so `loadConfig()` never
+ * saw them and every channel reported "not configured". These tests fail if a
+ * provider var is dropped from the forwarding list again.
+ */
+describe('forwardedEnv', () => {
+	it('forwards only the keys that read back a non-empty string', () => {
+		const source: Record<string, unknown> = {
+			JWT_SECRET: 'secret',
+			TWILIO_ACCOUNT_SID: 'AC123',
+			TWILIO_AUTH_TOKEN: '',
+			MONGODB_URI: undefined,
+			// A non-string binding (e.g. the Durable Object namespace) is never forwarded.
+			API_CONTAINER: { fetch() {} },
+		};
+		const forwarded = forwardedEnv(
+			['JWT_SECRET', 'TWILIO_ACCOUNT_SID', 'TWILIO_AUTH_TOKEN', 'MONGODB_URI', 'API_CONTAINER'],
+			(key) => source[key],
+		);
+		expect(forwarded).toEqual({ JWT_SECRET: 'secret', TWILIO_ACCOUNT_SID: 'AC123' });
+		// Unset/empty are dropped — never reach the container as the string "undefined".
+		expect('TWILIO_AUTH_TOKEN' in forwarded).toBe(false);
+		expect('MONGODB_URI' in forwarded).toBe(false);
+	});
+
+	it('ignores keys the source does not have at all', () => {
+		expect(forwardedEnv(['NOT_SET'], () => undefined)).toEqual({});
+	});
+});
+
+describe('FORWARDED_VARS', () => {
+	it('forwards every messaging-provider credential and webhook var', () => {
+		// The credentials and webhook URLs the container needs to activate a channel.
+		const required = [
+			'TWILIO_ACCOUNT_SID',
+			'TWILIO_AUTH_TOKEN',
+			'TWILIO_API_URL',
+			'TWILIO_WHATSAPP_WEBHOOK_URL',
+			'TWILIO_SMS_WEBHOOK_URL',
+			'TWILIO_VOICE_WEBHOOK_URL',
+			'TWILIO_NUMBER_COUNTRY',
+			'PLIVO_AUTH_ID',
+			'PLIVO_AUTH_TOKEN',
+			'PLIVO_API_URL',
+			'PLIVO_WEBHOOK_URL',
+			'PLIVO_SMS_WEBHOOK_URL',
+			'PLIVO_NUMBER_COUNTRY',
+			'ZERNIO_API_KEY',
+			'ZERNIO_API_URL',
+			'ZERNIO_WEBHOOK_SECRET',
+			'ZERNIO_VERIFY_TOKEN',
+		];
+		for (const key of required) {
+			expect(FORWARDED_VARS).toContain(key);
+		}
+	});
+
+	it('still forwards the core secrets the API needs to boot', () => {
+		for (const key of ['MONGODB_URI', 'JWT_SECRET', 'RESEND_API_KEY', 'APP_URL']) {
+			expect(FORWARDED_VARS).toContain(key);
+		}
+	});
+});

--- a/packages/api/worker/env.ts
+++ b/packages/api/worker/env.ts
@@ -1,0 +1,76 @@
+/**
+ * Environment forwarding for the API container, split out from `./index.ts` so
+ * the pure logic can be unit-tested without importing the
+ * `@cloudflare/containers` runtime (which only loads on the Workers runtime).
+ *
+ * The Fastify container reads its configuration from `process.env` via
+ * `loadConfig()`, but a var only reaches that process if it is forwarded here.
+ * So EVERY variable `../src/config` reads must appear in {@link FORWARDED_VARS},
+ * or the app reports the feature as "not configured" even when the secret is
+ * set on the Worker — the exact trap the messaging channels fell into.
+ * `./index.ts` asserts at compile time that each entry names a real `Env`
+ * binding.
+ */
+
+/** Every Worker binding forwarded into the container's `process.env`. */
+export const FORWARDED_VARS = [
+	'RIVUS_ENV',
+	'MONGODB_URI',
+	'JWT_SECRET',
+	'CORS_ORIGIN',
+	'COOKIE_DOMAIN',
+	'RESEND_API_KEY',
+	'EMAIL_FROM',
+	'APP_URL',
+	'WEBSITE_URL',
+	'AGENT_EMAIL_DOMAIN',
+	'RESEND_WEBHOOK_SECRET',
+	'OPENAI_API_KEY',
+	'OPENAI_MODEL',
+	'GOOGLE_GENERATIVE_AI_API_KEY',
+	'GEMINI_MODEL',
+	'XAI_API_KEY',
+	'XAI_MODEL',
+	'ANTHROPIC_API_KEY',
+	'ANTHROPIC_MODEL',
+	// Messaging providers — the container reads these in `loadConfig` to pick the
+	// WhatsApp/SMS/voice sender + provisioner. Missing here = "channel not
+	// configured" in the app even when the secret is set on the Worker.
+	'TWILIO_ACCOUNT_SID',
+	'TWILIO_AUTH_TOKEN',
+	'TWILIO_API_URL',
+	'TWILIO_WHATSAPP_WEBHOOK_URL',
+	'TWILIO_SMS_WEBHOOK_URL',
+	'TWILIO_VOICE_WEBHOOK_URL',
+	'TWILIO_NUMBER_COUNTRY',
+	'PLIVO_AUTH_ID',
+	'PLIVO_AUTH_TOKEN',
+	'PLIVO_API_URL',
+	'PLIVO_WEBHOOK_URL',
+	'PLIVO_SMS_WEBHOOK_URL',
+	'PLIVO_NUMBER_COUNTRY',
+	'ZERNIO_API_KEY',
+	'ZERNIO_API_URL',
+	'ZERNIO_WEBHOOK_SECRET',
+	'ZERNIO_VERIFY_TOKEN',
+] as const;
+
+/**
+ * The subset of `keys` that `read` returns a non-empty string for, as a plain
+ * map. An unset binding is dropped so it never reaches the container as the
+ * string "undefined"; keys with a default in `loadConfig` (e.g. `*_API_URL`)
+ * simply fall back to that default when unset.
+ */
+export function forwardedEnv(
+	keys: readonly string[],
+	read: (key: string) => unknown,
+): Record<string, string> {
+	const forwarded: Record<string, string> = {};
+	for (const key of keys) {
+		const value = read(key);
+		if (typeof value === 'string' && value !== '') {
+			forwarded[key] = value;
+		}
+	}
+	return forwarded;
+}

--- a/packages/api/worker/index.ts
+++ b/packages/api/worker/index.ts
@@ -1,4 +1,5 @@
 import { Container, getContainer } from '@cloudflare/containers';
+import { FORWARDED_VARS, forwardedEnv } from './env';
 
 /** Bindings available to the front-door Worker and the container Durable Object. */
 export interface Env {
@@ -35,7 +36,35 @@ export interface Env {
 	XAI_MODEL?: string;
 	ANTHROPIC_API_KEY?: string;
 	ANTHROPIC_MODEL?: string;
+	// Messaging channels (WhatsApp / SMS / voice). Twilio is the primary provider,
+	// Plivo is retained during the migration, and zernio is the WhatsApp-only
+	// alternative. All optional — an unset provider degrades to a no-op, and only
+	// the ones actually set are forwarded to the container (see FORWARDED_VARS).
+	// The `*_API_URL` / `*_NUMBER_COUNTRY` keys have defaults in `loadConfig`, so
+	// leaving them unset is fine; the credentials and webhook URLs are what matter.
+	TWILIO_ACCOUNT_SID?: string;
+	TWILIO_AUTH_TOKEN?: string;
+	TWILIO_API_URL?: string;
+	TWILIO_WHATSAPP_WEBHOOK_URL?: string;
+	TWILIO_SMS_WEBHOOK_URL?: string;
+	TWILIO_VOICE_WEBHOOK_URL?: string;
+	TWILIO_NUMBER_COUNTRY?: string;
+	PLIVO_AUTH_ID?: string;
+	PLIVO_AUTH_TOKEN?: string;
+	PLIVO_API_URL?: string;
+	PLIVO_WEBHOOK_URL?: string;
+	PLIVO_SMS_WEBHOOK_URL?: string;
+	PLIVO_NUMBER_COUNTRY?: string;
+	ZERNIO_API_KEY?: string;
+	ZERNIO_API_URL?: string;
+	ZERNIO_WEBHOOK_SECRET?: string;
+	ZERNIO_VERIFY_TOKEN?: string;
 }
+
+// Compile-time guard: every forwarded var names a real `Env` binding, so a typo
+// or a key removed from `Env` fails the build here rather than silently dropping
+// a variable from the container. Used by `envVars` below, so it isn't dead code.
+const FORWARDED: readonly (keyof Env)[] = FORWARDED_VARS;
 
 /**
  * The Fastify API needs Node and the MongoDB driver, so it can't run on the
@@ -49,33 +78,12 @@ export class ApiContainer extends Container<Env> {
 	override defaultPort = 4000;
 	override sleepAfter = '10m';
 	// A data property (not a getter): the base Container constructor assigns
-	// `this.envVars`, so a getter-only override would throw. Spread each binding
-	// only when set so an unset secret never reaches the container as "undefined".
+	// `this.envVars`, so a getter-only override would throw. Only the bindings
+	// actually set are forwarded, so an unset secret never reaches the container
+	// as the string "undefined".
 	override envVars = {
 		NODE_ENV: 'production',
-		...(this.env.RIVUS_ENV ? { RIVUS_ENV: this.env.RIVUS_ENV } : {}),
-		...(this.env.MONGODB_URI ? { MONGODB_URI: this.env.MONGODB_URI } : {}),
-		...(this.env.JWT_SECRET ? { JWT_SECRET: this.env.JWT_SECRET } : {}),
-		...(this.env.CORS_ORIGIN ? { CORS_ORIGIN: this.env.CORS_ORIGIN } : {}),
-		...(this.env.COOKIE_DOMAIN ? { COOKIE_DOMAIN: this.env.COOKIE_DOMAIN } : {}),
-		...(this.env.RESEND_API_KEY ? { RESEND_API_KEY: this.env.RESEND_API_KEY } : {}),
-		...(this.env.EMAIL_FROM ? { EMAIL_FROM: this.env.EMAIL_FROM } : {}),
-		...(this.env.APP_URL ? { APP_URL: this.env.APP_URL } : {}),
-		...(this.env.WEBSITE_URL ? { WEBSITE_URL: this.env.WEBSITE_URL } : {}),
-		...(this.env.AGENT_EMAIL_DOMAIN ? { AGENT_EMAIL_DOMAIN: this.env.AGENT_EMAIL_DOMAIN } : {}),
-		...(this.env.RESEND_WEBHOOK_SECRET
-			? { RESEND_WEBHOOK_SECRET: this.env.RESEND_WEBHOOK_SECRET }
-			: {}),
-		...(this.env.OPENAI_API_KEY ? { OPENAI_API_KEY: this.env.OPENAI_API_KEY } : {}),
-		...(this.env.OPENAI_MODEL ? { OPENAI_MODEL: this.env.OPENAI_MODEL } : {}),
-		...(this.env.GOOGLE_GENERATIVE_AI_API_KEY
-			? { GOOGLE_GENERATIVE_AI_API_KEY: this.env.GOOGLE_GENERATIVE_AI_API_KEY }
-			: {}),
-		...(this.env.GEMINI_MODEL ? { GEMINI_MODEL: this.env.GEMINI_MODEL } : {}),
-		...(this.env.XAI_API_KEY ? { XAI_API_KEY: this.env.XAI_API_KEY } : {}),
-		...(this.env.XAI_MODEL ? { XAI_MODEL: this.env.XAI_MODEL } : {}),
-		...(this.env.ANTHROPIC_API_KEY ? { ANTHROPIC_API_KEY: this.env.ANTHROPIC_API_KEY } : {}),
-		...(this.env.ANTHROPIC_MODEL ? { ANTHROPIC_MODEL: this.env.ANTHROPIC_MODEL } : {}),
+		...forwardedEnv(FORWARDED, (key) => this.env[key as keyof Env]),
 	};
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, ...)

Bug fix — makes the messaging channels actually activate in the deployed environment.

### The bug

The Fastify API runs as a **container fronted by a Cloudflare Worker** (`worker/index.ts`). The Worker forwards a **hardcoded allowlist** of its bindings into the container's `process.env` so `loadConfig()` can read them. None of the messaging-provider variables — `TWILIO_*`, `PLIVO_*`, `ZERNIO_*` — were in that allowlist.

So a deployment could set `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` as secrets on the Worker (correctly!), yet inside the container they read back `undefined`, `providerConfigured()` returned false, and every channel toggle showed **"That channel is not configured on this deployment."**

This gap **predates the Twilio work** — zernio (the first messaging PR) and Plivo were never forwarded either — which means the WhatsApp/SMS/voice channels have never activated in the deployed environment. It slipped through five PRs because nothing tested the Worker→container env bridge.

### The fix

- Add every `TWILIO_*` / `PLIVO_*` / `ZERNIO_*` binding to the Worker's `Env` interface.
- Extract the forwarding into a node-safe `worker/env.ts` (`FORWARDED_VARS` + `forwardedEnv`) so it's unit-testable without importing the `@cloudflare/containers` runtime, and express it as **one maintained list** instead of ~20 spread expressions — the whole bug was a forgotten entry, so a single list is the fix and the guard against recurrence.
- Compile-time guard in `index.ts` asserts every forwarded key is a real `Env` binding (a typo or removed key fails the build).
- New `test/worker-env.test.ts` asserts the provider vars are in the forwarded set and that unset / non-string bindings are dropped (never reach the container as the string `"undefined"`).

### After this deploys

Set `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and the three `TWILIO_*_WEBHOOK_URL`s on the Worker, redeploy, and the channel toggles activate. SMS and voice work end-to-end (webhooks auto-attach at number purchase). WhatsApp rents its number but still needs the sender registered in the Twilio console until sender auto-registration lands (`TODO(twilio)`).

### Gates

`pnpm lint && pnpm type-check && pnpm test` all green — 980 API tests (both `tsc` projects, including `worker/tsconfig.json`, type-check clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2)_