### PR TITLE
feat(api,app): dev-only switch to test WhatsApp on the Twilio sandbox

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -263,6 +263,18 @@ number via TwiML — one number per account carries all three channels.
    link and an OTP round-trip — see `TODO(twilio)` in `src/services/twilio.ts`.
 4. An account **owner** enables each channel as described in its section;
    `…/disable` turns it off but retains the number.
+5. **Testing WhatsApp in development — the sandbox.** Twilio's shared WhatsApp
+   sandbox (`+1 415 523 8886`, testers text a per-account join code) needs no
+   WABA or sender registration and fires real inbound webhooks. Point the
+   sandbox's inbound webhook (Console → Messaging → Try it out → Sandbox
+   settings) at this API's `/v1/channels/whatsapp/twilio/inbound`, then use the
+   development-only switch `POST /v1/admin/sandbox/whatsapp` (`{"mode":
+   "attach" | "detach"}`, Rivus staff only — surfaced in the app's Settings as
+   "Developer · WhatsApp sandbox") to point the current account's WhatsApp
+   channel at the sandbox number so those conversations reach the agent. It
+   refuses to replace a real provisioned number, only one account per
+   deployment can hold the sandbox, and free-form agent replies work because
+   the customer always messages first (the 24-hour session window).
 
 | Variable                      | Default                   | Notes                                                                                                                 |
 | ----------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------- |

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import { isSeedingEnabled } from '../config';
 import {
 	accountListResponseSchema,
+	accountResponseSchema,
 	authResponseSchema,
 	errorResponseSchema,
 	idParamsSchema,
@@ -18,6 +19,7 @@ import {
 } from '../http-schemas';
 import { toPublicAccount, toPublicUser } from '../presenters';
 import { issueSession } from '../services/session';
+import { TWILIO_SANDBOX_PROVIDER_REF, TWILIO_WHATSAPP_SANDBOX_NUMBER } from '../services/twilio';
 
 /** List query: standard pagination plus an optional free-text company search. */
 const listCompaniesQuerySchema = paginationQuerySchema.extend({
@@ -26,6 +28,11 @@ const listCompaniesQuerySchema = paginationQuerySchema.extend({
 		.trim()
 		.max(160, { error: 'Search must be 160 characters or fewer.' })
 		.optional(),
+});
+
+/** Body of the dev-only WhatsApp-sandbox switch: attach (default) or detach. */
+const sandboxWhatsappSchema = z.object({
+	mode: z.enum(['attach', 'detach']).default('attach'),
 });
 
 /**
@@ -178,6 +185,84 @@ export const adminRoutes: FastifyPluginAsync = async (fastify) => {
 					},
 					{ seed: body.seed, log: (message) => request.log.info(message) },
 				);
+			},
+		);
+
+		// Development-only WhatsApp sandbox switch, gated exactly like the seeder.
+		// Twilio's sandbox is the zero-compliance way to test WhatsApp end-to-end
+		// (no WABA, no sender registration, real inbound webhooks), but inbound
+		// resolution matches on the account's stored channel address — and the
+		// enable flow can't rent the shared sandbox number. This flips the current
+		// account's WhatsApp channel onto the sandbox number (and back off it),
+		// with guards so it can never clobber a real provisioned number. Setup that
+		// stays in the Twilio console: point the sandbox's inbound webhook at
+		// /v1/channels/whatsapp/twilio/inbound and have testers send the join code.
+		app.post(
+			'/sandbox/whatsapp',
+			{
+				onRequest: [fastify.authenticate, fastify.requireStaff],
+				schema: {
+					tags: ['admin'],
+					summary:
+						'Point this account’s WhatsApp at the Twilio sandbox (development only, Rivus staff only)',
+					description:
+						'Attaches the current account’s WhatsApp channel to Twilio’s shared ' +
+						'sandbox number so sandbox conversations reach the scheduling agent — ' +
+						'or detaches it again. Attach refuses to replace a real provisioned ' +
+						'number, and detach only ever clears the sandbox number. Configure the ' +
+						'sandbox’s inbound webhook (Console → Messaging → Try it out) to this ' +
+						'API’s /v1/channels/whatsapp/twilio/inbound route.',
+					security: [{ bearerAuth: [] }],
+					body: sandboxWhatsappSchema,
+					response: {
+						200: accountResponseSchema,
+						401: errorResponseSchema,
+						403: errorResponseSchema,
+						404: errorResponseSchema,
+						409: errorResponseSchema,
+					},
+				},
+			},
+			async (request) => {
+				const accountId = request.user.accountId as AccountId;
+				const account = await accounts.findById(accountId);
+				if (!account) {
+					throw app.httpErrors.notFound('Account not found');
+				}
+				const whatsapp = account.channels.whatsapp;
+				if (request.body.mode === 'detach') {
+					// Only ever clear the sandbox number — never a real one.
+					if (whatsapp.address !== TWILIO_WHATSAPP_SANDBOX_NUMBER) {
+						throw app.httpErrors.conflict('This account is not on the WhatsApp sandbox.');
+					}
+					const updated = await accounts.setChannelConfig(accountId, 'whatsapp', {
+						enabled: false,
+						address: '',
+						providerRef: '',
+					});
+					if (!updated) {
+						throw app.httpErrors.notFound('Account not found');
+					}
+					return toPublicAccount(updated);
+				}
+				// Attach. A real provisioned number is the account's retained identity —
+				// replacing it would orphan the rental, so refuse instead.
+				if (whatsapp.address !== '' && whatsapp.address !== TWILIO_WHATSAPP_SANDBOX_NUMBER) {
+					throw app.httpErrors.conflict(
+						'This account already has a WhatsApp number; the sandbox would replace it.',
+					);
+				}
+				// The repositories' cross-account uniqueness makes a second account's
+				// attach fail with a 409 — one sandbox tenant per deployment.
+				const updated = await accounts.setChannelConfig(accountId, 'whatsapp', {
+					enabled: true,
+					address: TWILIO_WHATSAPP_SANDBOX_NUMBER,
+					providerRef: TWILIO_SANDBOX_PROVIDER_REF,
+				});
+				if (!updated) {
+					throw app.httpErrors.notFound('Account not found');
+				}
+				return toPublicAccount(updated);
 			},
 		);
 	}

--- a/packages/api/src/services/twilio.ts
+++ b/packages/api/src/services/twilio.ts
@@ -361,6 +361,23 @@ export class TwilioProvisioner implements ChannelProvisioner {
 	}
 }
 
+/**
+ * Twilio's shared WhatsApp **sandbox** number — the same for every Twilio
+ * account (testers opt in with a per-account join code). A development account
+ * can hold it as its WhatsApp address so sandbox traffic resolves to it
+ * (`POST /v1/admin/sandbox/whatsapp`).
+ */
+export const TWILIO_WHATSAPP_SANDBOX_NUMBER = '+14155238886';
+
+/**
+ * The providerRef stored while an account borrows the sandbox number.
+ * Deliberately NOT an ownership fingerprint: outbound sends fall through to the
+ * primary chain (Twilio, when configured — exactly how sandbox sends work), and
+ * the channel-enable sharing logic never adopts the shared sandbox number onto
+ * SMS/voice the way it would a genuinely owned `PN…` number.
+ */
+export const TWILIO_SANDBOX_PROVIDER_REF = 'twilio-sandbox';
+
 /** Twilio phone-number SIDs: `PN` + 32 hex characters. */
 const TWILIO_NUMBER_SID = /^PN[0-9a-fA-F]{32}$/;
 

--- a/packages/api/test/admin-sandbox-whatsapp.test.ts
+++ b/packages/api/test/admin-sandbox-whatsapp.test.ts
@@ -1,0 +1,228 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { loadConfig } from '../src/config';
+import {
+	TWILIO_SANDBOX_PROVIDER_REF,
+	TWILIO_WHATSAPP_SANDBOX_NUMBER,
+} from '../src/services/twilio';
+import {
+	authHeader,
+	buildTestApp,
+	buildTestAppWithRepos,
+	type RecordingWhatsappSender,
+	signupOwner,
+} from './helpers';
+
+const SANDBOX_URL = '/v1/admin/sandbox/whatsapp';
+const STAFF_EMAIL = 'ops@rivus.ai';
+
+/** Dev-mode config (NODE_ENV=development), where the sandbox route is registered. */
+function devConfig() {
+	return loadConfig({
+		NODE_ENV: 'development',
+		JWT_SECRET: 'test-secret-value-1234',
+		LOG_LEVEL: 'silent',
+	} as NodeJS.ProcessEnv);
+}
+
+/**
+ * The dev-only switch that points an account's WhatsApp channel at Twilio's
+ * shared sandbox number, so sandbox conversations resolve to the account and
+ * the agent answers — the zero-compliance way to test WhatsApp end-to-end.
+ */
+describe('POST /v1/admin/sandbox/whatsapp', () => {
+	let app: FastifyInstance | undefined;
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it('does not exist outside development (404, like the seeder)', async () => {
+		// The default test app runs with NODE_ENV=test, so the route is never registered.
+		app = await buildTestApp();
+		const staff = await signupOwner(app, { email: STAFF_EMAIL });
+		const res = await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(staff.token),
+			payload: {},
+		});
+		expect(res.statusCode).toBe(404);
+	});
+
+	it('rejects non-staff users with 403', async () => {
+		app = await buildTestApp({ config: devConfig() });
+		const owner = await signupOwner(app, { email: 'owner@acme.test' });
+		const res = await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(owner.token),
+			payload: {},
+		});
+		expect(res.statusCode).toBe(403);
+	});
+
+	it('attaches the sandbox number to the current account (attach is the default mode)', async () => {
+		const { app: built, repos } = await buildTestAppWithRepos({ config: devConfig() });
+		app = built;
+		const staff = await signupOwner(app, { email: STAFF_EMAIL });
+		const res = await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(staff.token),
+			payload: {},
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.json().channels.whatsapp).toMatchObject({
+			enabled: true,
+			address: TWILIO_WHATSAPP_SANDBOX_NUMBER,
+		});
+		// The stored ref is the sandbox marker — not an ownership fingerprint, so
+		// sharing/routing never treat the shared number as an owned one.
+		const account = await repos.accounts.findById(staff.account.id);
+		expect(account?.channels.whatsapp.providerRef).toBe(TWILIO_SANDBOX_PROVIDER_REF);
+	});
+
+	it('is idempotent: re-attaching while on the sandbox stays attached', async () => {
+		app = await buildTestApp({ config: devConfig() });
+		const staff = await signupOwner(app, { email: STAFF_EMAIL });
+		await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(staff.token),
+			payload: { mode: 'attach' },
+		});
+		const again = await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(staff.token),
+			payload: { mode: 'attach' },
+		});
+		expect(again.statusCode).toBe(200);
+		expect(again.json().channels.whatsapp.address).toBe(TWILIO_WHATSAPP_SANDBOX_NUMBER);
+	});
+
+	it('refuses to replace a real provisioned number (409)', async () => {
+		const { app: built, repos } = await buildTestAppWithRepos({ config: devConfig() });
+		app = built;
+		const staff = await signupOwner(app, { email: STAFF_EMAIL });
+		await repos.accounts.setChannelConfig(staff.account.id, 'whatsapp', {
+			enabled: true,
+			address: '+14155550100',
+			providerRef: 'PN0123456789abcdef0123456789abcdef',
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(staff.token),
+			payload: { mode: 'attach' },
+		});
+		expect(res.statusCode).toBe(409);
+		// The real number is untouched.
+		const account = await repos.accounts.findById(staff.account.id);
+		expect(account?.channels.whatsapp.address).toBe('+14155550100');
+	});
+
+	it('detaches only when actually on the sandbox, resetting the channel to empty', async () => {
+		const { app: built, repos } = await buildTestAppWithRepos({ config: devConfig() });
+		app = built;
+		const staff = await signupOwner(app, { email: STAFF_EMAIL });
+
+		// Not attached yet → detach is a 409, not a silent wipe.
+		const early = await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(staff.token),
+			payload: { mode: 'detach' },
+		});
+		expect(early.statusCode).toBe(409);
+
+		await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(staff.token),
+			payload: { mode: 'attach' },
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(staff.token),
+			payload: { mode: 'detach' },
+		});
+		expect(res.statusCode).toBe(200);
+		expect(res.json().channels.whatsapp).toMatchObject({ enabled: false, address: '' });
+		const account = await repos.accounts.findById(staff.account.id);
+		expect(account?.channels.whatsapp.providerRef).toBe('');
+	});
+
+	it('never clears a real number on detach (409)', async () => {
+		const { app: built, repos } = await buildTestAppWithRepos({ config: devConfig() });
+		app = built;
+		const staff = await signupOwner(app, { email: STAFF_EMAIL });
+		await repos.accounts.setChannelConfig(staff.account.id, 'whatsapp', {
+			enabled: true,
+			address: '+14155550100',
+			providerRef: 'PN0123456789abcdef0123456789abcdef',
+		});
+		const res = await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(staff.token),
+			payload: { mode: 'detach' },
+		});
+		expect(res.statusCode).toBe(409);
+		const account = await repos.accounts.findById(staff.account.id);
+		expect(account?.channels.whatsapp.address).toBe('+14155550100');
+	});
+
+	it('allows one sandbox tenant per deployment (second account attach → 409)', async () => {
+		app = await buildTestApp({ config: devConfig() });
+		const first = await signupOwner(app, { email: STAFF_EMAIL });
+		await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(first.token),
+			payload: {},
+		});
+		const second = await signupOwner(app, { email: 'ops2@rivus.ai' });
+		const res = await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(second.token),
+			payload: {},
+		});
+		expect(res.statusCode).toBe(409);
+	});
+
+	it('routes inbound sandbox WhatsApp messages to the attached account end-to-end', async () => {
+		app = await buildTestApp({ config: devConfig() });
+		const staff = await signupOwner(app, { email: STAFF_EMAIL });
+		await app.inject({
+			method: 'POST',
+			url: SANDBOX_URL,
+			headers: authHeader(staff.token),
+			payload: {},
+		});
+		// A sandbox tester texts the shared number; Twilio posts it to our hook.
+		const inbound = await app.inject({
+			method: 'POST',
+			url: '/v1/channels/whatsapp/twilio/inbound',
+			payload: {
+				From: 'whatsapp:+15559990000',
+				To: `whatsapp:${TWILIO_WHATSAPP_SANDBOX_NUMBER}`,
+				Body: 'Can I book something?',
+				MessageSid: 'SMsandbox001',
+				ProfileName: 'Dana',
+			},
+		});
+		expect(inbound.statusCode).toBe(200);
+		expect(inbound.body).toBe('<Response/>');
+		// The agent replied from the sandbox number (unknown sender → signup link).
+		const sender = app.deps.whatsappSender as RecordingWhatsappSender;
+		const sent = sender.messages.at(-1);
+		expect(sent?.from).toBe(TWILIO_WHATSAPP_SANDBOX_NUMBER);
+		expect(sent?.to).toBe('+15559990000');
+		expect(sent?.text).toContain('phone=');
+		expect(sent?.providerRef).toBe(TWILIO_SANDBOX_PROVIDER_REF);
+	});
+});

