### PR TITLE
feat(website): publish transparent pricing with all features on every plan

### DIFF
--- a/packages/website/src/app/globals.css
+++ b/packages/website/src/app/globals.css
@@ -1740,6 +1740,15 @@ button:focus-visible {
 	color: #a8a4bd;
 }
 
+.plan__price-note {
+	font-size: 13px;
+	color: var(--sub);
+}
+
+.plan--featured .plan__price-note {
+	color: #a8a4bd;
+}
+
 .plan__cta {
 	display: block;
 	text-align: center;

--- a/packages/website/src/components/marketing/pricing.tsx
+++ b/packages/website/src/components/marketing/pricing.tsx
@@ -33,7 +33,7 @@ export function Pricing() {
 								{tier.cta}
 							</a>
 							<ul className="plan__features">
-								{tier.features.map((feature) => (
+								{[...tier.capacity, ...tier.features].map((feature) => (
 									<li key={feature}>
 										<CheckIcon size={18} />
 										{feature}

--- a/packages/website/src/components/marketing/pricing.tsx
+++ b/packages/website/src/components/marketing/pricing.tsx
@@ -11,7 +11,7 @@ export function Pricing() {
 				</div>
 				<div className="price-note">
 					<CheckIcon size={17} />
-					Free onboarding specialist on every plan
+					Every feature on every plan — plus a free onboarding specialist
 				</div>
 				<div className="price-grid">
 					{pricingTiers.map((tier) => (
@@ -25,6 +25,7 @@ export function Pricing() {
 								</span>
 								{tier.period ? <span className="plan__period">{tier.period}</span> : null}
 							</div>
+							{tier.priceNote ? <div className="plan__price-note">{tier.priceNote}</div> : null}
 							<a
 								className={tier.featured ? 'btn btn--primary plan__cta' : 'btn btn--soft plan__cta'}
 								href={tier.ctaHref ?? signupUrl}

--- a/packages/website/src/lib/admin.ts
+++ b/packages/website/src/lib/admin.ts
@@ -159,7 +159,7 @@ export const accounts: Account[] = [
 		loc: 'Boise, ID',
 		initials: 'R',
 		plan: 'Multi-location',
-		mrr: '$1,180',
+		mrr: '$1,096',
 		channels: 'Phone · SMS · Email · WA',
 		specialist: 'Aisha N.',
 		status: 'active',

--- a/packages/website/src/lib/site.test.ts
+++ b/packages/website/src/lib/site.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-	apiUrl,
-	type Feature,
-	featureAnchor,
-	features,
-	type PricingTier,
-	pricingTiers,
-} from './site';
+import { apiUrl, type Feature, featureAnchor, features, pricingTiers } from './site';
 
 describe('site content', () => {
 	it('derives a url-safe anchor from a feature title', () => {
@@ -35,14 +28,13 @@ describe('site content', () => {
 		}
 	});
 
-	it('ships the same feature set on every tier — plans differ only by users and locations', () => {
-		// Capacity and per-location pricing lines mention users/locations; the
-		// product features that remain must be identical across all tiers.
-		const productFeatures = (tier: PricingTier) =>
-			tier.features.filter((feature) => !/user|location/i.test(feature));
-		const [first, ...rest] = pricingTiers.map(productFeatures);
-		for (const other of rest) {
-			expect(other).toEqual(first);
+	it('ships the same feature set on every tier — plans differ only by capacity', () => {
+		const [first, ...rest] = pricingTiers;
+		if (!first) throw new Error('no pricing tiers defined');
+		expect(first.features.length).toBeGreaterThan(0);
+		for (const tier of rest) {
+			expect(tier.features).toEqual(first.features);
+			expect(tier.capacity.length).toBeGreaterThan(0);
 		}
 	});
 

--- a/packages/website/src/lib/site.test.ts
+++ b/packages/website/src/lib/site.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { apiUrl, type Feature, featureAnchor, features, pricingTiers } from './site';
+import {
+	apiUrl,
+	type Feature,
+	featureAnchor,
+	features,
+	type PricingTier,
+	pricingTiers,
+} from './site';
 
 describe('site content', () => {
 	it('derives a url-safe anchor from a feature title', () => {
@@ -19,6 +26,24 @@ describe('site content', () => {
 
 	it('marks exactly one pricing tier as the featured plan', () => {
 		expect(pricingTiers.filter((tier) => tier.featured)).toHaveLength(1);
+	});
+
+	it('publishes a real monthly price on every tier — no contact-sales pricing', () => {
+		for (const tier of pricingTiers) {
+			expect(tier.price).toMatch(/^\$\d/);
+			expect(tier.period).toBe('/mo');
+		}
+	});
+
+	it('ships the same feature set on every tier — plans differ only by users and locations', () => {
+		// Capacity and per-location pricing lines mention users/locations; the
+		// product features that remain must be identical across all tiers.
+		const productFeatures = (tier: PricingTier) =>
+			tier.features.filter((feature) => !/user|location/i.test(feature));
+		const [first, ...rest] = pricingTiers.map(productFeatures);
+		for (const other of rest) {
+			expect(other).toEqual(first);
+		}
 	});
 
 	it('falls back to a local api url', () => {

--- a/packages/website/src/lib/site.ts
+++ b/packages/website/src/lib/site.ts
@@ -255,6 +255,8 @@ export interface PricingTier {
 	audience: string;
 	price: string;
 	period?: string;
+	/** Fine print directly under the price (e.g. what the base price covers). */
+	priceNote?: string;
 	cta: string;
 	/** Where the tier's CTA goes; defaults to the sign-up section. */
 	ctaHref?: string;
@@ -263,6 +265,19 @@ export interface PricingTier {
 	badge?: string;
 }
 
+/**
+ * The full product — every plan ships every feature. Tiers differ only by how
+ * many users and locations they cover.
+ */
+const allPlanFeatures = [
+	'All channels answered 24/7',
+	'Scheduling & reminders',
+	'QuickBooks billing',
+	'Reviews & FAQs',
+	'Google & Facebook ads',
+	'Newsletter & campaigns',
+];
+
 export const pricingTiers: PricingTier[] = [
 	{
 		name: 'Solo',
@@ -270,12 +285,7 @@ export const pricingTiers: PricingTier[] = [
 		price: '$149',
 		period: '/mo',
 		cta: 'Start free',
-		features: [
-			'All channels answered 24/7',
-			'Scheduling & reminders',
-			'QuickBooks billing',
-			'Reviews & FAQs',
-		],
+		features: ['1 user · 1 location', ...allPlanFeatures],
 	},
 	{
 		name: 'Team',
@@ -285,24 +295,19 @@ export const pricingTiers: PricingTier[] = [
 		cta: 'Start free',
 		featured: true,
 		badge: 'Most popular',
-		features: [
-			'Everything in Solo',
-			'Up to 10 team members',
-			'Google & Facebook ads',
-			'Newsletter & campaigns',
-		],
+		features: ['Unlimited users · 1 location', ...allPlanFeatures],
 	},
 	{
 		name: 'Multi-location',
 		audience: 'For franchises & chains',
-		price: "Let's talk",
-		cta: 'Contact sales',
-		ctaHref: '/contact',
+		price: '$349',
+		period: '/mo',
+		priceNote: 'for the first location',
+		cta: 'Start free',
 		features: [
-			'Everything in Team',
-			'Unlimited locations & seats',
-			'Dedicated success manager',
-			'SLA & priority support',
+			'Unlimited users · unlimited locations',
+			'$249/mo per additional location',
+			...allPlanFeatures,
 		],
 	},
 ];

--- a/packages/website/src/lib/site.ts
+++ b/packages/website/src/lib/site.ts
@@ -260,14 +260,17 @@ export interface PricingTier {
 	cta: string;
 	/** Where the tier's CTA goes; defaults to the sign-up section. */
 	ctaHref?: string;
+	/** What the plan covers — users, locations, per-location pricing. */
+	capacity: string[];
+	/** Product features; identical on every tier — every plan gets everything. */
 	features: string[];
 	featured?: boolean;
 	badge?: string;
 }
 
 /**
- * The full product — every plan ships every feature. Tiers differ only by how
- * many users and locations they cover.
+ * The full product — every plan ships every feature. Tiers differ only by
+ * capacity (how many users and locations they cover).
  */
 const allPlanFeatures = [
 	'All channels answered 24/7',
@@ -285,7 +288,8 @@ export const pricingTiers: PricingTier[] = [
 		price: '$149',
 		period: '/mo',
 		cta: 'Start free',
-		features: ['1 user · 1 location', ...allPlanFeatures],
+		capacity: ['1 user · 1 location'],
+		features: allPlanFeatures,
 	},
 	{
 		name: 'Team',
@@ -295,7 +299,8 @@ export const pricingTiers: PricingTier[] = [
 		cta: 'Start free',
 		featured: true,
 		badge: 'Most popular',
-		features: ['Unlimited users · 1 location', ...allPlanFeatures],
+		capacity: ['Unlimited users · 1 location'],
+		features: allPlanFeatures,
 	},
 	{
 		name: 'Multi-location',
@@ -304,11 +309,8 @@ export const pricingTiers: PricingTier[] = [
 		period: '/mo',
 		priceNote: 'for the first location',
 		cta: 'Start free',
-		features: [
-			'Unlimited users · unlimited locations',
-			'$249/mo per additional location',
-			...allPlanFeatures,
-		],
+		capacity: ['Unlimited users · unlimited locations', '$249/mo per additional location'],
+		features: allPlanFeatures,
 	},
 ];
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature — restructures the marketing site's pricing tiers so plans differ only by users and locations, with fully published pricing:

- **Solo** — unchanged at **$149/mo**, now explicitly *1 user · 1 location*.
- **Team** — unchanged at **$349/mo**, now *unlimited users · 1 location* (was "Up to 10 team members").
- **Multi-location** — "Let's talk" is gone: **$349/mo for the first location, $249/mo per additional location**, with a self-serve **Start free** CTA (was "Contact sales" → `/contact`).
- **Every plan ships every feature.** The per-tier "Everything in Solo/Team" ladder is replaced by one shared feature list on all three cards, and the section banner now reads "Every feature on every plan — plus a free onboarding specialist". The Multi-location-only "Dedicated success manager" and "SLA & priority support" bullets were removed as part of this flattening.

Implementation notes:

- `PricingTier` gains an optional `priceNote` (fine print under the price — used for "for the first location"), rendered in `pricing.tsx` with a new `plan__price-note` style built from existing tokens.
- Admin console sample data: the Multi-location account's MRR is now `$1,096` ($349 + 3 × $249, a 4-location account) so the illustrative numbers match the published formula.
- New tests lock in the two content invariants: every tier publishes a real `$…/mo` price (no contact-sales pricing), and all tiers share an identical product feature set.
- The app needed no changes: it only surfaces the `free` plan today ("Paid plans aren't available yet"), so no tier pricing appears there.

`pnpm lint && pnpm type-check && pnpm test` all pass (1,546 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wYsmbMUE6ckReRNVnLYfn

---
_Generated by [Claude Code](https://claude.ai/code/session_016wYsmbMUE6ckReRNVnLYfn)_