### PR TITLE
feat(website): environment-aware app links, direct signup CTAs, and mobile badge fix

### DIFF
--- a/packages/app/src/auth/AuthScreen.tsx
+++ b/packages/app/src/auth/AuthScreen.tsx
@@ -17,7 +17,8 @@ type Step = 'form' | 'code';
 const COPY: Record<Mode, { title: string; subtitle: string; submit: string; tabTitle: string }> = {
 	signup: {
 		title: 'Create your business account',
-		subtitle: 'Set up Rivus for your business in under a minute.',
+		subtitle:
+			'Start your free 14-day trial — no credit card required, and a free onboarding specialist sets everything up for you.',
 		submit: 'Create account',
 		tabTitle: 'Sign up',
 	},

--- a/packages/website/next.config.ts
+++ b/packages/website/next.config.ts
@@ -1,10 +1,17 @@
 import { initOpenNextCloudflareForDev } from '@opennextjs/cloudflare';
 import type { NextConfig } from 'next';
+import { resolveAppUrl } from './src/lib/env';
 
 const nextConfig: NextConfig = {
 	reactStrictMode: true,
 	// @rivus/core is shipped as TypeScript source, so Next must transpile it.
 	transpilePackages: ['@rivus/core'],
+	env: {
+		// Resolved per environment at build time (dev deploys link to
+		// dev-app.rivus.ai) and inlined into the client bundle, where the
+		// build-only RIVUS_ENV variable isn't visible.
+		NEXT_PUBLIC_APP_URL: resolveAppUrl(),
+	},
 };
 
 export default nextConfig;

--- a/packages/website/src/app/globals.css
+++ b/packages/website/src/app/globals.css
@@ -286,6 +286,9 @@ button:focus-visible {
 	letter-spacing: 0.04em;
 	padding: 4px 9px;
 	border-radius: 999px;
+	/* The chip must never break into two lines when the badge is squeezed. */
+	white-space: nowrap;
+	flex-shrink: 0;
 }
 
 .badge__text {
@@ -2503,6 +2506,16 @@ button:focus-visible {
 
 	.hero__inner {
 		padding: 34px 20px 40px;
+	}
+	/* When the badge text wraps, a full pill grows tall, ugly rounded caps;
+	   soften to a card radius and let the two-line text breathe. */
+	.badge {
+		border-radius: 16px;
+		align-items: center;
+		padding: 7px 14px 7px 8px;
+	}
+	.badge__text {
+		line-height: 1.4;
 	}
 	.hero__title {
 		font-size: 38px;

--- a/packages/website/src/components/marketing/hero.tsx
+++ b/packages/website/src/components/marketing/hero.tsx
@@ -1,4 +1,4 @@
-import { siteConfig } from '../../lib/site';
+import { signupUrl, siteConfig } from '../../lib/site';
 import { BrandImg } from './brand-img';
 import { ArrowRightIcon, BoltIcon, CheckIcon, PlayIcon } from './icons';
 
@@ -18,7 +18,7 @@ export function Hero() {
 					</h1>
 					<p className="hero__lead">{siteConfig.heroLead}</p>
 					<div className="hero__actions">
-						<a className="btn btn--primary btn--lg" href="#cta">
+						<a className="btn btn--primary btn--lg" href={signupUrl}>
 							Get started free
 							<ArrowRightIcon size={18} />
 						</a>

--- a/packages/website/src/components/marketing/onboarding-section.tsx
+++ b/packages/website/src/components/marketing/onboarding-section.tsx
@@ -1,4 +1,4 @@
-import { onboardingChecklist, onboardingStats } from '../../lib/site';
+import { onboardingChecklist, onboardingStats, signupUrl } from '../../lib/site';
 import { ArrowRightIcon, CheckIcon } from './icons';
 
 export function OnboardingSection() {
@@ -33,7 +33,7 @@ export function OnboardingSection() {
 				</div>
 
 				<div className="onboard__cta">
-					<a className="btn btn--white btn--lg" href="#cta">
+					<a className="btn btn--white btn--lg" href={signupUrl}>
 						Claim your free onboarding
 						<ArrowRightIcon size={18} />
 					</a>

--- a/packages/website/src/components/marketing/pricing.tsx
+++ b/packages/website/src/components/marketing/pricing.tsx
@@ -1,4 +1,4 @@
-import { pricingTiers } from '../../lib/site';
+import { pricingTiers, signupUrl } from '../../lib/site';
 import { CheckIcon } from './icons';
 
 export function Pricing() {
@@ -27,7 +27,7 @@ export function Pricing() {
 							</div>
 							<a
 								className={tier.featured ? 'btn btn--primary plan__cta' : 'btn btn--soft plan__cta'}
-								href={tier.ctaHref ?? '#cta'}
+								href={tier.ctaHref ?? signupUrl}
 							>
 								{tier.cta}
 							</a>

--- a/packages/website/src/components/marketing/site-nav.test.tsx
+++ b/packages/website/src/components/marketing/site-nav.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { appUrl } from '../../lib/site';
+import { appUrl, signupUrl } from '../../lib/site';
 import { SiteNav } from './site-nav';
 
 describe('SiteNav', () => {
@@ -11,6 +11,11 @@ describe('SiteNav', () => {
 		for (const link of signIns) {
 			expect(link.getAttribute('href')).toBe(`${appUrl}/login`);
 		}
+	});
+
+	it('sends "Get started" straight to the app signup', () => {
+		render(<SiteNav />);
+		expect(screen.getByRole('link', { name: 'Get started' }).getAttribute('href')).toBe(signupUrl);
 	});
 
 	it('toggles the mobile menu open and closed', () => {

--- a/packages/website/src/components/marketing/site-nav.tsx
+++ b/packages/website/src/components/marketing/site-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
-import { appUrl, navLinks } from '../../lib/site';
+import { appUrl, navLinks, signupUrl } from '../../lib/site';
 import { BrandImg } from './brand-img';
 import { MenuIcon } from './icons';
 
@@ -32,9 +32,9 @@ export function SiteNav() {
 					Sign in
 				</a>
 				<div className="nav__actions">
-					<Link className="btn btn--primary nav__cta" href="/#cta">
+					<a className="btn btn--primary nav__cta" href={signupUrl}>
 						Get started
-					</Link>
+					</a>
 					<button
 						type="button"
 						className="nav__menu-btn"

--- a/packages/website/src/lib/env.test.ts
+++ b/packages/website/src/lib/env.test.ts
@@ -39,6 +39,12 @@ describe('resolveAppUrl', () => {
 		).toBe('http://localhost:8081');
 	});
 
+	it('strips trailing slashes from the override so appended paths stay clean', () => {
+		expect(resolveAppUrl({ NEXT_PUBLIC_APP_URL: 'https://app.example.com/' })).toBe(
+			'https://app.example.com',
+		);
+	});
+
 	it('reads from process.env by default', () => {
 		expect(resolveAppUrl()).toMatch(/^https?:\/\//);
 	});

--- a/packages/website/src/lib/env.test.ts
+++ b/packages/website/src/lib/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isProductionEnv } from './env';
+import { isProductionEnv, resolveAppUrl } from './env';
 
 describe('isProductionEnv', () => {
 	it('is true only when RIVUS_ENV is exactly "production"', () => {
@@ -17,5 +17,29 @@ describe('isProductionEnv', () => {
 	it('reads from process.env by default', () => {
 		// No throw, returns a boolean regardless of ambient env.
 		expect(typeof isProductionEnv()).toBe('boolean');
+	});
+});
+
+describe('resolveAppUrl', () => {
+	it('points the development deploy at the dev app', () => {
+		expect(resolveAppUrl({ RIVUS_ENV: 'development' })).toBe('https://dev-app.rivus.ai');
+	});
+
+	it('points production at the production app', () => {
+		expect(resolveAppUrl({ RIVUS_ENV: 'production' })).toBe('https://app.rivus.ai');
+	});
+
+	it('defaults local builds (RIVUS_ENV unset) to the production app', () => {
+		expect(resolveAppUrl({})).toBe('https://app.rivus.ai');
+	});
+
+	it('lets NEXT_PUBLIC_APP_URL override the environment mapping', () => {
+		expect(
+			resolveAppUrl({ RIVUS_ENV: 'development', NEXT_PUBLIC_APP_URL: 'http://localhost:8081' }),
+		).toBe('http://localhost:8081');
+	});
+
+	it('reads from process.env by default', () => {
+		expect(resolveAppUrl()).toMatch(/^https?:\/\//);
 	});
 });

--- a/packages/website/src/lib/env.ts
+++ b/packages/website/src/lib/env.ts
@@ -13,3 +13,22 @@ export function isProductionEnv(env?: Record<string, string | undefined>): boole
 	const target = env ?? (typeof process !== 'undefined' ? process.env : {});
 	return target.RIVUS_ENV === 'production';
 }
+
+/**
+ * The product-app base URL this deployment should link to. Each marketing
+ * environment points at its sibling app deployment — dev.rivus.ai must send
+ * sign-ups to dev-app.rivus.ai, never the production app — with
+ * `NEXT_PUBLIC_APP_URL` as an explicit override for either.
+ *
+ * Called from next.config.ts at build time (the deploy workflows set
+ * `RIVUS_ENV` in the build job's env), which inlines the result into both the
+ * server and client bundles as `NEXT_PUBLIC_APP_URL`; client components can't
+ * read `RIVUS_ENV` themselves.
+ */
+export function resolveAppUrl(env?: Record<string, string | undefined>): string {
+	const target = env ?? (typeof process !== 'undefined' ? process.env : {});
+	if (target.NEXT_PUBLIC_APP_URL) {
+		return target.NEXT_PUBLIC_APP_URL;
+	}
+	return target.RIVUS_ENV === 'development' ? 'https://dev-app.rivus.ai' : 'https://app.rivus.ai';
+}

--- a/packages/website/src/lib/env.ts
+++ b/packages/website/src/lib/env.ts
@@ -28,7 +28,9 @@ export function isProductionEnv(env?: Record<string, string | undefined>): boole
 export function resolveAppUrl(env?: Record<string, string | undefined>): string {
 	const target = env ?? (typeof process !== 'undefined' ? process.env : {});
 	if (target.NEXT_PUBLIC_APP_URL) {
-		return target.NEXT_PUBLIC_APP_URL;
+		// Strip trailing slashes so consumers can safely append paths
+		// (`${appUrl}/signup`) without producing `https://host//signup`.
+		return target.NEXT_PUBLIC_APP_URL.replace(/\/+$/, '');
 	}
 	return target.RIVUS_ENV === 'development' ? 'https://dev-app.rivus.ai' : 'https://app.rivus.ai';
 }

--- a/packages/website/src/lib/site.ts
+++ b/packages/website/src/lib/site.ts
@@ -349,5 +349,13 @@ export const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000'
  * Base URL of the Rivus product app — where sign-in, signup, and demo booking
  * live. It's a separate deploy from this marketing site, so links to it are
  * absolute external URLs (plain anchors, not next/link).
+ *
+ * `NEXT_PUBLIC_APP_URL` is injected at build time by next.config.ts
+ * (`resolveAppUrl`), which points each environment at its sibling app deploy —
+ * dev.rivus.ai links to dev-app.rivus.ai. The fallback here only matters in
+ * tests, where the config's env injection doesn't run.
  */
 export const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.rivus.ai';
+
+/** Where every "Get started" CTA lands: the product app's signup. */
+export const signupUrl = `${appUrl}/signup`;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature/fix — follow-ups to the public-site buildout (#120):

### Environment-aware app links
- On the development deploy (`RIVUS_ENV=development`, dev.rivus.ai), every product-app link (sign in, get started, demo) now points at **dev-app.rivus.ai** instead of the production app.
- `next.config.ts` resolves `NEXT_PUBLIC_APP_URL` per environment at build time via a new `resolveAppUrl()` helper in `lib/env.ts` and inlines it into the client bundle — client components can't read the build-only `RIVUS_ENV` themselves. `NEXT_PUBLIC_APP_URL` remains an explicit override.

### "Get started" goes straight to signup
- The nav CTA, hero "Get started free", onboarding "Claim your free onboarding", and pricing "Start free" buttons now link directly to the app's `/signup` (via a shared `signupUrl`) instead of scrolling to the in-page `#cta` section.

### Signup-page marketing
- The app's signup screen now leads with the offer: "Start your free 14-day trial — no credit card required, and a free onboarding specialist sets everything up for you."

### Mobile badge fix
- The hero "FREE SETUP" badge no longer breaks on small screens: the chip never wraps internally (`white-space: nowrap`), and when the text wraps the badge softens from a tall pill to a 16px card radius with readable line height.

### Verification
- `pnpm lint && pnpm type-check && pnpm test` all green (1,627 tests; new `resolveAppUrl` and nav-CTA tests included).
- Booted the site with `RIVUS_ENV=development` and verified every app link renders as `https://dev-app.rivus.ai/...`; screenshot-verified the mobile badge at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PySmUDn68RxvrFZrV5wES3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PySmUDn68RxvrFZrV5wES3)_