### PR TITLE
feat(app): settings UX — proper Switch toggles, button states, danger-zone buttons

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: verify
+description: Run the Rivus stack locally (in-memory API + Expo web) and drive it with Playwright to verify app changes end-to-end.
+---
+
+# Verifying app changes end-to-end
+
+Boot the whole stack with no Mongo and no provider credentials, then drive the
+web app with Playwright against the pre-installed Chromium.
+
+## 1. API on :4000 — in-memory harness
+
+`packages/api/src/server.ts` requires Mongo, but `buildApp(deps)` doesn't. Write
+a scratch script (do NOT commit it) that mirrors `packages/api/test/helpers.ts`:
+`createInMemoryRepositories()` + `NoopChannelProvisioner` (mints deterministic
+`+1555…` numbers) + noop FAQ/email services, and a mailer that appends
+`${to} ${code}` to a `codes.log` file — one-time sign-in codes are otherwise
+unreadable. Load config with `NODE_ENV: 'development'`, `CORS_ORIGIN: '*'`, then
+`app.listen({ host: '127.0.0.1', port: 4000 })`. Run it with
+`cd packages/api && pnpm exec tsx <script>.mts` (absolute-path imports into
+`packages/api/src/*.ts` work under tsx).
+
+## 2. App on :8081 — Expo web
+
+```bash
+cd packages/app && CI=1 EXPO_NO_TELEMETRY=1 BROWSER=none pnpm exec expo start --web --port 8081
+```
+
+- The React Native DevTools (Electron) crash under root is harmless.
+- **Metro's file watcher can be dead in containers**: edits made after Metro
+  boots may never appear. If a change doesn't show up, restart the Expo server.
+
+## 3. Drive with Playwright
+
+Use `playwright-core` (npm-install it in the scratchpad, not the repo) with
+`executablePath: '/opt/pw-browsers/chromium'` and `--no-sandbox`.
+
+- Browse **http://localhost:8081** (not 127.0.0.1): web auth is a SameSite
+  session cookie scoped to the API host `localhost:4000`, so the page must be
+  same-site with it. And navigate in-app (click the sidebar) — a hard `goto`
+  drops the session in this setup.
+- Sign up at `/signup` (placeholders: `Cascade Plumbing & Heating`,
+  `Marcus Thompson`, `you@business.com` → button `Create account`), read the
+  code from `codes.log`, fill placeholder `123456`, `Verify & continue`, then
+  wait for the `Good …` greeting.
+- A fresh unique email per run avoids colliding with earlier signups.
+- One `401` console error before login (the session-restore probe) is normal.

--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -35,6 +35,7 @@ theme) instead of hard-coding a new literal in a component.
 | Card           | `#ffffff`  | Cards, sheets, raised surfaces              |
 | Briefing dark  | `#13131f`  | Dark "briefing" surfaces (gradient base)    |
 | Hairline       | `#e9eaf0`  | 1px borders, dividers, separators           |
+| Switch track   | `#d9dbe6`  | Off-state fill of the Switch control        |
 
 ### Status
 
