### PR TITLE
chore(api): declare Twilio webhook URLs in wrangler vars

### DIFF
--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -58,7 +58,19 @@
 				// (Resend). Dev uses the `dev.riv.us` subdomain so test traffic never
 				// lands in the production `riv.us` inbox; it's configured as a receiving
 				// (MX) and verified sending domain in Resend, separate from prod's.
-				"AGENT_EMAIL_DOMAIN": "dev.riv.us"
+				"AGENT_EMAIL_DOMAIN": "dev.riv.us",
+				// Public URLs of this environment's Twilio webhooks — plain config, not
+				// secrets (the credentials TWILIO_ACCOUNT_SID/TWILIO_AUTH_TOKEN are set
+				// with `wrangler secret put`). Each pins webhook signature verification
+				// (the URL Twilio calls must match byte-for-byte) and rides along on
+				// sends as the delivery-status callback; the SMS and voice URLs are also
+				// attached to newly rented numbers at purchase (SmsUrl/VoiceUrl), so
+				// numbers rented while these were unset need the two per-number webhooks
+				// pasted into the Twilio console by hand. The voice *input* endpoint has
+				// no var — it derives from the answer URL.
+				"TWILIO_WHATSAPP_WEBHOOK_URL": "https://dev-api.rivus.ai/v1/channels/whatsapp/twilio/inbound",
+				"TWILIO_SMS_WEBHOOK_URL": "https://dev-api.rivus.ai/v1/channels/sms/twilio/inbound",
+				"TWILIO_VOICE_WEBHOOK_URL": "https://dev-api.rivus.ai/v1/channels/voice/twilio/answer"
 			},
 			"containers": [
 				{
@@ -95,7 +107,14 @@
 				"WEBSITE_URL": "https://rivus.ai",
 				// Inbound/outbound domain for the scheduling agent's email channel
 				// (Resend). Production customers email `<account-slug>@riv.us`.
-				"AGENT_EMAIL_DOMAIN": "riv.us"
+				"AGENT_EMAIL_DOMAIN": "riv.us",
+				// Public URLs of this environment's Twilio webhooks — same three roles as
+				// the development block above (signature pinning, send-time status
+				// callback, attached to numbers at purchase). Credentials stay in
+				// `wrangler secret put`, never here.
+				"TWILIO_WHATSAPP_WEBHOOK_URL": "https://api.rivus.ai/v1/channels/whatsapp/twilio/inbound",
+				"TWILIO_SMS_WEBHOOK_URL": "https://api.rivus.ai/v1/channels/sms/twilio/inbound",
+				"TWILIO_VOICE_WEBHOOK_URL": "https://api.rivus.ai/v1/channels/voice/twilio/answer"
 			},
 			"containers": [
 				{


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. *(N/A — deployment config only; full gates run green.)*

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore / deployment config — declares the three `TWILIO_*_WEBHOOK_URL` values in `wrangler.jsonc`'s per-environment `vars` blocks so they're version-controlled and can't drift from what's hand-set in the Cloudflare dashboard.

### Why

These URLs are **public configuration, not secrets** — the same class as `APP_URL`/`WEBSITE_URL`/`CORS_ORIGIN`, which already live in the config. Until now they existed only as dashboard-entered variables, which deploys can clobber and reviewers can't see. Credentials (`TWILIO_ACCOUNT_SID`/`TWILIO_AUTH_TOKEN`) stay in `wrangler secret put`, never in the file.

### Values

| Env | WhatsApp | SMS | Voice |
|---|---|---|---|
| `development` (`rivus-api-dev`) | `dev-api.rivus.ai/v1/channels/whatsapp/twilio/inbound` | `…/sms/twilio/inbound` | `…/voice/twilio/answer` |
| `production` (`rivus-api`) | `api.rivus.ai/v1/channels/whatsapp/twilio/inbound` | `…/sms/twilio/inbound` | `…/voice/twilio/answer` |

The comments document each var's three roles (signature pinning, send-time status callback, attached to numbers as `SmsUrl`/`VoiceUrl` at purchase) and the operational gotcha we hit live: numbers rented while the vars were unset need their per-number webhooks pasted into the Twilio console by hand.

No behavior change to the API itself; the container already reads these via the forwarding list from #116. Full gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPjwTaT8KWD5uGYjoih9C2)_