--- a/packages/app/app/settings.tsx
+++ b/packages/app/app/settings.tsx
@@ -8,7 +8,12 @@ import {
 	useWindowDimensions,
 	View,
 } from 'react-native';
-import { ApiError, type Billing, type SeedSummary } from '@/src/api/client';
+import {
+	ApiError,
+	type Billing,
+	type SeedSummary,
+	TWILIO_WHATSAPP_SANDBOX_NUMBER,
+} from '@/src/api/client';
 import { getGoogleMapsApiKey, isSeedingEnabled } from '@/src/api/config';
 import { deviceTimezone, listTimezones } from '@/src/api/timezones';
 import { useAuth } from '@/src/auth/AuthContext';
@@ -184,6 +189,83 @@ function DevSeedCard() {
 	);
 }
 
+/**
+ * A development-only, Rivus-staff-only switch that points this account's
+ * WhatsApp channel at Twilio's shared **sandbox** number, so sandbox
+ * conversations reach the scheduling agent — the zero-compliance way to test
+ * WhatsApp end to end (no WABA, no sender registration). Attach/detach state
+ * reads from the session's account; the API refuses to replace or clear a real
+ * provisioned number, so this can never clobber one. Gated exactly like
+ * {@link DevSeedCard}, with the same server-side enforcement.
+ */
+function DevSandboxCard() {
+	const { session, sandboxWhatsapp, isStaff } = useAuth();
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const visible = Boolean(session) && isStaff && isSeedingEnabled();
+	const whatsapp = session?.account.channels.whatsapp;
+	const attached = whatsapp?.address === TWILIO_WHATSAPP_SANDBOX_NUMBER;
+	// A real provisioned number blocks the sandbox (the API refuses to replace it).
+	const blocked = Boolean(whatsapp && whatsapp.address !== '' && !attached);
+
+	async function onToggle() {
+		if (busy || !session) {
+			return;
+		}
+		setError(null);
+		setBusy(true);
+		try {
+			await sandboxWhatsapp(attached ? 'detach' : 'attach');
+		} catch (caught) {
+			setError(messageFor(caught, 'Could not update the WhatsApp sandbox.'));
+		} finally {
+			setBusy(false);
+		}
+	}
+
+	if (!visible || !session) {
+		return null;
+	}
+
+	return (
+		<Card style={[styles.card, styles.devCard]}>
+			<SectionLabel style={styles.devLabel}>Developer · WhatsApp sandbox</SectionLabel>
+			<Txt style={styles.rowSub}>
+				{attached
+					? `WhatsApp is on Twilio's sandbox number (${TWILIO_WHATSAPP_SANDBOX_NUMBER}). Send the ` +
+						'sandbox join code to it from WhatsApp and the agent answers. Detach to hand the ' +
+						'channel back.'
+					: blocked
+						? 'This account already has a real WhatsApp number, so the sandbox is unavailable ' +
+							'here — use a fresh test account.'
+						: "Point WhatsApp at Twilio's shared sandbox number to test the agent end to end " +
+							'with no sender registration. First, set the sandbox inbound webhook (Twilio ' +
+							'Console → Messaging → Try it out) to this API. Visible only in development, to ' +
+							'Rivus staff.'}
+			</Txt>
+
+			{error ? <Txt style={styles.errorTxt}>{error}</Txt> : null}
+
+			<GradientButton
+				label={
+					busy
+						? attached
+							? 'Detaching…'
+							: 'Attaching…'
+						: attached
+							? 'Detach the sandbox'
+							: 'Use the WhatsApp sandbox'
+				}
+				icon="message-circle"
+				loading={busy}
+				disabled={blocked}
+				onPress={onToggle}
+			/>
+		</Card>
+	);
+}
+
 export default function SettingsScreen() {
 	useDocumentTitle('Settings');
 	const { session, client, updateAccount, cancelAccount, setChannelEnabled } = useAuth();
@@ -283,6 +365,7 @@ export default function SettingsScreen() {
 					</Txt>
 				</Card>
 				<DevSeedCard />
+				<DevSandboxCard />
 			</ScrollView>
 		);
 	}