@@ -82,8 +83,9 @@ linear-gradient(135deg, #1ebefa, #6e1ec8)
 ```
 
 The **one** signature element. Reserve it for Rivus-the-agent: primary buttons,
-the symbol tile, AI status, active nav. **Never** use it as a page or card
-background.
+the symbol tile, AI status, active nav, and the **on** state of a Switch that
+puts Rivus live on a channel (that is AI status). **Never** use it as a page or
+card background, and never on destructive actions (see Buttons → Danger).
 
 Supporting gradients:
 
@@ -179,9 +181,36 @@ A single dashboard metric.
 ### Buttons
 
 - **Primary:** uses the signature gradient at `11px` radius.
-- **Secondary:** white with a `1px` hairline (`#e9eaf0`) border.
-- Both stay **inline** — there is no shared button design component; build per
-  platform using these recipes.
+- **Secondary:** white with a `1px` hairline (`#e9eaf0`) border. Takes a
+  **danger tone** (Danger-red text and a red-tinted hairline) for the
+  low-emphasis entry into a destructive flow ("Cancel account").
+- **Danger:** solid Danger red (`#f0584b`, hover `#d2503f`) with white text —
+  the destructive confirm itself ("Yes, cancel account"). Destructive actions
+  **never** wear the signature gradient.
+- All buttons stay **inline** — there is no shared button design component;
+  build per platform using these recipes.
+
+**States** (all variants): `loading` swaps the icon slot for a small inline
+spinner and ignores presses (label may switch to the progressive form, e.g.
+"Saving…"); `disabled` renders at 50% opacity; hover (web) lifts primary/danger
+slightly and tints secondary with the soft field color; pressed dims to 85%
+opacity. Buttons announce `disabled`/`busy` state to assistive tech.
+
+### Switch
+
+Boolean on/off control for live settings that apply immediately (e.g. switching
+a messaging channel on) — form choices between options stay a segmented control.
+
+- **Props:** `value` · `onValueChange` · `busy` · `disabled` · `accessibilityLabel`
+- **Geometry:** `46×26px` pill track with a `2px` inset, `22px` white thumb
+  (soft shadow) that slides `20px`; thumb and track crossfade over ~160ms.
+- **Off:** Switch-track fill (`#d9dbe6`). **On:** the signature gradient —
+  allowed because flipping one on puts Rivus-the-agent live (AI status).
+- **Busy:** a small violet spinner rides inside the thumb while the change is
+  in flight (e.g. a number provisioning) and presses are ignored — never a
+  detached spinner beside the control. **Disabled:** 50% opacity.
+- Announces as a switch with `checked`/`disabled`/`busy` state; pair it with a
+  visible "On"/"Off" text echo where color alone would carry the state.
 
 ### Navigation
 

--- a/packages/app/app/settings.tsx
+++ b/packages/app/app/settings.tsx
@@ -325,6 +325,9 @@ export default function SettingsScreen() {
 	}
 
 	async function onToggleChannel(channel: ProvisionedChannel, enabled: boolean, noun: string) {
+		// The `!session` guard isn't redundant: narrowing from the render path's
+		// early return doesn't reach hoisted function declarations, so tsc requires
+		// it here ('session' is possibly 'null' without it).
 		if (channelBusy[channel] || !session || enabled === session.account.channels[channel].enabled) {
 			return;
 		}

--- a/packages/app/app/settings.tsx
+++ b/packages/app/app/settings.tsx
@@ -1,4 +1,4 @@
-import { agentEmailLocalPart } from '@rivus/core';
+import { agentEmailLocalPart, type ProvisionedChannel } from '@rivus/core';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
 	ActivityIndicator,
@@ -16,12 +16,13 @@ import { AddressAutocomplete } from '@/src/components/AddressAutocomplete';
 import { CopyField } from '@/src/components/CopyField';
 import {
 	Card,
+	DangerButton,
 	GradientButton,
 	OutlineButton,
 	Pill,
 	SectionLabel,
-	Segmented,
 	Select,
+	Switch,
 	TextField,
 	Txt,
 } from '@/src/components/ui';
@@ -31,6 +32,83 @@ import { useDocumentTitle } from '@/src/theme/useDocumentTitle';
 const PLAN_LABELS: Record<Billing['plan'], string> = {
 	free: 'Free',
 };
+
+/**
+ * Copy for the customer-facing channels a business can switch on. Each renders
+ * as a {@link ChannelCard}; `noun` is how the channel reads inside an error
+ * sentence ("Could not enable texting.").
+ */
+const CHANNELS: {
+	key: ProvisionedChannel;
+	title: string;
+	hint: string;
+	addressLabel: string;
+	noun: string;
+}[] = [
+	{
+		key: 'whatsapp',
+		title: 'WhatsApp Business',
+		hint: 'Customers can message this number on WhatsApp — Rivus books them the same way it does over email. Turn it on to get a number.',
+		addressLabel: 'Your WhatsApp number',
+		noun: 'WhatsApp',
+	},
+	{
+		key: 'sms',
+		title: 'Text messages (SMS)',
+		hint: 'Customers can text this number — Rivus books them the same way it does over email. Turn it on to get a number; WhatsApp and texting share one number when both are on.',
+		addressLabel: 'Your SMS number',
+		noun: 'texting',
+	},
+	{
+		key: 'voice',
+		title: 'Phone calls',
+		hint: 'Customers can call this number — Rivus answers, offers open times, and books them. Turn it on to get a number; calls share one number with WhatsApp and texting.',
+		addressLabel: 'Your phone number',
+		noun: 'phone calls',
+	},
+];
+
+/**
+ * One customer-facing channel (WhatsApp / SMS / voice): an on-off switch in the
+ * card header, the provisioned number once there is one, and any toggle error.
+ * The switch spins in place while the number provisions or releases.
+ */
+function ChannelCard({
+	title,
+	hint,
+	addressLabel,
+	enabled,
+	address,
+	busy,
+	error,
+	onToggle,
+}: {
+	title: string;
+	hint: string;
+	addressLabel: string;
+	enabled: boolean;
+	address: string;
+	busy: boolean;
+	error: string | null;
+	onToggle: (enabled: boolean) => void;
+}) {
+	return (
+		<Card style={styles.card}>
+			<View style={styles.channelHeader}>
+				<SectionLabel style={styles.channelTitle}>{title}</SectionLabel>
+				<View style={styles.channelToggle}>
+					<Txt style={[styles.channelState, enabled && styles.channelStateOn]}>
+						{enabled ? 'On' : 'Off'}
+					</Txt>
+					<Switch value={enabled} onValueChange={onToggle} busy={busy} accessibilityLabel={title} />
+				</View>
+			</View>
+			<Txt style={styles.agentEmailHint}>{hint}</Txt>
+			{enabled && address ? <CopyField label={addressLabel} value={address} /> : null}
+			{error ? <Txt style={styles.errorTxt}>{error}</Txt> : null}
+		</Card>
+	);
+}
 
 function messageFor(error: unknown, fallback: string): string {
 	if (error instanceof ApiError || error instanceof Error) {
@@ -98,6 +176,7 @@ function DevSeedCard() {
 			<GradientButton
 				label={seeding ? 'Seeding…' : 'Seed this account'}
 				icon="database"
+				loading={seeding}
 				onPress={onSeed}
 			/>
 		</Card>
@@ -124,14 +203,12 @@ export default function SettingsScreen() {
 	const [saved, setSaved] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
-	const [whatsappBusy, setWhatsappBusy] = useState(false);
-	const [whatsappError, setWhatsappError] = useState<string | null>(null);
-
-	const [smsBusy, setSmsBusy] = useState(false);
-	const [smsError, setSmsError] = useState<string | null>(null);
-
-	const [voiceBusy, setVoiceBusy] = useState(false);
-	const [voiceError, setVoiceError] = useState<string | null>(null);
+	// Channels toggle independently (provisioning one number can be slow), so
+	// busy/error state is tracked per channel rather than shared.
+	const [channelBusy, setChannelBusy] = useState<Partial<Record<ProvisionedChannel, boolean>>>({});
+	const [channelError, setChannelError] = useState<
+		Partial<Record<ProvisionedChannel, string | null>>
+	>({});
 
 	const [confirmingCancel, setConfirmingCancel] = useState(false);
 	const [canceling, setCanceling] = useState(false);
@@ -247,60 +324,23 @@ export default function SettingsScreen() {
 		}
 	}
 
-	const whatsapp = session.account.channels.whatsapp;
-	const sms = session.account.channels.sms;
-	const voice = session.account.channels.voice;
-
-	async function onToggleWhatsapp(next: string) {
-		const enabled = next === 'on';
-		if (whatsappBusy || enabled === whatsapp.enabled) {
+	async function onToggleChannel(channel: ProvisionedChannel, enabled: boolean, noun: string) {
+		if (channelBusy[channel] || !session || enabled === session.account.channels[channel].enabled) {
 			return;
 		}
-		setWhatsappError(null);
-		setWhatsappBusy(true);
+		setChannelError((prev) => ({ ...prev, [channel]: null }));
+		setChannelBusy((prev) => ({ ...prev, [channel]: true }));
 		try {
-			// Enabling provisions a number on the first call; the session updates in place.
-			await setChannelEnabled('whatsapp', enabled);
+			// Enabling provisions a number on the first call (channels share one
+			// number where providers allow it); the session updates in place.
+			await setChannelEnabled(channel, enabled);
 		} catch (caught) {
-			setWhatsappError(messageFor(caught, `Could not ${enabled ? 'enable' : 'disable'} WhatsApp.`));
+			setChannelError((prev) => ({
+				...prev,
+				[channel]: messageFor(caught, `Could not ${enabled ? 'enable' : 'disable'} ${noun}.`),
+			}));
 		} finally {
-			setWhatsappBusy(false);
-		}
-	}
-
-	async function onToggleSms(next: string) {
-		const enabled = next === 'on';
-		if (smsBusy || enabled === sms.enabled) {
-			return;
-		}
-		setSmsError(null);
-		setSmsBusy(true);
-		try {
-			// Enabling provisions a number on the first call (reusing the WhatsApp
-			// number when both channels share one); the session updates in place.
-			await setChannelEnabled('sms', enabled);
-		} catch (caught) {
-			setSmsError(messageFor(caught, `Could not ${enabled ? 'enable' : 'disable'} texting.`));
-		} finally {
-			setSmsBusy(false);
-		}
-	}
-
-	async function onToggleVoice(next: string) {
-		const enabled = next === 'on';
-		if (voiceBusy || enabled === voice.enabled) {
-			return;
-		}
-		setVoiceError(null);
-		setVoiceBusy(true);
-		try {
-			// Enabling provisions a number on the first call (reusing the WhatsApp/SMS
-			// number when the channels share one); the session updates in place.
-			await setChannelEnabled('voice', enabled);
-		} catch (caught) {
-			setVoiceError(messageFor(caught, `Could not ${enabled ? 'enable' : 'disable'} phone calls.`));
-		} finally {
-			setVoiceBusy(false);
+			setChannelBusy((prev) => ({ ...prev, [channel]: false }));
 		}
 	}
 
@@ -308,6 +348,7 @@ export default function SettingsScreen() {
 	// business slug with a stable per-account hex tag (so look-alike names never
 	// collide); the domain comes from the session (`AGENT_EMAIL_DOMAIN`).
 	const agentEmail = `${agentEmailLocalPart(session.account.slug, session.account.id)}@${session.agentEmailDomain}`;
+	const channels = session.account.channels;
 
 	return (
 		<ScrollView
@@ -366,6 +407,7 @@ export default function SettingsScreen() {
 					<GradientButton
 						label={saving ? 'Saving…' : 'Save changes'}
 						icon="check"
+						loading={saving}
 						onPress={onSave}
 					/>
 				</View>
@@ -380,74 +422,22 @@ export default function SettingsScreen() {
 				<CopyField label="Your agent address" value={agentEmail} />
 			</Card>
 
-			<Card style={styles.card}>
-				<SectionLabel>WhatsApp Business</SectionLabel>
-				<Txt style={styles.agentEmailHint}>
-					Customers can message this number on WhatsApp — Rivus books them the same way it does over
-					email. Turn it on to get a number.
-				</Txt>
-				<View style={styles.whatsappRow}>
-					<Segmented
-						options={[
-							{ label: 'Off', value: 'off' },
-							{ label: 'On', value: 'on' },
-						]}
-						value={whatsapp.enabled ? 'on' : 'off'}
-						onChange={onToggleWhatsapp}
+			{CHANNELS.map(({ key, title, hint, addressLabel, noun }) => {
+				const channel = channels[key];
+				return (
+					<ChannelCard
+						key={key}
+						title={title}
+						hint={hint}
+						addressLabel={addressLabel}
+						enabled={channel.enabled}
+						address={channel.address}
+						busy={Boolean(channelBusy[key])}
+						error={channelError[key] ?? null}
+						onToggle={(enabled) => onToggleChannel(key, enabled, noun)}
 					/>
-					{whatsappBusy ? <ActivityIndicator color={colors.brandPurple} /> : null}
-				</View>
-				{whatsapp.enabled && whatsapp.address ? (
-					<CopyField label="Your WhatsApp number" value={whatsapp.address} />
-				) : null}
-				{whatsappError ? <Txt style={styles.errorTxt}>{whatsappError}</Txt> : null}
-			</Card>
-
-			<Card style={styles.card}>
-				<SectionLabel>Text messages (SMS)</SectionLabel>
-				<Txt style={styles.agentEmailHint}>
-					Customers can text this number — Rivus books them the same way it does over email. Turn it
-					on to get a number; WhatsApp and texting share one number when both are on.
-				</Txt>
-				<View style={styles.whatsappRow}>
-					<Segmented
-						options={[
-							{ label: 'Off', value: 'off' },
-							{ label: 'On', value: 'on' },
-						]}
-						value={sms.enabled ? 'on' : 'off'}
-						onChange={onToggleSms}
-					/>
-					{smsBusy ? <ActivityIndicator color={colors.brandPurple} /> : null}
-				</View>
-				{sms.enabled && sms.address ? (
-					<CopyField label="Your SMS number" value={sms.address} />
-				) : null}
-				{smsError ? <Txt style={styles.errorTxt}>{smsError}</Txt> : null}
-			</Card>
-
-			<Card style={styles.card}>
-				<SectionLabel>Phone calls</SectionLabel>
-				<Txt style={styles.agentEmailHint}>
-					Customers can call this number — Rivus answers, offers open times, and books them. Turn it
-					on to get a number; calls share one number with WhatsApp and texting.
-				</Txt>
-				<View style={styles.whatsappRow}>
-					<Segmented
-						options={[
-							{ label: 'Off', value: 'off' },
-							{ label: 'On', value: 'on' },
-						]}
-						value={voice.enabled ? 'on' : 'off'}
-						onChange={onToggleVoice}
-					/>
-					{voiceBusy ? <ActivityIndicator color={colors.brandPurple} /> : null}
-				</View>
-				{voice.enabled && voice.address ? (
-					<CopyField label="Your phone number" value={voice.address} />
-				) : null}
-				{voiceError ? <Txt style={styles.errorTxt}>{voiceError}</Txt> : null}
-			</Card>
+				);
+			})}
 
 			<Card style={styles.card}>
 				<SectionLabel>Plan &amp; billing</SectionLabel>
@@ -489,14 +479,16 @@ export default function SettingsScreen() {
 
 				{confirmingCancel ? (
 					<View style={[styles.confirmRow, narrow && styles.confirmRowNarrow]}>
-						<GradientButton
+						<DangerButton
 							label={canceling ? 'Canceling…' : 'Yes, cancel account'}
 							icon="alert-triangle"
+							loading={canceling}
 							onPress={onCancelAccount}
 							style={[styles.confirmBtn, narrow && styles.confirmBtnNarrow]}
 						/>
 						<OutlineButton
 							label="Keep account"
+							disabled={canceling}
 							onPress={() => setConfirmingCancel(false)}
 							style={[styles.confirmBtn, narrow && styles.confirmBtnNarrow]}
 						/>
@@ -504,8 +496,8 @@ export default function SettingsScreen() {
 				) : (
 					<OutlineButton
 						label="Cancel account"
+						tone="danger"
 						onPress={() => setConfirmingCancel(true)}
-						style={styles.dangerBtn}
 					/>
 				)}
 			</Card>
@@ -547,11 +539,29 @@ const styles = StyleSheet.create({
 		marginTop: -2,
 		marginBottom: 4,
 	},
-	whatsappRow: {
+	channelHeader: {
 		flexDirection: 'row',
 		alignItems: 'center',
+		justifyContent: 'space-between',
 		gap: 12,
-		marginBottom: 12,
+	},
+	// Keep long titles from pushing the switch off the card edge.
+	channelTitle: {
+		flex: 1,
+	},
+	channelToggle: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 8,
+	},
+	// Textual echo of the switch state, so state never rides on color alone.
+	channelState: {
+		fontFamily: font.semibold,
+		fontSize: 12,
+		color: colors.textFaint,
+	},
+	channelStateOn: {
+		color: colors.green,
 	},
 	errorTxt: {
 		fontFamily: font.medium,
@@ -612,9 +622,6 @@ const styles = StyleSheet.create({
 	},
 	devLabel: {
 		color: colors.brandPurpleInk,
-	},
-	dangerBtn: {
-		borderColor: 'rgba(240,88,75,0.45)',
 	},
 	confirmRow: {
 		flexDirection: 'row',

--- a/packages/app/src/components/ui.tsx
+++ b/packages/app/src/components/ui.tsx
@@ -1,10 +1,13 @@
 import { Feather } from '@expo/vector-icons';
-import { type ComponentProps, type ReactNode, useMemo, useState } from 'react';
+import { type ComponentProps, type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import {
+	ActivityIndicator,
+	Animated,
 	FlatList,
 	Image,
 	Modal,
 	Pressable,
+	type PressableStateCallbackType,
 	type StyleProp,
 	StyleSheet,
 	Text,
@@ -16,10 +19,28 @@ import {
 	type ViewStyle,
 } from 'react-native';
 import { RivusSymbol } from '../brand/RivusLogo';
-import { colors, font, radii, shadowCard } from '../theme/tokens';
+import { colors, font, radii, shadowCard, shadowSoft } from '../theme/tokens';
 import { BrandGradient } from './Gradient';
 
 type FeatherName = ComponentProps<typeof Feather>['name'];
+
+// react-native-web extends Pressable's style-callback state with `hovered` /
+// `focused`; core react-native types only declare `pressed`. Widening the state
+// here keeps hover affordances typed without `any` — on native the extra flags
+// are simply undefined and the hover styles never apply.
+type PressableState = PressableStateCallbackType & { hovered?: boolean; focused?: boolean };
+
+/** Shared props for the button family. */
+type ButtonProps = {
+	label: string;
+	icon?: FeatherName;
+	onPress?: () => void;
+	style?: StyleProp<ViewStyle>;
+	/** Grays the button out and ignores presses. */
+	disabled?: boolean;
+	/** Swaps the icon slot for a spinner and ignores presses while work is in flight. */
+	loading?: boolean;
+};
 
 /** Text with Montserrat applied by default. Override weight/size/color via style. */
 export function Txt({ style, ...rest }: TextProps) {
@@ -171,27 +192,153 @@ export function RivusBadge({ size = 40, radius = 12 }: { size?: number; radius?:
 }
 
 /** Primary action button with the brand gradient. */
-export function GradientButton({
-	label,
-	icon,
-	onPress,
-	style,
-}: {
-	label: string;
-	icon?: FeatherName;
-	onPress?: () => void;
-	style?: StyleProp<ViewStyle>;
-}) {
+export function GradientButton({ label, icon, onPress, style, disabled, loading }: ButtonProps) {
+	const inert = Boolean(disabled || loading);
 	return (
 		<Pressable
 			onPress={onPress}
+			disabled={inert}
 			accessibilityRole="button"
-			style={({ pressed }) => [styles.gradientBtnWrap, pressed && styles.pressed, style]}
+			accessibilityState={{ disabled: inert, busy: Boolean(loading) }}
+			aria-busy={Boolean(loading)}
+			aria-disabled={inert}
+			style={(state) => {
+				const { pressed, hovered } = state as PressableState;
+				return [
+					styles.gradientBtnWrap,
+					hovered && !inert && styles.btnHoverLift,
+					pressed && !inert && styles.pressed,
+					disabled && styles.btnDisabled,
+					style,
+				];
+			}}
 		>
 			<BrandGradient style={styles.gradientBtn}>
-				{icon ? <Feather name={icon} size={16} color="#fff" /> : null}
+				{loading ? (
+					<ActivityIndicator size="small" color="#fff" style={styles.btnSpinner} />
+				) : icon ? (
+					<Feather name={icon} size={16} color="#fff" />
+				) : null}
 				<Txt style={styles.gradientBtnTxt}>{label}</Txt>
 			</BrandGradient>
+		</Pressable>
+	);
+}
+
+/**
+ * Destructive action button — solid Danger red. Destructive confirms never wear
+ * the brand gradient (that marks Rivus-the-agent; see DESIGN_SYSTEM.md).
+ */
+export function DangerButton({ label, icon, onPress, style, disabled, loading }: ButtonProps) {
+	const inert = Boolean(disabled || loading);
+	return (
+		<Pressable
+			onPress={onPress}
+			disabled={inert}
+			accessibilityRole="button"
+			accessibilityState={{ disabled: inert, busy: Boolean(loading) }}
+			aria-busy={Boolean(loading)}
+			aria-disabled={inert}
+			style={(state) => {
+				const { pressed, hovered } = state as PressableState;
+				return [
+					styles.dangerBtn,
+					hovered && !inert && styles.dangerBtnHover,
+					pressed && !inert && styles.pressed,
+					disabled && styles.btnDisabled,
+					style,
+				];
+			}}
+		>
+			{loading ? (
+				<ActivityIndicator size="small" color="#fff" style={styles.btnSpinner} />
+			) : icon ? (
+				<Feather name={icon} size={16} color="#fff" />
+			) : null}
+			<Txt style={styles.gradientBtnTxt}>{label}</Txt>
+		</Pressable>
+	);
+}
+
+// Thumb geometry for Switch: a 46×26 pill track with a 2px inset, so the 22px
+// thumb travels the remaining 20px when toggled on.
+const SWITCH_THUMB_TRAVEL = 20;
+
+/**
+ * Animated on/off switch for boolean settings. The on state wears the brand
+ * gradient: flipping a switch puts Rivus-the-agent live on something, which is
+ * AI status (see DESIGN_SYSTEM.md). While `busy` the thumb holds a spinner and
+ * presses are ignored, so an in-flight change can't be double-toggled.
+ */
+export function Switch({
+	value,
+	onValueChange,
+	disabled,
+	busy,
+	accessibilityLabel,
+}: {
+	value: boolean;
+	onValueChange?: (value: boolean) => void;
+	disabled?: boolean;
+	/** Shows a spinner in the thumb and ignores presses while a change is in flight. */
+	busy?: boolean;
+	accessibilityLabel?: string;
+}) {
+	const position = useRef(new Animated.Value(value ? 1 : 0)).current;
+
+	useEffect(() => {
+		Animated.timing(position, {
+			toValue: value ? 1 : 0,
+			duration: 160,
+			// Animated values also drive the track crossfade; the JS driver keeps
+			// behavior identical on web (react-native-web) and native.
+			useNativeDriver: false,
+		}).start();
+	}, [position, value]);
+
+	const inert = Boolean(disabled || busy);
+
+	return (
+		<Pressable
+			onPress={() => onValueChange?.(!value)}
+			disabled={inert || !onValueChange}
+			accessibilityRole="switch"
+			accessibilityLabel={accessibilityLabel}
+			accessibilityState={{ checked: value, disabled: inert, busy: Boolean(busy) }}
+			// react-native-web doesn't derive aria-* from accessibilityState, so
+			// mirror the state explicitly for web screen readers.
+			aria-checked={value}
+			aria-busy={Boolean(busy)}
+			aria-disabled={inert}
+			hitSlop={8}
+			style={({ pressed }) => [
+				styles.switchTrack,
+				pressed && !inert && styles.switchPressed,
+				disabled && styles.btnDisabled,
+			]}
+		>
+			<Animated.View style={[styles.switchTrackOn, { opacity: position }]}>
+				<BrandGradient style={styles.switchTrackFill} />
+			</Animated.View>
+			<Animated.View
+				style={[
+					styles.switchThumb,
+					{
+						transform: [
+							{
+								translateX: position.interpolate({
+									inputRange: [0, 1],
+									outputRange: [0, SWITCH_THUMB_TRAVEL],
+								}),
+							},
+						],
+					},
+				]}
+			>
+				{busy ? (
+					<ActivityIndicator size="small" color={colors.brandPurple} style={styles.switchSpinner} />
+				) : null}
+			</Animated.View>
 		</Pressable>
 	);
 }
@@ -330,14 +477,24 @@ export function Segmented<T extends string>({
 	onChange: (value: T) => void;
 }) {
 	return (
-		<View style={styles.segmented}>
+		<View style={styles.segmented} accessibilityRole="radiogroup">
 			{options.map((option) => {
 				const active = option.value === value;
 				return (
 					<Pressable
 						key={option.value}
 						onPress={() => onChange(option.value)}
-						style={[styles.segment, active && styles.segmentActive]}
+						accessibilityRole="radio"
+						accessibilityState={{ checked: active }}
+						aria-checked={active}
+						style={(state) => {
+							const { hovered } = state as PressableState;
+							return [
+								styles.segment,
+								hovered && !active && styles.segmentHover,
+								active && styles.segmentActive,
+							];
+						}}
 					>
 						<Txt style={[styles.segmentTxt, active && styles.segmentTxtActive]}>{option.label}</Txt>
 					</Pressable>
@@ -347,22 +504,49 @@ export function Segmented<T extends string>({
 	);
 }
 
-/** Secondary (outline) button for low-emphasis actions. */
+/**
+ * Secondary (outline) button for low-emphasis actions. The `danger` tone marks
+ * the entry point to a destructive flow (red text, red-tinted hairline) — the
+ * confirm itself is a {@link DangerButton}.
+ */
 export function OutlineButton({
 	label,
+	icon,
 	onPress,
 	style,
-}: {
-	label: string;
-	onPress?: () => void;
-	style?: StyleProp<ViewStyle>;
-}) {
+	disabled,
+	loading,
+	tone = 'default',
+}: ButtonProps & { tone?: 'default' | 'danger' }) {
+	const inert = Boolean(disabled || loading);
+	const danger = tone === 'danger';
+	const contentColor = danger ? colors.redInk : colors.textSub;
 	return (
 		<Pressable
 			onPress={onPress}
-			style={({ pressed }) => [styles.outlineBtn, pressed && styles.pressed, style]}
+			disabled={inert}
+			accessibilityRole="button"
+			accessibilityState={{ disabled: inert, busy: Boolean(loading) }}
+			aria-busy={Boolean(loading)}
+			aria-disabled={inert}
+			style={(state) => {
+				const { pressed, hovered } = state as PressableState;
+				return [
+					styles.outlineBtn,
+					danger && styles.outlineBtnDanger,
+					hovered && !inert && (danger ? styles.outlineBtnDangerHover : styles.outlineBtnHover),
+					pressed && !inert && styles.pressed,
+					disabled && styles.btnDisabled,
+					style,
+				];
+			}}
 		>
-			<Txt style={styles.outlineBtnTxt}>{label}</Txt>
+			{loading ? (
+				<ActivityIndicator size="small" color={contentColor} style={styles.btnSpinner} />
+			) : icon ? (
+				<Feather name={icon} size={16} color={contentColor} />
+			) : null}
+			<Txt style={[styles.outlineBtnTxt, danger && styles.outlineBtnTxtDanger]}>{label}</Txt>
 		</Pressable>
 	);
 }
@@ -442,6 +626,69 @@ export const styles = StyleSheet.create({
 	},
 	pressed: {
 		opacity: 0.85,
+	},
+	btnHoverLift: {
+		opacity: 0.92,
+		...shadowSoft,
+	},
+	btnDisabled: {
+		opacity: 0.5,
+	},
+	// Constrain the spinner to the 16px icon slot so a button keeps its height
+	// when `loading` swaps the icon out (the "small" indicator draws at 20px).
+	btnSpinner: {
+		width: 16,
+		height: 16,
+		transform: [{ scale: 0.75 }],
+	},
+	dangerBtn: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: 8,
+		paddingVertical: 11,
+		paddingHorizontal: 16,
+		borderRadius: radii.lg,
+		backgroundColor: colors.red,
+	},
+	dangerBtnHover: {
+		backgroundColor: colors.redInk,
+	},
+	switchTrack: {
+		width: 46,
+		height: 26,
+		borderRadius: radii.pill,
+		padding: 2,
+		backgroundColor: colors.switchTrackOff,
+		justifyContent: 'center',
+		cursor: 'pointer',
+	},
+	switchTrackOn: {
+		position: 'absolute',
+		top: 0,
+		left: 0,
+		right: 0,
+		bottom: 0,
+		borderRadius: radii.pill,
+		overflow: 'hidden',
+	},
+	switchTrackFill: {
+		flex: 1,
+	},
+	switchThumb: {
+		width: 22,
+		height: 22,
+		borderRadius: radii.pill,
+		backgroundColor: colors.surface,
+		alignItems: 'center',
+		justifyContent: 'center',
+		...shadowSoft,
+	},
+	switchSpinner: {
+		transform: [{ scale: 0.7 }],
+	},
+	switchPressed: {
+		opacity: 0.9,
 	},
 	fieldWrap: {
 		gap: 6,
@@ -535,6 +782,8 @@ export const styles = StyleSheet.create({
 		flexDirection: 'row',
 		gap: 6,
 		backgroundColor: colors.field,
+		borderWidth: 1,
+		borderColor: colors.borderField,
 		borderRadius: radii.md,
 		padding: 4,
 	},
@@ -543,6 +792,9 @@ export const styles = StyleSheet.create({
 		alignItems: 'center',
 		paddingVertical: 9,
 		borderRadius: radii.sm,
+	},
+	segmentHover: {
+		backgroundColor: 'rgba(22,22,31,0.05)',
 	},
 	segmentActive: {
 		backgroundColor: colors.surface,
@@ -558,8 +810,10 @@ export const styles = StyleSheet.create({
 		fontFamily: font.semibold,
 	},
 	outlineBtn: {
+		flexDirection: 'row',
 		alignItems: 'center',
 		justifyContent: 'center',
+		gap: 8,
 		paddingVertical: 11,
 		paddingHorizontal: 16,
 		borderRadius: radii.lg,
@@ -567,10 +821,22 @@ export const styles = StyleSheet.create({
 		borderColor: colors.border,
 		backgroundColor: colors.surface,
 	},
+	outlineBtnHover: {
+		backgroundColor: colors.fieldSoft,
+	},
+	outlineBtnDanger: {
+		borderColor: 'rgba(240,88,75,0.45)',
+	},
+	outlineBtnDangerHover: {
+		backgroundColor: 'rgba(240,88,75,0.05)',
+	},
 	outlineBtnTxt: {
 		fontFamily: font.semibold,
 		fontSize: 13.5,
 		color: colors.textSub,
+	},
+	outlineBtnTxtDanger: {
+		color: colors.redInk,
 	},
 	statusChip: {
 		flexDirection: 'row',

--- a/packages/app/src/components/ui.tsx
+++ b/packages/app/src/components/ui.tsx
@@ -296,12 +296,16 @@ export function Switch({
 		}).start();
 	}, [position, value]);
 
-	const inert = Boolean(disabled || busy);
+	// A switch without a handler is non-interactive (e.g. purely presentational
+	// inside a larger pressable row) — announce it as disabled too, so assistive
+	// tech never offers an interaction that won't work. It keeps full opacity,
+	// though: only an explicit `disabled` should read as grayed out.
+	const inert = Boolean(disabled || busy || !onValueChange);
 
 	return (
 		<Pressable
 			onPress={() => onValueChange?.(!value)}
-			disabled={inert || !onValueChange}
+			disabled={inert}
 			accessibilityRole="switch"
 			accessibilityLabel={accessibilityLabel}
 			accessibilityState={{ checked: value, disabled: inert, busy: Boolean(busy) }}
@@ -310,7 +314,8 @@ export function Switch({
 			aria-checked={value}
 			aria-busy={Boolean(busy)}
 			aria-disabled={inert}
-			hitSlop={8}
+			// The 26px track + 9px vertical slop clears the 44px minimum tap target.
+			hitSlop={{ top: 9, bottom: 9, left: 8, right: 8 }}
 			style={({ pressed }) => [
 				styles.switchTrack,
 				pressed && !inert && styles.switchPressed,

--- a/packages/app/src/theme/tokens.ts
+++ b/packages/app/src/theme/tokens.ts
@@ -52,6 +52,9 @@ export const colors = {
 	avatarBg: '#eceef4',
 	avatarText: '#4a4b58',
 	chipBg: '#eef0f4',
+
+	// Controls
+	switchTrackOff: '#d9dbe6',
 } as const;
 
 // The signature Rivus gradient (135deg, cyan -> purple).


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — *No existing component-render test layer in `@rivus/app` (logic-only tests); all repo gates pass (`pnpm lint && pnpm type-check && pnpm test`, 1601 tests), and the change was verified end-to-end in the running web app (details below).*

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature / UX fix: a UX audit of the settings page, fixing the channel toggles and the button components.

### What was wrong

- The WhatsApp / SMS / Phone-calls toggles were two-segment **Off/On pickers** — the wrong control for a boolean setting, with a near-invisible active state (white chip on pale gray), no switch semantics for assistive tech, and a detached spinner that popped in beside the control while a number provisioned. The three cards were also triplicated code.
- The destructive **"Yes, cancel account" confirm wore the signature brand gradient** — the most positive affordance in the system on the most destructive action, violating the design system's "one gradient, one job" rule; the "Cancel account" entry button had a red border but gray text.
- Buttons had **no loading/disabled states** (screens faked loading by swapping label text while the button stayed pressable) and no hover feedback on web.

### What changed

- New **`Switch`** component: 46×26 pill with an animated thumb, gradient on-state (flipping a channel on puts Rivus live — AI status), an in-thumb spinner while provisioning (presses ignored), disabled state, and full `role="switch"` + `aria-checked`/`aria-busy` wiring (react-native-web doesn't derive aria-* from `accessibilityState`, so they're mirrored explicitly).
- Settings channel cards collapse into one **`ChannelCard`** (switch in the card header with an On/Off text echo, number + errors inline) driven by a single `onToggleChannel` handler with per-channel busy/error state.
- **`GradientButton` / `OutlineButton`** gain `loading` (inline spinner, presses ignored), `disabled`, hover/pressed feedback, and a11y state; `OutlineButton` gains an `icon` and a **danger tone**; new solid-red **`DangerButton`** for destructive confirms — the danger zone now uses danger-toned buttons instead of the gradient.
- **`Segmented`** gains radiogroup/radio semantics with `aria-checked`, hover, and a hairline border.
- `DESIGN_SYSTEM.md` documents the Switch spec, the off-track token (`#d9dbe6`, added to `tokens.ts`), the Danger button recipe, and button states; a repo `verify` skill captures how to run the stack locally for end-to-end checks.

### How it was verified

Drove the real app (in-memory API harness + Expo web + Playwright/Chromium): signup → Settings; toggled all three channels on and off (fake numbers provision and render in the copy field, `aria-checked` flips, busy spinner shows in-thumb); rapid double-toggle can't double-fire an in-flight change; cancel-account confirm/keep flow; save-changes loading state and "Saved." confirmation; narrow (400px) layout with stacked confirm buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FXBnRkvMWTB4prcY19iSH

---
_Generated by [Claude Code](https://claude.ai/code/session_019FXBnRkvMWTB4prcY19iSH)_