@@ -508,6 +591,7 @@ export default function SettingsScreen() {
 			</Card>
 
 			<DevSeedCard />
+			<DevSandboxCard />
 		</ScrollView>
 	);
 }

--- a/packages/app/src/api/client.test.ts
+++ b/packages/app/src/api/client.test.ts
@@ -8,7 +8,13 @@ import type {
 	NotificationId,
 } from '@rivus/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ApiError, createApiClient, NetworkError, ValidationError } from './client';
+import {
+	ApiError,
+	createApiClient,
+	NetworkError,
+	TWILIO_WHATSAPP_SANDBOX_NUMBER,
+	ValidationError,
+} from './client';
 
 /** Build a `Response`-like object the client's `text()`/`ok` logic understands. */
 function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
@@ -593,6 +599,37 @@ describe('createApiClient', () => {
 			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
 			expect(url).toBe(`${BASE}/v1/account/channels/whatsapp/disable`);
 			expect(init.method).toBe('POST');
+		});
+	});
+
+	describe('sandboxWhatsapp', () => {
+		it('POSTs the mode to the dev-only sandbox route and returns the account', async () => {
+			const account = makeAccount();
+			account.channels.whatsapp = {
+				enabled: true,
+				address: TWILIO_WHATSAPP_SANDBOX_NUMBER,
+				providerRef: 'twilio-sandbox',
+			};
+			fetchMock.mockResolvedValueOnce(jsonResponse(account));
+
+			const client = createApiClient(BASE, fetchMock);
+			const result = await client.sandboxWhatsapp('staff-token');
+
+			expect(result.channels.whatsapp.address).toBe(TWILIO_WHATSAPP_SANDBOX_NUMBER);
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe(`${BASE}/v1/admin/sandbox/whatsapp`);
+			expect(init.method).toBe('POST');
+			expect(init.headers).toMatchObject({ Authorization: 'Bearer staff-token' });
+			// Attach is the default mode; detach is sent explicitly.
+			expect(JSON.parse(String(init.body))).toEqual({ mode: 'attach' });
+		});
+
+		it('sends detach when asked', async () => {
+			fetchMock.mockResolvedValueOnce(jsonResponse(makeAccount()));
+			const client = createApiClient(BASE, fetchMock);
+			await client.sandboxWhatsapp('staff-token', 'detach');
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(JSON.parse(String(init.body))).toEqual({ mode: 'detach' });
 		});
 	});
 

--- a/packages/app/src/api/client.ts
+++ b/packages/app/src/api/client.ts
@@ -204,6 +204,13 @@ const channelConfigResponseSchema = z.object({
 	providerRef: z.string().default(''),
 });
 
+/**
+ * Twilio's shared WhatsApp sandbox number — what the account's WhatsApp address
+ * equals while the dev-only sandbox switch ({@link ApiClient.sandboxWhatsapp})
+ * is attached. Mirrors the API's constant of the same name.
+ */
+export const TWILIO_WHATSAPP_SANDBOX_NUMBER = '+14155238886';
+
 const accountResponseSchema = z.object({
 	id: accountId(),
 	name: z.string(),
@@ -736,6 +743,16 @@ export interface RivusApiClient {
 	 * for non-staff callers. The app gates the Settings affordance the same way.
 	 */
 	seedAccount(token: string, input?: SeedAccountBody): Promise<SeedSummary>;
+	/**
+	 * Point the current account's WhatsApp channel at Twilio's shared sandbox
+	 * number (or detach it), so sandbox conversations reach the scheduling agent
+	 * — the zero-compliance way to test WhatsApp end-to-end in development.
+	 *
+	 * Development + Rivus-staff only, exactly like {@link seedAccount}: the route
+	 * 404s in deployed environments and 403s for non-staff callers. The API
+	 * refuses to replace (or clear) a real provisioned number.
+	 */
+	sandboxWhatsapp(token: string, mode?: 'attach' | 'detach'): Promise<Account>;
 }
 
 /** Strip a single trailing slash so `${base}${path}` never doubles up. */
@@ -1262,6 +1279,14 @@ export function createApiClient(
 		async seedAccount(token: string, input: SeedAccountBody = {}) {
 			const payload = parseInput(seedAccountSchema, input);
 			return request('/v1/admin/seed', seedSummaryResponseSchema, jsonInit('POST', payload, token));
+		},
+
+		sandboxWhatsapp(token: string, mode: 'attach' | 'detach' = 'attach') {
+			return request(
+				'/v1/admin/sandbox/whatsapp',
+				accountResponseSchema,
+				jsonInit('POST', { mode }, token),
+			);
 		},
 	};
 }

--- a/packages/app/src/auth/AuthContext.tsx
+++ b/packages/app/src/auth/AuthContext.tsx
@@ -57,6 +57,11 @@ export interface AuthContextValue {
 	 */
 	setChannelEnabled: (channel: ProvisionedChannel, enabled: boolean) => Promise<void>;
 	/**
+	 * Point this account's WhatsApp at Twilio's shared sandbox number, or detach
+	 * it, keeping the session in sync (development + Rivus staff only).
+	 */
+	sandboxWhatsapp: (mode: 'attach' | 'detach') => Promise<void>;
+	/**
 	 * Update your own profile (name, phone, email, profile image), keeping the
 	 * session in sync. Changing the email stages it on `session.user.pendingEmail`
 	 * and emails a code; the live email only changes once
@@ -160,6 +165,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 				const account = enabled
 					? await client.enableChannel(session.token, channel)
 					: await client.disableChannel(session.token, channel);
+				setSession({ ...session, account });
+			},
+			async sandboxWhatsapp(mode) {
+				if (!session) {
+					return;
+				}
+				const account = await client.sandboxWhatsapp(session.token, mode);
 				setSession({ ...session, account });
 			},
 			async verifyEmailChange(input) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature (development tooling) — makes WhatsApp testable end-to-end in dev with two clicks, via Twilio's sandbox.

### Why

Twilio's shared WhatsApp sandbox is the zero-compliance way to test the channel (no WABA, no sender registration, **real inbound webhooks**, free-form replies inside the 24-hour window — which is Rivus's entire send model). But inbound resolution matches on the account's stored channel address, and the enable flow can't rent the shared sandbox number — so attaching an account to the sandbox meant a manual DB edit. This removes that wrinkle.

### What

- **`POST /v1/admin/sandbox/whatsapp`** (`{"mode": "attach" | "detach"}`) points the *current* account's WhatsApp channel at the sandbox number (`+14155238886`). Gated exactly like the account seeder: registered only in development (`isSeedingEnabled` — 404 everywhere else), Rivus staff only.
- **Safety guards:** attach refuses to replace a real provisioned number (409); detach only ever clears the sandbox number (409 otherwise); the repositories' cross-account uniqueness keeps it to **one sandbox tenant per deployment**.
- **Routing/sharing correctness:** the stored `providerRef` is a deliberate non-fingerprint marker (`twilio-sandbox`), so outbound replies route through the primary Twilio sender (exactly how sandbox sends work) and the channel-enable sharing logic never adopts the shared number onto SMS/voice.
- **App:** a "Developer · WhatsApp sandbox" card next to the seeder in Settings — attach/detach state read from the session account, with the blocked state explained when the account holds a real number. New `sandboxWhatsapp` client method + AuthContext action keeping the session in sync.
- **Docs:** README documents the full setup (sandbox inbound webhook → `/v1/channels/whatsapp/twilio/inbound`, join code, the switch).

Dev-only routes are intentionally absent from the public OpenAPI spec (same as the seeder), so no spec change.

### Tests

9 new route tests — the dev/staff gates, every guard, and an **end-to-end inbound sandbox message answered by the agent from the sandbox number** — plus 2 client tests. Full gates green: 990 API / 191 app tests.

### How to use it (after deploy)

1. Twilio Console → Messaging → Try it out → Sandbox settings → "When a message comes in" → `https://dev-api.rivus.ai/v1/channels/whatsapp/twilio/inbound`.
2. In the app (dev, staff account): Settings → **Developer · WhatsApp sandbox** → *Use the WhatsApp sandbox*.
3. From WhatsApp, send the sandbox join code to `+1 415 523 8886`, then just talk to the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2)_